### PR TITLE
Added setting _id in mongo as field pid on save new datasets

### DIFF
--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -13,14 +13,35 @@ import { ConfigModule } from "@nestjs/config";
   imports: [
     AttachmentsModule,
     ConfigModule,
-    MongooseModule.forFeature([
+    MongooseModule.forFeatureAsync([
       {
         name: Dataset.name,
-        schema: DatasetSchema,
         discriminators: [
           { name: "raw", schema: RawDatasetSchema },
           { name: "derived", schema: DerivedDatasetSchema },
         ],
+
+        //schema: DatasetSchema,
+        useFactory: () => {
+          const schema = DatasetSchema;
+
+          schema.pre<Dataset>(
+            'save', 
+            function (next: Function) {
+              const dataset = this;
+
+              // if _id is empty or differnet than pid, 
+              // set _id to pid
+              if (!this._id) {
+                this._id = this.pid;
+              }
+
+              next();            
+          });
+
+          return schema;
+        },
+
       },
     ]),
   ],

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -25,16 +25,14 @@ import { ConfigModule } from "@nestjs/config";
         useFactory: () => {
           const schema = DatasetSchema;
 
-          schema.pre<Dataset>("save",
-            function (next) {
-              // if _id is empty or differnet than pid,
-              // set _id to pid
-              if (!this._id) {
-                this._id = this.pid;
-              }
-              next();
+          schema.pre<Dataset>("save",function (next) {
+            // if _id is empty or differnet than pid,
+            // set _id to pid
+            if (!this._id) {
+              this._id = this.pid;
             }
-          );
+            next();
+          });
 
           return schema;
         },

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -25,18 +25,16 @@ import { ConfigModule } from "@nestjs/config";
         useFactory: () => {
           const schema = DatasetSchema;
 
-          schema.pre<Dataset>(
-            "save",
+          schema.pre<Dataset>("save",
             function (next) {
-              //const dataset = this;
-
               // if _id is empty or differnet than pid,
               // set _id to pid
               if (!this._id) {
                 this._id = this.pid;
               }
               next();
-          });
+            }
+          );
 
           return schema;
         },

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -25,7 +25,7 @@ import { ConfigModule } from "@nestjs/config";
         useFactory: () => {
           const schema = DatasetSchema;
 
-          schema.pre<Dataset>("save",function (next) {
+          schema.pre<Dataset>("save", function (next) {
             // if _id is empty or differnet than pid,
             // set _id to pid
             if (!this._id) {

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -26,22 +26,20 @@ import { ConfigModule } from "@nestjs/config";
           const schema = DatasetSchema;
 
           schema.pre<Dataset>(
-            'save', 
-            function (next: Function) {
-              const dataset = this;
+            "save",
+            function (next) {
+              //const dataset = this;
 
-              // if _id is empty or differnet than pid, 
+              // if _id is empty or differnet than pid,
               // set _id to pid
               if (!this._id) {
                 this._id = this.pid;
               }
-
-              next();            
+              next();
           });
 
           return schema;
         },
-
       },
     ]),
   ],

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -35,6 +35,12 @@ export class Dataset extends Ownable {
   })
   pid: string;
 
+  @Prop({ 
+    type: String, 
+    unique: true,
+  })
+  _id: string;
+
   @ApiProperty()
   @Prop({ type: String, required: true, index: true })
   owner: string;

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -35,8 +35,8 @@ export class Dataset extends Ownable {
   })
   pid: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     unique: true,
   })
   _id: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ async function bootstrap() {
     ConfigService,
   );
   const port = configService.get<number>("port") ?? 3000;
+  Logger.log("mongodb uri : " + configService.get<string>("mongodbUri"));
   Logger.log("Scicat Backend listening on port: " + port, "Main");
 
   await app.listen(port);


### PR DESCRIPTION
## Description
The code to set the mongodb document _id to the same value as the field pid.

## Motivation
This is needed when working in a mixed configuration where different endpoints are served by the two different backend implementation

## Fixes:
* No new files added

## Changes:
* src/datasets/datasets.module.ts:  configured so Mongoose does not assign default value and value of pid field is assigned when new or empty 
* src/datasets/schemas/dataset.schema.ts : added _id field
* src/main.ts: added logging of mongodb url


## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
