### PR TITLE
Remove unique index on dataset.techniques

### DIFF
--- a/src/datasets/schemas/technique.schema.ts
+++ b/src/datasets/schemas/technique.schema.ts
@@ -10,7 +10,7 @@ export class Technique {
     type: String,
     description: "Persistent Identifier dervied from UUIDv4",
   })
-  @Prop({ type: String, unique: true, sparse: true })
+  @Prop({ type: String, sparse: true })
   pid: string;
 
   @ApiProperty({


### PR DESCRIPTION
## Description

Fixes #121. There was a PR a few months ago that removed many unique index constraints, replacing them with sparse. This particular index was missed...it was made sparse but unique was not removed. This PR fixes that.

Tests pass.