### PR TITLE
fix: create origdatablock with empty chkAlg causing 500 error

### DIFF
--- a/src/origdatablocks/dto/create-origdatablock.dto.ts
+++ b/src/origdatablocks/dto/create-origdatablock.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsOptional,
   IsString,
+  IsNotEmpty,
   ValidateNested,
 } from "class-validator";
 import { DataFileDto } from "src/common/dto/datafile.dto";
@@ -20,6 +21,7 @@ export class CreateOrigDatablockDto extends OwnableDto {
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   readonly chkAlg: string;
 
   @IsArray()

--- a/src/origdatablocks/schemas/origdatablock.schema.ts
+++ b/src/origdatablocks/schemas/origdatablock.schema.ts
@@ -52,7 +52,7 @@ export class OrigDatablock extends OwnableClass {
     description: "Algorithm used to compute the file chksum",
   })
   @Prop({
-    type: Number,
+    type: String,
     required: false,
   })
   chkAlg: string;

--- a/test/Instrument.js
+++ b/test/Instrument.js
@@ -8,7 +8,7 @@ let accessToken = null,
   accessTokenArchiveManager = null,
   instrumentId = null;
 
-const newName="ESS2.5";
+const newName = "ESS2.5";
 
 describe("Instrument: Instrument management", () => {
   beforeEach((done) => {
@@ -44,7 +44,9 @@ describe("Instrument: Instrument management", () => {
       .expect(201)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("name").and.be.equal(TestData.InstrumentCorrect.name);
+        res.body.should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect.name);
         res.body.should.have.property("pid").and.be.string;
         instrumentId = res.body["pid"];
       });
@@ -58,7 +60,9 @@ describe("Instrument: Instrument management", () => {
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("name").and.be.equal(TestData.InstrumentCorrect.name);
+        res.body.should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect.name);
         res.body.should.have.property("pid").and.be.equal(instrumentId);
       });
   });
@@ -72,7 +76,9 @@ describe("Instrument: Instrument management", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.an("array").to.have.length(1);
-        res.body[0].should.have.property("name").and.be.equal(TestData.InstrumentCorrect.name);
+        res.body[0].should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect.name);
         res.body[0].should.have.property("pid").and.be.equal(instrumentId);
       });
   });

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -1,18 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-var utils = require("./LoginUtils");
+const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
 
 describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw Datasets", () => {
-  var accessTokenIngestor = null;
-  var accessTokenArchiveManager = null;
-
-  var datasetPid = null;
-
-  var origDatablockId1 = null;
-  var origDatablockId2 = null;
-
-  var origDatablockData1 = null;
-  var origDatablockData2 = null;
+  let accessTokenIngestor = null,
+    accessTokenArchiveManager = null,
+    datasetPid = null,
+    origDatablockId1 = null,
+    origDatablockId2 = null,
+    origDatablockData1 = null,
+    origDatablockData2 = null,
+    origDatablockWithEmptyChkAlg = null,
+    origDatablockWithCorrectChkAlg = null;
 
   beforeEach((done) => {
     utils.getToken(
@@ -39,6 +38,8 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
 
     origDatablockData1 = { ...TestData.OrigDataBlockCorrect1 };
     origDatablockData2 = { ...TestData.OrigDataBlockCorrect2 };
+    origDatablockWithEmptyChkAlg = { ...TestData.OrigDataBlockWrongChkAlg };
+    origDatablockWithCorrectChkAlg = { ...TestData.OrigDataBlockCorrect3 };
   });
 
   it("adds a new raw dataset", async () => {
@@ -100,6 +101,34 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(403)
       .expect("Content-Type", /json/);
+  });
+
+  it("add a new origDatablock with empty chkAlg should fail", async () => {
+    return request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
+      .send(origDatablockWithEmptyChkAlg)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(400)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("error");
+      });
+  });
+
+  it("add a new origDatablock with valid chkAlg should success", async () => {
+    return request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
+      .send(origDatablockWithCorrectChkAlg)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(201)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("chkAlg")
+          .and.equal(TestData.OrigDataBlockCorrect3.chkAlg);
+      });
   });
 
   it("adds a new origDatablock with correct account", async () => {

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -12,7 +12,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
     origDatablockData1 = null,
     origDatablockData2 = null,
     origDatablockWithEmptyChkAlg = null,
-    origDatablockWithCorrectChkAlg = null;
+    origDatablockWithValidChkAlg = null;
 
   beforeEach((done) => {
     utils.getToken(
@@ -40,7 +40,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
     origDatablockData1 = { ...TestData.OrigDataBlockCorrect1 };
     origDatablockData2 = { ...TestData.OrigDataBlockCorrect2 };
     origDatablockWithEmptyChkAlg = { ...TestData.OrigDataBlockWrongChkAlg };
-    origDatablockWithCorrectChkAlg = { ...TestData.OrigDataBlockCorrect3 };
+    origDatablockWithValidChkAlg = { ...TestData.OrigDataBlockCorrect3 };
   });
 
   it("adds a new raw dataset", async () => {
@@ -120,7 +120,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
   it("add a new origDatablock with valid chkAlg should success", async () => {
     return request(appUrl)
       .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
-      .send(origDatablockWithCorrectChkAlg)
+      .send(origDatablockWithValidChkAlg)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(201)

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -243,7 +243,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
         res.body.origdatablocks.should.be
           .instanceof(Array)
           .and.to.have.length(3);
-        res.body.origdatablocks[0].should.have
+        res.body.origdatablocks[1].should.have
           .property("dataFileList")
           .and.be.instanceof(Array)
           .and.to.have.length(
@@ -365,7 +365,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
           .and.equal(
             TestData.OrigDataBlockCorrect1.size +
               TestData.OrigDataBlockCorrect2.size +
-              TestData.OrigDataBlockCorrect3,
+              TestData.OrigDataBlockCorrect3.size,
           );
         res.body.should.have
           .property("numberOfFiles")

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -8,6 +8,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
     datasetPid = null,
     origDatablockId1 = null,
     origDatablockId2 = null,
+    origDatablockId3 = null,
     origDatablockData1 = null,
     origDatablockData2 = null,
     origDatablockWithEmptyChkAlg = null,
@@ -128,6 +129,8 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
         res.body.should.have
           .property("chkAlg")
           .and.equal(TestData.OrigDataBlockCorrect3.chkAlg);
+        res.body.should.have.property("id").and.be.string;
+        origDatablockId3 = encodeURIComponent(res.body["id"]);
       });
   });
 
@@ -173,9 +176,22 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.instanceof(Array).and.to.have.length(2);
-        res.body[0]["id"].should.be.oneOf([origDatablockId1, origDatablockId2]);
-        res.body[1]["id"].should.be.oneOf([origDatablockId1, origDatablockId2]);
+        res.body.should.be.instanceof(Array).and.to.have.length(3);
+        res.body[0]["id"].should.be.oneOf([
+          origDatablockId1,
+          origDatablockId2,
+          origDatablockId3,
+        ]);
+        res.body[1]["id"].should.be.oneOf([
+          origDatablockId1,
+          origDatablockId2,
+          origDatablockId3,
+        ]);
+        res.body[2]["id"].should.be.oneOf([
+          origDatablockId1,
+          origDatablockId2,
+          origDatablockId3,
+        ]);
       });
   });
 
@@ -189,7 +205,8 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
       .then((res) => {
         res.body["size"].should.be.equal(
           TestData.OrigDataBlockCorrect1.size +
-            TestData.OrigDataBlockCorrect2.size,
+            TestData.OrigDataBlockCorrect2.size +
+            TestData.OrigDataBlockCorrect3.size,
         );
       });
   });
@@ -225,7 +242,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
         res.body["pid"].should.be.equal(decodeURIComponent(datasetPid));
         res.body.origdatablocks.should.be
           .instanceof(Array)
-          .and.to.have.length(2);
+          .and.to.have.length(3);
         res.body.origdatablocks[0].should.have
           .property("dataFileList")
           .and.be.instanceof(Array)
@@ -347,13 +364,15 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
           .property("size")
           .and.equal(
             TestData.OrigDataBlockCorrect1.size +
-              TestData.OrigDataBlockCorrect2.size,
+              TestData.OrigDataBlockCorrect2.size +
+              TestData.OrigDataBlockCorrect3,
           );
         res.body.should.have
           .property("numberOfFiles")
           .and.equal(
             TestData.OrigDataBlockCorrect1.dataFileList.length +
-              TestData.OrigDataBlockCorrect2.dataFileList.length,
+              TestData.OrigDataBlockCorrect2.dataFileList.length +
+              TestData.OrigDataBlockCorrect3.dataFileList.length,
           );
       });
   });
@@ -372,6 +391,16 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
     return request(appUrl)
       .delete(
         `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId2}`,
+      )
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(200);
+  });
+
+  it("should delete third OrigDatablock", async () => {
+    return request(appUrl)
+      .delete(
+        `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId3}`,
       )
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -108,7 +108,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
       .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
       .send(origDatablockWithEmptyChkAlg)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(400)
       .expect("Content-Type", /json/)
       .then((res) => {
@@ -121,7 +121,7 @@ describe("RawDatasetOrigDatablock: Test OrigDatablocks and their relation to raw
       .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
       .send(origDatablockWithCorrectChkAlg)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(201)
       .expect("Content-Type", /json/)
       .then((res) => {

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { faker } = require("@faker-js/faker");
 
 const TestData = {
@@ -157,7 +158,7 @@ const TestData = {
     type: "raw",
     keywords: ["sls", "protein"],
   },
-  
+
   RawCorrectRandom: {
     principalInvestigator: faker.internet.email(),
     endTime: faker.date.past().toISOString(),
@@ -565,8 +566,37 @@ const TestData = {
     ],
   },
 
+  OrigDataBlockCorrect3: {
+    chkAlg: "Test-chkAlg",
+    size: 41780189,
+    dataFileList: [
+      {
+        path: "N1039-1.tif",
+        size: 8356037,
+        time: "2017-07-24T13:56:30.000Z",
+        uid: "egon.meiera@psi.ch",
+        gid: "p16738",
+        perm: "-rw-rw-r--",
+      },
+    ],
+  },
+
   OrigDataBlockWrong: {
     size: "This is wrong",
+  },
+  OrigDataBlockWrongChkAlg: {
+    chkAlg: "",
+    size: 41780189,
+    dataFileList: [
+      {
+        path: "N1039-1.tif",
+        size: 8356037,
+        time: "2017-07-24T13:56:30.000Z",
+        uid: "egon.meiera@psi.ch",
+        gid: "p16738",
+        perm: "-rw-rw-r--",
+      },
+    ],
   },
 
   DatasetLifecycle_query_1: {
@@ -687,9 +717,8 @@ const TestData = {
     customMetadata: {
       institute: "An immaginary intitution",
       department: "An immaginary department",
-    }
+    },
   },
-
 };
 
 module.exports = { TestData };


### PR DESCRIPTION
## Description

when I create an origdatablock with field chkAlg field set to empty string, I receive a 500 error.

## Fixes
https://jira.esss.lu.se/browse/SWAP-3161

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
