### PR TITLE
fix: admin should have access to all logbooks for proposals

### DIFF
--- a/src/logbooks/interceptors/users-logbooks.interceptor.ts
+++ b/src/logbooks/interceptors/users-logbooks.interceptor.ts
@@ -7,7 +7,7 @@ import {
 import { map, Observable } from "rxjs";
 import { ProposalsService } from "src/proposals/proposals.service";
 import { Logbook } from "../schemas/logbook.schema";
-
+import { Role } from "src/auth/role.enum";
 @Injectable()
 export class UsersLogbooksInterceptor implements NestInterceptor {
   constructor(private readonly proposalsService: ProposalsService) {}
@@ -17,6 +17,7 @@ export class UsersLogbooksInterceptor implements NestInterceptor {
     next: CallHandler,
   ): Promise<Observable<Logbook | Logbook[] | null>> {
     const usersGroups = context.getArgs()[1].req.user.currentGroups;
+    const isAdmin = usersGroups.includes(Role.Admin);
     const proposals = await this.proposalsService.findAll({
       where: { ownerGroup: { $in: usersGroups } },
     });
@@ -25,12 +26,13 @@ export class UsersLogbooksInterceptor implements NestInterceptor {
     return next.handle().pipe(
       map((payload: unknown) => {
         if (Array.isArray(payload)) {
-          const filteredLogbook = (payload as Logbook[]).filter((logbook) =>
-            proposalIds.includes(logbook?.name),
+          const filteredLogbook = (payload as Logbook[]).filter(
+            (logbook) => proposalIds.includes(logbook?.name) || isAdmin,
           );
           return filteredLogbook;
         }
-        return proposalIds.includes((payload as Logbook)?.name)
+
+        return proposalIds.includes((payload as Logbook)?.name) || isAdmin
           ? (payload as Logbook)
           : null;
       }),


### PR DESCRIPTION
## Description

Currently, admin can view logbooks in the proposal only when the proposal Id is included in the access group like other normal user.

## Motivation

As an admin I want to be able to access all logbooks in any proposals.

## Fixes:

https://jira.esss.lu.se/browse/SWAP-3195



## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
