### PR TITLE
removed unique prop and add sparse prop

### DIFF
--- a/src/attachments/schemas/attachment.schema.ts
+++ b/src/attachments/schemas/attachment.schema.ts
@@ -14,7 +14,7 @@ export type AttachmentDocument = Attachment & Document;
 })
 export class Attachment extends Ownable {
   @ApiProperty({ type: String, default: () => uuidv4() })
-  @Prop({ type: String, required: true, unique: true, default: () => uuidv4() })
+  @Prop({ type: String, default: () => uuidv4(), sparse: true })
   _id: string;
 
   @ApiProperty({

--- a/src/datablocks/schemas/datablock.schema.ts
+++ b/src/datablocks/schemas/datablock.schema.ts
@@ -20,7 +20,6 @@ export class Datablock extends Ownable {
   })
   @Prop({
     type: String,
-    unique: true,
     required: true,
     default: () => uuidv4(),
   })
@@ -39,7 +38,7 @@ export class Datablock extends Ownable {
     description:
       "Unique identifier given bey archive system to the stored datablock. This id is used when data is retrieved back.",
   })
-  @Prop({ type: String, required: true, unique: true })
+  @Prop({ type: String, required: true, unique: true, sparse: true })
   archiveId: string;
 
   @ApiProperty({

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -50,7 +50,6 @@ export class Dataset extends Ownable {
 
   @Prop({
     type: String,
-    unique: true,
   })
   _id: string;
 

--- a/src/datasets/schemas/technique.schema.ts
+++ b/src/datasets/schemas/technique.schema.ts
@@ -10,7 +10,7 @@ export class Technique {
     type: String,
     description: "Persistent Identifier dervied from UUIDv4",
   })
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String, unique: true, sparse: true })
   pid: string;
 
   @ApiProperty({

--- a/src/initial-datasets/schemas/initial-dataset.schema.ts
+++ b/src/initial-datasets/schemas/initial-dataset.schema.ts
@@ -10,7 +10,7 @@ export type InitialDatasetDocument = InitialDataset & Document;
   },
 })
 export class InitialDataset {
-  @Prop({ type: String, required: true, unique: true })
+  @Prop({ type: String, required: true })
   _id: string;
 }
 

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -13,7 +13,7 @@ export type InstrumentDocument = Instrument & Document;
   },
 })
 export class Instrument {
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String })
   _id: string;
 
   @ApiProperty({

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -13,7 +13,7 @@ export type JobDocument = Job & Document;
   },
 })
 export class Job {
-  @Prop({ type: String, unique: true, default: () => uuidv4() })
+  @Prop({ type: String, default: () => uuidv4() })
   _id: string;
 
   id?: string;

--- a/src/origdatablocks/schemas/origdatablock.schema.ts
+++ b/src/origdatablocks/schemas/origdatablock.schema.ts
@@ -19,7 +19,6 @@ export class OrigDatablock extends Ownable {
   })
   @Prop({
     type: String,
-    unique: true,
     required: true,
     default: () => uuidv4(),
   })

--- a/src/policies/schemas/policy.schema.ts
+++ b/src/policies/schemas/policy.schema.ts
@@ -14,7 +14,7 @@ export type PolicyDocument = Policy & Document;
 })
 export class Policy extends Ownable {
   @ApiProperty()
-  @Prop({ type: String, unique: true, default: () => uuidv4() })
+  @Prop({ type: String, default: () => uuidv4() })
   _id: string;
 
   @ApiProperty({

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -29,7 +29,7 @@ export class Proposal extends Ownable {
   @Prop({ type: String, unique: true, required: true })
   proposalId: string;
 
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String })
   _id: string;
 
   @ApiProperty({ type: String, description: "Email of principal investigator" })

--- a/src/published-data/schemas/published-data.schema.ts
+++ b/src/published-data/schemas/published-data.schema.ts
@@ -14,7 +14,6 @@ export type PublishedDataDocument = PublishedData & Document;
 export class PublishedData {
   @Prop({
     type: String,
-    unique: true,
     default: function genUUID(): string {
       return process.env.DOI_PREFIX + uuidv4();
     },

--- a/src/samples/schemas/sample.schema.ts
+++ b/src/samples/schemas/sample.schema.ts
@@ -18,7 +18,7 @@ export type SampleDocument = Sample & Document;
   },
 })
 export class Sample extends Ownable {
-  @Prop({ type: String, unique: true })
+  @Prop({ type: String })
   _id: string;
 
   @ApiProperty({


### PR DESCRIPTION
## Description
See #75 
## Motivation
For embedded document like Attachment, Technique, etc they can be empty/null if we don't add sparse the mongodb will index all documents even the ones that are `null` hence we get the exception. This PR add `sparse: true` which means only index the documents that contain the field to be indexed.
## Fixes:
See #75
## Changes:
- Add sparse property to schema
- Remove unique: true property since `_id `is a special field and mongo db always index this field. Adding unique might cause problem since mongodb will think we want to create a custom index for `_id`.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
