### PR TITLE
Increase max payload size to 16mb

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import * as session from "express-session";
+import { json } from "body-parser";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
@@ -18,6 +19,8 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup("explorer-next", app, document);
+
+  app.use(json({ limit: "16mb" }));
 
   const configService: ConfigService<Record<string, unknown>, false> = app.get(
     ConfigService,


### PR DESCRIPTION
## Description

Increase max payload size on POST requests from 100 kb to 16 mb to allow the creation of Attachments.

## Motivation

See issue #73.

## Fixes:

* #73

## Changes:

* Set upper limit of POST request body to 16 mb

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
