### PR TITLE
fix published dataset datablocks and attachments permissions

### DIFF
--- a/src/logbooks/interceptors/users-logbooks.interceptor.ts
+++ b/src/logbooks/interceptors/users-logbooks.interceptor.ts
@@ -26,10 +26,10 @@ export class UsersLogbooksInterceptor implements NestInterceptor {
       map((payload: unknown) => {
         if (Array.isArray(payload)) {
           return (payload as Logbook[]).filter((logbook) =>
-            proposalIds.includes(logbook.name),
+            proposalIds.includes(logbook?.name),
           );
         }
-        return proposalIds.includes((payload as Logbook).name)
+        return proposalIds.includes((payload as Logbook)?.name)
           ? (payload as Logbook)
           : null;
       }),

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -142,6 +142,50 @@ describe("DatasetAuthorization: Test access to dataset", () => {
       });
   });
 
+  it("adds a new origDatablock on the published dataset", async () => {
+    return request(appUrl)
+      .post(`/api/v3/datasets/${encodedDatasetPid1}/origdatablocks`)
+      .send(TestData.OrigDataBlockCorrect1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(201)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("size")
+          .and.equal(TestData.OrigDataBlockCorrect1.size);
+        res.body.should.have.property("id").and.be.string;
+      });
+  });
+
+  it("adds a new datablock on the published dataset", async () => {
+    const randomArchiveId = Math.random().toString(36).slice(2);
+
+    return request(appUrl)
+      .post(`/api/v3/datasets/${encodedDatasetPid1}/datablocks`)
+      .send({ ...TestData.DataBlockCorrect, archiveId: randomArchiveId })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(201)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("size")
+          .and.equal(TestData.DataBlockCorrect.size);
+        res.body.should.have.property("id").and.be.string;
+      });
+  });
+
+  it("adds a new attachment on the published dataset", async () => {
+    return request(appUrl)
+      .post(`/api/v3/datasets/${encodedDatasetPid1}/attachments`)
+      .send(TestData.AttachmentCorrect)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(201)
+      .expect("Content-Type", /json/);
+  });
+
   it("list of public datasets, aka as unauthenticated user", async () => {
     return request(appUrl)
       .get("/api/v3/Datasets")
@@ -505,5 +549,50 @@ describe("DatasetAuthorization: Test access to dataset", () => {
       .then((res) => {
         res.body[0].all[0].totalSets.should.be.equal(2);
       });
+  });
+
+  it("access dataset 1 origdatablocks as user 3", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/origdatablocks")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
+  });
+
+  it("access dataset 1 datablocks as user 3", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/datablocks")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
+  });
+
+  it("access dataset 1 attachments as user 3", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
+  });
+
+  it("access dataset 1 thumbnail as user 3", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/thumbnail")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(200);
   });
 });

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -266,7 +266,7 @@ describe("PublishedData: Test of access to published data", () => {
       .send(testAttachment)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessToken}` })
-      .expect(200)
+      .expect(201)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have


### PR DESCRIPTION
## Description

Fix permissions for following endpoints:

- GET /datasets/:id/thumbnail
- GET /datasets/:id/origdatablocks
- GET /datasets/:id/datablocks
- GET /datasets/:id/attachments

## Motivation

The above endpoints were not allowing unauthenticated user to access data on public datasets.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-3084

## Changes:

* changes made

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
