### PR TITLE
Add getters to schemas where missing

### DIFF
--- a/src/attachments/schemas/attachment.schema.ts
+++ b/src/attachments/schemas/attachment.schema.ts
@@ -8,6 +8,9 @@ export type AttachmentDocument = Attachment & Document;
 
 @Schema({
   collection: "Attachment",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Attachment extends Ownable {
   @ApiProperty({ type: String, default: () => uuidv4() })

--- a/src/datablocks/schemas/datablock.schema.ts
+++ b/src/datablocks/schemas/datablock.schema.ts
@@ -8,6 +8,9 @@ export type DatablockDocument = Datablock & Document;
 
 @Schema({
   collection: "Datablock",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Datablock extends Ownable {
   @ApiProperty({

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -25,6 +25,9 @@ export type DatasetDocument = Dataset & Document;
   collection: "Dataset",
   discriminatorKey: "type",
   minimize: false,
+  toJSON: {
+    getters: true,
+  },
 })
 export class Dataset extends Ownable {
   @ApiProperty({

--- a/src/initial-datasets/schemas/initial-dataset.schema.ts
+++ b/src/initial-datasets/schemas/initial-dataset.schema.ts
@@ -5,6 +5,9 @@ export type InitialDatasetDocument = InitialDataset & Document;
 
 @Schema({
   collection: "InitialDataset",
+  toJSON: {
+    getters: true,
+  },
 })
 export class InitialDataset {
   @Prop({ type: String, required: true, unique: true })

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -8,6 +8,9 @@ export type InstrumentDocument = Instrument & Document;
 
 @Schema({
   collection: "Instrument",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Instrument {
   @Prop({ type: String, unique: true })

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -15,22 +15,10 @@ import { ConfigModule } from "@nestjs/config";
     CommonModule,
     ConfigModule,
     DatasetsModule,
-    MongooseModule.forFeatureAsync([
+    MongooseModule.forFeature([
       {
         name: Job.name,
-        useFactory: () => {
-          const schema = JobSchema;
-
-          schema.pre<Job>("save", function (next) {
-            // if _id is empty or different than id,
-            // set _id to id
-            if (!this._id) {
-              this._id = this.id;
-            }
-            next();
-          });
-          return schema;
-        },
+        schema: JobSchema,
       },
     ]),
     PoliciesModule,

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -8,13 +8,15 @@ export type JobDocument = Job & Document;
 
 @Schema({
   collection: "Job",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Job {
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String, unique: true, default: () => uuidv4() })
   _id: string;
 
-  @Prop({ type: String, unique: true, default: () => uuidv4() })
-  id: string;
+  id?: string;
 
   @ApiProperty({
     description: "The email of the person initiating the job request",

--- a/src/origdatablocks/schemas/origdatablock.schema.ts
+++ b/src/origdatablocks/schemas/origdatablock.schema.ts
@@ -8,6 +8,9 @@ export type OrigDatablockDocument = OrigDatablock & Document;
 
 @Schema({
   collection: "OrigDatablock",
+  toJSON: {
+    getters: true,
+  },
 })
 export class OrigDatablock extends Ownable {
   @ApiProperty({

--- a/src/policies/schemas/policy.schema.ts
+++ b/src/policies/schemas/policy.schema.ts
@@ -8,6 +8,9 @@ export type PolicyDocument = Policy & Document;
 
 @Schema({
   collection: "Policy",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Policy extends Ownable {
   @ApiProperty()

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -15,6 +15,9 @@ import {
 export type ProposalDocument = Proposal & Document;
 @Schema({
   collection: "Proposal",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Proposal extends Ownable {
   @ApiProperty({

--- a/src/published-data/schemas/published-data.schema.ts
+++ b/src/published-data/schemas/published-data.schema.ts
@@ -7,6 +7,9 @@ export type PublishedDataDocument = PublishedData & Document;
 
 @Schema({
   collection: "PublishedData",
+  toJSON: {
+    getters: true,
+  },
 })
 export class PublishedData {
   @Prop({

--- a/src/samples/schemas/sample.schema.ts
+++ b/src/samples/schemas/sample.schema.ts
@@ -13,6 +13,9 @@ export type SampleDocument = Sample & Document;
 
 @Schema({
   collection: "Sample",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Sample extends Ownable {
   @Prop({ type: String, unique: true })

--- a/src/users/schemas/role.schema.ts
+++ b/src/users/schemas/role.schema.ts
@@ -6,6 +6,9 @@ export type RoleDocument = Role & Document;
 
 @Schema({
   collection: "Role",
+  toJSON: {
+    getters: true,
+  },
 })
 export class Role {
   _id: string;

--- a/src/users/schemas/user-identity.schema.ts
+++ b/src/users/schemas/user-identity.schema.ts
@@ -7,6 +7,9 @@ export type UserIdentityDocument = UserIdentity & Document;
 
 @Schema({
   collection: "UserIdentity",
+  toJSON: {
+    getters: true,
+  },
 })
 export class UserIdentity {
   @Prop()

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -42,42 +42,16 @@ import { AuthService } from "src/auth/auth.service";
         schema: RoleSchema,
       },
       {
+        name: User.name,
+        schema: UserSchema,
+      },
+      {
         name: UserRole.name,
         schema: UserRoleSchema,
       },
-    ]),
-    MongooseModule.forFeatureAsync([
-      {
-        name: User.name,
-        useFactory: () => {
-          const schema = UserSchema;
-
-          schema.pre<User>("save", function (next) {
-            // if id is empty or different than _id,
-            // set id to _id
-            if (!this.id) {
-              this.id = this._id;
-            }
-            next();
-          });
-          return schema;
-        },
-      },
       {
         name: UserSettings.name,
-        useFactory: () => {
-          const schema = UserSettingsSchema;
-
-          schema.pre<UserSettings>("save", function (next) {
-            // if id is empty or different than _id,
-            // set id to _id
-            if (!this.id) {
-              this.id = this._id;
-            }
-            next();
-          });
-          return schema;
-        },
+        schema: UserSettingsSchema,
       },
     ]),
   ],


### PR DESCRIPTION
## Description

Add the 

```
toJSON: {
  getters: true
}
```

option to schemas where missing.

## Motivation

This makes mongoose change `_id` to `id` when returning documents from the database.

## Changes:

* Add getters to schemas where missing

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
