### PR TITLE
feat: add all the migration scripts in one place to be able to run with migrate-mongo

### DIFF
--- a/migrations/20220726224709-technique_index.js
+++ b/migrations/20220726224709-technique_index.js
@@ -1,13 +1,23 @@
 module.exports = {
   async up(db, client) {
-    await db.collection("Dataset").dropIndex("techniques.pid_1");
+    try {
+      await db.collection("Dataset").dropIndex("techniques.pid_1");
+    } catch (error) {
+      console.info(`Index techniques.pid_1 not found`, error);
+    }
     await db
       .collection("Dataset")
       .createIndex({ "techniques.pid": 1 }, { sparse: true });
   },
 
   async down(db, client) {
-    await db.collection("Dataset").dropIndex("techniques.pid_1");
+    try {
+      await db.collection("Dataset").dropIndex("techniques.pid_1");
+    } catch (error) {
+      console.info(`Index techniques.pid_1 not found`, error);
+    }
+    // NOTE: This unique flag here is problematic because after importing production data and trying it throws an error:
+    // E11000 duplicate key error collection: dacat.Dataset index: techniques.pid_1 dup key
     await db
       .collection("Dataset")
       .createIndex({ "techniques.pid": 1 }, { unique: true, sparse: true });

--- a/migrations/20230125083116-migrate-id-field-to-pid.js
+++ b/migrations/20230125083116-migrate-id-field-to-pid.js
@@ -1,0 +1,38 @@
+const collections = [
+  { name: "Dataset", idField: "pid" },
+  { name: "Instrument", idField: "pid" },
+  { name: "Proposal", idField: "proposalId" },
+  { name: "PublishedData", idField: "doi" },
+  { name: "Sample", idField: "sampleId" },
+];
+
+module.exports = {
+  async up(db, client) {
+    for (let index = 0; index < collections.length; index++) {
+      const { name, idField } = collections[index];
+
+      await db
+        .collection(name)
+        .updateMany({}, [{ $set: { [idField]: "$_id" } }]);
+      await db.collection(name).createIndex(idField, { unique: true });
+
+      console.info("Collection: " + name);
+      console.info(`Migrate _id field to ${idField}`);
+    }
+  },
+
+  async down(db, client) {
+    for (let index = 0; index < collections.length; index++) {
+      const { name, idField } = collections[index];
+      try {
+        await db.collection(name).dropIndex(`${idField}_1`);
+      } catch (error) {
+        console.info(`Index ${idField}_1 not found`, error);
+      }
+      await db.collection(name).updateMany({}, { $unset: { [idField]: "" } });
+
+      console.info("Collection: " + name);
+      console.info(`Down migrate ${idField} field`);
+    }
+  },
+};

--- a/migrations/20230125143522-replace-object-ids.js
+++ b/migrations/20230125143522-replace-object-ids.js
@@ -1,0 +1,72 @@
+const names = [
+  "Job",
+  "Policy",
+  "Sample",
+  "UserSetting",
+  "Attachment",
+  "OrigDatablock",
+];
+
+const translation = {};
+
+module.exports = {
+  async up(db, client) {
+    for (var i = 0; i < names.length; i++) {
+      console.info("Collection:" + names[i]);
+      db.collection(names[i])
+        .find({
+          $or: [
+            {
+              _id: {
+                $regex: /^[a-f\d]{24}$/i,
+              },
+            },
+            {
+              _id: {
+                $type: "objectId",
+              },
+            },
+          ],
+        })
+        .forEach(function (x) {
+          var oldId = x._id;
+          // eslint-disable-next-line @typescript-eslint/quotes
+          x._id = UUID().toString().split('"')[1];
+          console.info("   Update id " + oldId + " to id " + x._id);
+          if (names[i] == "Sample") {
+            translation[oldId] = x._id;
+          }
+          db.collection(names[i]).insert(x);
+          db.collection(names[i]).remove({
+            _id: oldId,
+          });
+        });
+    }
+    console.info("Update sampleIds in datasets:");
+    console.info(translation);
+    db.collection("Dataset")
+      .find({
+        sampleId: {
+          $in: Object.keys(translation),
+        },
+      })
+      .forEach(function (ds) {
+        if ("sampleId" in ds) {
+          db.collection("Dataset").update(
+            {
+              _id: ds._id,
+            },
+            {
+              $set: {
+                sampleId: translation[ds.sampleId],
+              },
+            },
+          );
+        }
+      });
+  },
+
+  async down(db, client) {
+    // TODO: Not sure how to write this down migration???
+  },
+};


### PR DESCRIPTION
## Description

Adding all database migration scripts in one place.

## Motivation

Previously we had shell scripts and migrate-mongo scripts for initial database migration and needed two different ways of running them.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-2982
