### PR TITLE
Add migrate-mongo and a migration

### DIFF
--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -1,0 +1,36 @@
+// In this file you can configure migrate-mongo
+
+const config = {
+  mongodb: {
+    // TODO Change (or review) the url to your MongoDB:
+    url: "mongodb://localhost:27017",
+
+    // TODO Change this to your database name:
+    databaseName: "dacat",
+
+    options: {
+      useNewUrlParser: true, // removes a deprecation warning when connecting
+      useUnifiedTopology: true, // removes a deprecating warning when connecting
+      //   connectTimeoutMS: 3600000, // increase connection timeout to 1 hour
+      //   socketTimeoutMS: 3600000, // increase socket timeout to 1 hour
+    }
+  },
+
+  // The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
+  migrationsDir: "migrations",
+
+  // The mongodb collection where the applied changes are stored. Only edit this when really necessary.
+  changelogCollectionName: "changelog",
+
+  // The file extension to create migrations and search for in migration dir 
+  migrationFileExtension: ".js",
+
+  // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
+  // if the file should be run.  Requires that scripts are coded to be run multiple times.
+  useFileHash: false,
+
+  // Don't change this, unless you know what you're doing
+  moduleSystem: 'commonjs',
+};
+
+module.exports = config;

--- a/migrations/20220726224709-technique_index.js
+++ b/migrations/20220726224709-technique_index.js
@@ -1,0 +1,15 @@
+module.exports = {
+  async up(db, client) {
+    await db.collection("Dataset").dropIndex("techniques.pid_1");
+    await db
+      .collection("Dataset")
+      .createIndex({ "techniques.pid": 1 }, { sparse: true });
+  },
+
+  async down(db, client) {
+    await db.collection("Dataset").dropIndex("techniques.pid_1");
+    await db
+      .collection("Dataset")
+      .createIndex({ "techniques.pid": 1 }, { unique: true, sparse: true });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "BSD-3-Clause",
+  "type": "commonjs",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
## Description
This is experimental, would love some opinions before anyone thinks about merging.

Adds a package, migrate-mongo, to be able to manage database schema changes on the new backend.

## Motivation

Database migrations are a fairly standard practice, and there are a lot of tools out there to help manage the process of handling them during upgrades of the backend code. I hit the potential need in a recent PR, where I know that folks will want to drop and index after taking the changes.

I spent a little time playing with different tools. There are a couple of projects that use mongoose directly, but they are effectively dead. `migrate-mongo` appears to be well maintained and seemed to work for my very simple use case.

## How to use
If this gets merged, we'll want to write some official documentation. Here's at least an outline.

### For Scicat Deployers
Occasionally, upgrades of the backend code will require database migration scripts to be run. These scripts are managed by a package called  [migrate-mongo](https://github.com/seppevs/migrate-mongo). After upgrading server code, it is best practice to run the following from the command line where the server is installed.

```
migrate-mongo up
```

Any scripts that are in the `/migrations` directory will be run.

### For SciCat Developers
Did you prepare a PR that requires database schema changes? Create a migration script!

First, to create a script, in the root of the project, run:
```
migrate-mongo create <script name>
```
This will create a stub script in the `/migrations` directory. Code your changes there.

## Changes:

* Added dependency on `migrate-mongo`
* Added a migration script for a small change to Dataset indexes

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
