### PR TITLE
Fix dockerfile to use default arch and mount dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM --platform=amd64 node:16-alpine AS dev
+FROM node:16-alpine AS dev
 
 # Prepare app directory
 WORKDIR /home/node/app
 COPY . .
 
 # Set up local user
+RUN mkdir /home/node/app/dist
 RUN chown -R node:node /home/node/app
 USER node
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - .:/home/node/app
       - /home/node/app/node_modules
+      - /home/node/app/dist
     environment:
       MONGODB_URI: mongodb://mongodb:27017/scicat
       EXPRESS_SESSION_SECRET: a_scicat_secret


### PR DESCRIPTION
## Description

Remove the explicit setting of the architecture to use and add the dist volume mount not to override the container dist folder with the one that might be present on the host

## Motivation

Setting the architecture had some drawbacks with different OS
