### PR TITLE
Implement datasets PUT by standards

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -27,7 +27,7 @@ import {
   getSchemaPath,
 } from "@nestjs/swagger";
 import { DatasetsService } from "./datasets.service";
-import { UpdateDatasetDto } from "./dto/update-dataset.dto";
+import { PartialUpdateDatasetDto } from "./dto/update-dataset.dto";
 import { DatasetClass, DatasetDocument } from "./schemas/dataset.schema";
 import { CreateRawDatasetDto } from "./dto/create-raw-dataset.dto";
 import { CreateDerivedDatasetDto } from "./dto/create-derived-dataset.dto";
@@ -58,12 +58,18 @@ import { MultiUTCTimeInterceptor } from "src/common/interceptors/multi-utc-time.
 import { FullQueryInterceptor } from "./interceptors/fullquery.interceptor";
 import { FormatPhysicalQuantitiesInterceptor } from "src/common/interceptors/format-physical-quantities.interceptor";
 import { IFacets, IFilters } from "src/common/interfaces/common.interface";
-import { plainToInstance } from "class-transformer";
+import { ClassConstructor, plainToInstance } from "class-transformer";
 import { validate, ValidationError, ValidatorOptions } from "class-validator";
 import { HistoryInterceptor } from "src/common/interceptors/history.interceptor";
 import { CreateDatasetOrigDatablockDto } from "src/origdatablocks/dto/create-dataset-origdatablock";
-import { UpdateRawDatasetDto } from "./dto/update-raw-dataset.dto";
-import { UpdateDerivedDatasetDto } from "./dto/update-derived-dataset.dto";
+import {
+  PartialUpdateRawDatasetDto,
+  UpdateRawDatasetDto,
+} from "./dto/update-raw-dataset.dto";
+import {
+  PartialUpdateDerivedDatasetDto,
+  UpdateDerivedDatasetDto,
+} from "./dto/update-derived-dataset.dto";
 import { CreateDatasetDatablockDto } from "src/datablocks/dto/create-dataset-datablock";
 import { filterDescription, filterExample } from "src/common/utils";
 import { TechniqueClass } from "./schemas/technique.schema";
@@ -124,16 +130,33 @@ export class DatasetsController {
     @Body() createDatasetDto: CreateRawDatasetDto | CreateDerivedDatasetDto,
   ): Promise<DatasetClass> {
     // validate dataset
-    const validatedDatasetDto = await this.validateDataset(createDatasetDto);
-    return this.datasetsService.create(validatedDatasetDto);
+    await this.validateDataset(
+      createDatasetDto,
+      createDatasetDto.type === "raw"
+        ? CreateRawDatasetDto
+        : CreateDerivedDatasetDto,
+    );
+
+    return this.datasetsService.create(createDatasetDto);
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
   async validateDataset(
-    inputDatasetDto: CreateRawDatasetDto | CreateDerivedDatasetDto,
-  ): Promise<CreateRawDatasetDto | CreateDerivedDatasetDto> {
-    let errors: Array<unknown> = [];
-    let outputDatasetDto: CreateRawDatasetDto | CreateDerivedDatasetDto;
+    inputDatasetDto:
+      | CreateRawDatasetDto
+      | CreateDerivedDatasetDto
+      | PartialUpdateRawDatasetDto
+      | PartialUpdateDerivedDatasetDto
+      | UpdateRawDatasetDto
+      | UpdateDerivedDatasetDto,
+    dto: ClassConstructor<
+      | CreateRawDatasetDto
+      | CreateDerivedDatasetDto
+      | PartialUpdateRawDatasetDto
+      | PartialUpdateDerivedDatasetDto
+      | UpdateRawDatasetDto
+      | UpdateDerivedDatasetDto
+    >,
+  ) {
     const type = inputDatasetDto.type;
     const validateOptions: ValidatorOptions = {
       whitelist: true,
@@ -141,6 +164,7 @@ export class DatasetsController {
       forbidUnknownValues: true,
       validationError: {
         value: false,
+        target: false,
       },
     };
 
@@ -154,16 +178,9 @@ export class DatasetsController {
       );
     }
 
-    if (type == "raw") {
-      outputDatasetDto = plainToInstance(CreateRawDatasetDto, inputDatasetDto);
-      errors = await validate(outputDatasetDto, validateOptions);
-    } else {
-      outputDatasetDto = plainToInstance(
-        CreateDerivedDatasetDto,
-        inputDatasetDto,
-      );
-      errors = await validate(outputDatasetDto, validateOptions);
-    }
+    const outputDatasetDto = plainToInstance(dto, inputDatasetDto);
+    const errors = await validate(outputDatasetDto, validateOptions);
+
     if (errors.length > 0) {
       throw new HttpException(
         {
@@ -173,6 +190,7 @@ export class DatasetsController {
         HttpStatus.BAD_REQUEST,
       );
     }
+
     return outputDatasetDto;
   }
 
@@ -206,10 +224,7 @@ export class DatasetsController {
     description:
       "Check if the dataset provided pass validation. It return true if the validation is passed",
   })
-  async isValid(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    @Body() createDataset: unknown,
-  ): Promise<{ valid: boolean }> {
+  async isValid(@Body() createDataset: unknown): Promise<{ valid: boolean }> {
     const dtoTestRawCorrect = plainToInstance(
       CreateRawDatasetDto,
       createDataset,
@@ -574,24 +589,24 @@ export class DatasetsController {
   )
   @Patch("/:pid")
   @ApiOperation({
-    summary: "It updates the dataset.",
+    summary: "It partially updates the dataset.",
     description:
-      "It updates the dataset specified through the pid specified. It updates only the specified fields.",
+      "It updates the dataset through the pid specified. It updates only the specified fields.",
   })
   @ApiParam({
     name: "pid",
     description: "Id of the dataset to modify",
     type: String,
   })
-  @ApiExtraModels(UpdateRawDatasetDto, UpdateDerivedDatasetDto)
+  @ApiExtraModels(PartialUpdateRawDatasetDto, PartialUpdateDerivedDatasetDto)
   @ApiBody({
     description:
       "Fields that needs to be updated in the dataset. Only the fields that needs to be updated have to be passed in.",
     required: true,
     schema: {
       oneOf: [
-        { $ref: getSchemaPath(UpdateRawDatasetDto) },
-        { $ref: getSchemaPath(UpdateDerivedDatasetDto) },
+        { $ref: getSchemaPath(PartialUpdateRawDatasetDto) },
+        { $ref: getSchemaPath(PartialUpdateDerivedDatasetDto) },
       ],
     },
   })
@@ -604,17 +619,21 @@ export class DatasetsController {
   async findByIdAndUpdate(
     @Param("pid") pid: string,
     @Body()
-    updateDatasetDto: UpdateRawDatasetDto | UpdateDerivedDatasetDto,
+    updateDatasetDto:
+      | PartialUpdateRawDatasetDto
+      | PartialUpdateDerivedDatasetDto,
   ): Promise<DatasetClass | null> {
+    // NOTE: Default validation pipe does not validate union types. So we need custom validation.
+    await this.validateDataset(
+      updateDatasetDto,
+      updateDatasetDto.type === "raw"
+        ? PartialUpdateRawDatasetDto
+        : PartialUpdateDerivedDatasetDto,
+    );
+
     return this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto);
   }
 
-  /**
-   * NOTE: PUT and PATCH functionality is exactly the same and behaves as a PATCH. They update only the fields that are passed in.
-   * In literature, the PUT method should replace completely the object requested with the values passed in.
-   * Here is an example of a proper implementation: https://wanago.io/2021/09/27/api-nestjs-put-patch-mongodb-mongoose/
-   * There is a ticket open for discussion where we decide how to move forward: https://jira.esss.lu.se/browse/SWAP-2942
-   */
   // PUT /datasets/:id
   @UseGuards(PoliciesGuard)
   @CheckPolicies((ability: AppAbility) =>
@@ -629,8 +648,10 @@ export class DatasetsController {
   @Put("/:pid")
   @ApiOperation({
     summary: "It updates the dataset.",
-    description:
-      "It updates the dataset specified through the pid provided. Only the specified fields are updated(at the moment put and patch behavior is completely the same).",
+    description: `It updates(replaces) the dataset specified through the pid provided. If optional fields are not provided they will be removed.
+      The PUT method is responsible for modifying an existing entity. The crucial part about it is that it is supposed to replace an entity.
+      Therefore, if we don’t send a field of an entity when performing a PUT request, the missing field should be removed from the document.
+      (Caution: This operation could result with data loss if all the dataset fields are not provided)`,
   })
   @ApiParam({
     name: "pid",
@@ -640,7 +661,7 @@ export class DatasetsController {
   @ApiExtraModels(UpdateRawDatasetDto, UpdateDerivedDatasetDto)
   @ApiBody({
     description:
-      "Fields that needs to be updated in the dataset. Only the fields that needs to be updated have to be passed in.",
+      "Dataset object that needs to be updated. The whole dataset object with updated fields have to be passed in.",
     required: true,
     schema: {
       oneOf: [
@@ -655,11 +676,22 @@ export class DatasetsController {
     description:
       "Update an existing dataset and return its representation in SciCat",
   })
-  async findByIdReplaceOrCreate(
+  async findByIdAndReplace(
     @Param("pid") id: string,
     @Body() updateDatasetDto: UpdateRawDatasetDto | UpdateDerivedDatasetDto,
   ): Promise<DatasetClass | null> {
-    return this.datasetsService.findByIdAndUpdate(id, updateDatasetDto);
+    // NOTE: Default validation pipe does not validate union types. So we need custom validation.
+    const outputDto = await this.validateDataset(
+      updateDatasetDto,
+      updateDatasetDto.type === "raw"
+        ? UpdateRawDatasetDto
+        : UpdateDerivedDatasetDto,
+    );
+
+    return this.datasetsService.findByIdAndReplace(
+      id,
+      outputDto as UpdateRawDatasetDto | UpdateDerivedDatasetDto,
+    );
   }
 
   // DELETE /datasets/:id
@@ -957,7 +989,7 @@ export class DatasetsController {
         createOrigDatablock,
       );
 
-      const updateDatasetDto: UpdateDatasetDto = {
+      const updateDatasetDto: PartialUpdateDatasetDto = {
         size: dataset.size + datablock.size,
         numberOfFiles: dataset.numberOfFiles + datablock.dataFileList.length,
       };
@@ -1146,7 +1178,7 @@ export class DatasetsController {
         datasetId: datasetId,
       });
       // update dataset size and files number
-      const updateDatasetDto: UpdateDatasetDto = {
+      const updateDatasetDto: PartialUpdateDatasetDto = {
         size: odb.reduce((a, b) => a + b.size, 0),
         numberOfFiles: odb.reduce((a, b) => a + b.dataFileList.length, 0),
       };
@@ -1341,7 +1373,7 @@ export class DatasetsController {
         datasetId: datasetId,
       });
       // update dataset size and files number
-      const updateDatasetDto: UpdateDatasetDto = {
+      const updateDatasetDto: PartialUpdateDatasetDto = {
         packedSize: remainingDatablocks.reduce((a, b) => a + b.packedSize, 0),
         numberOfFilesArchived: remainingDatablocks.reduce(
           (a, b) => a + b.dataFileList.length,

--- a/src/datasets/dto/create-dataset.dto.ts
+++ b/src/datasets/dto/create-dataset.dto.ts
@@ -12,6 +12,7 @@ import {
   ValidateNested,
   IsObject,
   IsArray,
+  IsEnum,
 } from "class-validator";
 import { ApiProperty, ApiTags, getSchemaPath } from "@nestjs/swagger";
 import { DatasetType } from "../dataset-type.enum";
@@ -22,16 +23,6 @@ import { LifecycleClass } from "../schemas/lifecycle.schema";
 
 @ApiTags("datasets")
 export class CreateDatasetDto extends OwnableDto {
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "Persistent Identifier for datasets derived from UUIDv4 and prepended automatically by site specific PID prefix like 20.500.12345/",
-  })
-  @IsOptional()
-  @IsString()
-  readonly pid?: string;
-
   @ApiProperty({
     type: String,
     required: true,
@@ -151,7 +142,7 @@ export class CreateDatasetDto extends OwnableDto {
     description:
       "Characterize type of dataset, either 'base' or 'raw' or 'derived'. Autofilled when choosing the proper inherited models",
   })
-  @IsString()
+  @IsEnum(DatasetType)
   readonly type: string;
 
   @ApiProperty({

--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -1,4 +1,5 @@
 import { PartialType } from "@nestjs/swagger";
 import { CreateDatasetDto } from "./create-dataset.dto";
 
-export class UpdateDatasetDto extends PartialType(CreateDatasetDto) {}
+export class UpdateDatasetDto extends CreateDatasetDto {}
+export class PartialUpdateDatasetDto extends PartialType(CreateDatasetDto) {}

--- a/src/datasets/dto/update-derived-dataset.dto.ts
+++ b/src/datasets/dto/update-derived-dataset.dto.ts
@@ -1,6 +1,49 @@
 import { PartialType } from "@nestjs/swagger";
+import { Exclude } from "class-transformer";
+import { IsOptional } from "class-validator";
+import { Attachment } from "src/attachments/schemas/attachment.schema";
+import { Datablock } from "src/datablocks/schemas/datablock.schema";
+import { OrigDatablock } from "src/origdatablocks/schemas/origdatablock.schema";
 import { CreateDerivedDatasetDto } from "./create-derived-dataset.dto";
 
-export class UpdateDerivedDatasetDto extends PartialType(
+export class UpdateDerivedDatasetDto extends CreateDerivedDatasetDto {
+  @IsOptional()
+  @Exclude()
+  readonly _id?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly pid?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly createdAt?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly updatedAt?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly createdBy?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly updatedBy?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly history?: string;
+
+  @IsOptional()
+  attachments?: Attachment[];
+
+  @IsOptional()
+  origdatablocks?: OrigDatablock[];
+
+  @IsOptional()
+  datablocks?: Datablock[];
+}
+export class PartialUpdateDerivedDatasetDto extends PartialType(
   CreateDerivedDatasetDto,
 ) {}

--- a/src/datasets/dto/update-raw-dataset.dto.ts
+++ b/src/datasets/dto/update-raw-dataset.dto.ts
@@ -1,4 +1,65 @@
 import { PartialType } from "@nestjs/swagger";
+import { Exclude } from "class-transformer";
+import { IsOptional } from "class-validator";
+import { Attachment } from "src/attachments/schemas/attachment.schema";
+import { Datablock } from "src/datablocks/schemas/datablock.schema";
+import { OrigDatablock } from "src/origdatablocks/schemas/origdatablock.schema";
 import { CreateRawDatasetDto } from "./create-raw-dataset.dto";
 
-export class UpdateRawDatasetDto extends PartialType(CreateRawDatasetDto) {}
+export class UpdateRawDatasetDto extends CreateRawDatasetDto {
+  @IsOptional()
+  @Exclude()
+  readonly _id?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly pid?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly createdAt?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly updatedAt?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly createdBy?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly updatedBy?: string;
+
+  @IsOptional()
+  @Exclude()
+  readonly history?: string;
+
+  @IsOptional()
+  attachments?: Attachment[];
+
+  @IsOptional()
+  origdatablocks?: OrigDatablock[];
+
+  @IsOptional()
+  datablocks?: Datablock[];
+
+  @IsOptional()
+  investigator?: string;
+
+  @IsOptional()
+  inputDatasets?: string[];
+
+  @IsOptional()
+  usedSoftware?: string[];
+
+  @IsOptional()
+  jobParameters?: Record<string, unknown>;
+
+  @IsOptional()
+  jobLogData?: string;
+}
+
+export class PartialUpdateRawDatasetDto extends PartialType(
+  CreateRawDatasetDto,
+) {}


### PR DESCRIPTION
## Description

This PR aims to refactor and improve the PUT endpoint on the datasets. PUT method should be idempotent(calling it once or several times successively has the same effect). Now PUT endpoint uses `findOneAndReplace` instead of acting exactly the same as PATCH where we used `findOneAndUpdate` doing partial update instead of replacement.

## Motivation

PUT method should be replacing instead of doing partial updates.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-2942

## Changes:

* Changes are mainly in the dataset update/partial update DTOs, validation and controller logic.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
