### PR TITLE
added mongo migrate script to updated User and UserIdentity

### DIFF
--- a/migrations/20230309125203-update-user-entries.js
+++ b/migrations/20230309125203-update-user-entries.js
@@ -1,0 +1,37 @@
+module.exports = {
+  async up(db, client) {
+    db.collection("User")
+      .find({})
+      .forEach(user => {
+        let properties = {};
+        if (user.username.startsWith("oidc.")) {
+          properties['username'] = user.username.replace("oidc.","");
+          if (!user.authStrategy) {
+            properties["authStrategy"] = "oidc";
+          }
+        } else if (user.username.startsWith("ldap.")) {
+          properties['username'] = user.username.replace("ldap.","");
+          if (!user.authStrategy) {
+            properties["authStrategy"] = "ldap";
+          }
+        } else if (!user.authStrategy) {
+          properties["authStrategy"] = "local";
+        }
+        if (!!Object.keys(properties).length) {
+          console.log(`Updating User ${user.username}(${user._id}) with properties:`,JSON.stringify(properties));
+          db.collection("User").updateOne(
+            {
+              _id: user._id,
+            },
+            {
+              $set: properties,
+            }
+          )
+        }
+      });
+  },
+
+  async down(db, client) {
+    // No path back!!!
+  }
+};

--- a/migrations/20230309145701-update-user-indentity-entries.js
+++ b/migrations/20230309145701-update-user-indentity-entries.js
@@ -12,7 +12,7 @@ module.exports = {
           authStrategy = "ldap";
         }
         console.log(`Updating User Identity ${identity.externalId} (${identity.userId}) with authStrategy: ${authStrategy}`);
-        const res = db.collection("UserIdentity").updateOne(
+        db.collection("UserIdentity").updateOne(
           {
             _id: ObjectId(identity._id),
           },

--- a/migrations/20230309145701-update-user-indentity-entries.js
+++ b/migrations/20230309145701-update-user-indentity-entries.js
@@ -1,0 +1,31 @@
+const ObjectId = require('bson').ObjectId;
+
+module.exports = {
+  async up(db, client) {
+    await db.collection("UserIdentity")
+      .find({})
+      .forEach(identity => {
+        let authStrategy = "local";
+        if (identity.authScheme === "oidc") {
+          authStrategy = "oidc";
+        } else if (identity.authScheme === "ldap") {
+          authStrategy = "ldap";
+        }
+        console.log(`Updating User Identity ${identity.externalId} (${identity.userId}) with authStrategy: ${authStrategy}`);
+        const res = db.collection("UserIdentity").updateOne(
+          {
+            _id: ObjectId(identity._id),
+          },
+          {
+            $set: {
+              authStrategy : authStrategy,
+            },
+          }
+        )
+      });
+  },
+
+  async down(db, client) {
+    // No path backward
+  }
+};


### PR DESCRIPTION
## Description
We added a dedicate field to collection User and UserIdentity to store which strategy the user was authenticated with 
This PR adds the migrate mongo scripts to update such collections to adhere to the new schema

## Motivation
The new backend implements a cleaner schema to store the user information and which strategy they used to authenticate with.

## Changes:
* added migration mongo scripts

## Tests included/Docs Updated?
- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [x] New packages used/requires npm install? 
- [ ] Toggle added for new features?
