### PR TITLE
Instrument endpoint and tests

### DIFF
--- a/src/casl/action.enum.ts
+++ b/src/casl/action.enum.ts
@@ -15,7 +15,12 @@ export enum Action {
   UserCreateAny = "user_create_any",
   UserUpdateOwn = "user_update_own",
   UserUpdateAny = "user_update_any",
-  UserDeleteOwn = "user_update_own",
-  UserDeleteAny = "user_update_any",
+  UserDeleteOwn = "user_delete_own",
+  UserDeleteAny = "user_delete_any",
   UserCreateJwt = "user_create_jwt",
+  // Instrument actions
+  InstrumentRead = "instrument_read",
+  InstrumentUpdate = "instrument_update",
+  InstrumentCreate = "instrument_create",
+  InstrumentDelete = "instrument_delete",
 }

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -85,6 +85,12 @@ export class CaslAbilityFactory {
       can(Action.UserUpdateAny, User);
       can(Action.UserDeleteAny, User);
       can(Action.UserCreateJwt, User);
+      // -------------------------------------
+      // instrument
+      can(Action.InstrumentRead, Instrument);
+      can(Action.InstrumentCreate, Instrument);
+      can(Action.InstrumentUpdate, Instrument);
+      cannot(Action.InstrumentDelete, Instrument);
     } else {
       //
       // non admin users
@@ -112,6 +118,12 @@ export class CaslAbilityFactory {
       cannot(Action.UserUpdateAny, User);
       cannot(Action.UserDeleteAny, User);
       cannot(Action.UserCreateJwt, User);
+      // -------------------------------------
+      // instrument
+      can(Action.InstrumentRead, Instrument);
+      cannot(Action.InstrumentCreate, Instrument);
+      cannot(Action.InstrumentUpdate, Instrument);
+      cannot(Action.InstrumentDelete, Instrument);
     }
     can(Action.Read, DatasetClass, { isPublished: true });
     can(Action.Read, DatasetClass, {
@@ -136,10 +148,10 @@ export class CaslAbilityFactory {
     );
 
     // Instrument permissions
-    can(Action.Read, Instrument);
-    if (user.currentGroups.some((g) => adminGroups.includes(g))) {
-      can(Action.Manage, Instrument);
-    }
+    //can(Action.Read, Instrument);
+    //if (user.currentGroups.some((g) => adminGroups.includes(g))) {
+    //  can(Action.Manage, Instrument);
+    //}
 
     can(Action.Manage, Job);
 
@@ -186,10 +198,12 @@ export class CaslAbilityFactory {
       cannot(Action.Update, Datablock);
       can(Action.Delete, Datablock);
       can(Action.Delete, PublishedData);
-      // instruments
-      cannot(Action.Create, Instrument);
-      cannot(Action.Update, Instrument);
-      can(Action.Delete, Instrument);
+      //--------------------------------
+      // instrument
+      cannot(Action.InstrumentRead, Instrument);
+      cannot(Action.InstrumentCreate, Instrument);
+      cannot(Action.InstrumentUpdate, Instrument);
+      can(Action.InstrumentDelete, Instrument);
     }
     //if (user.currentGroups.includes(Role.GlobalAccess)) {
     //  can(Action.Read, "all");

--- a/src/instruments/instruments.service.ts
+++ b/src/instruments/instruments.service.ts
@@ -21,10 +21,12 @@ export class InstrumentsService {
 
   async findAll(filter: IFilters<InstrumentDocument>): Promise<Instrument[]> {
     const whereFilter: FilterQuery<InstrumentDocument> = filter.where ?? {};
+    const fieldsProjection: FilterQuery<InstrumentDocument> =
+      filter.fields ?? {};
     const { limit, skip, sort } = parseLimitFilters(filter.limits);
 
     const instrumentPromise = this.instrumentModel
-      .find(whereFilter)
+      .find(whereFilter, fieldsProjection)
       .limit(limit)
       .skip(skip)
       .sort(sort);

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -40,10 +40,11 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: "The name of the instrument.",
+    description: "The name of the instrument. The name has to be unique.",
   })
   @Prop({
     type: String,
+    unique: true,
     required: true,
   })
   name: string;

--- a/test/Instrument.js
+++ b/test/Instrument.js
@@ -4,13 +4,19 @@
 const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
 
-let accessToken = null,
+let accessTokenIngestor = null,
   accessTokenArchiveManager = null,
-  instrumentId = null;
+  accessTokenUser1 = null,
+  instrumentId1 = null,
+  encodedInstrumentId1 = null,
+  instrumentId2 = null,
+  encodedInstrumentId2 = null,
+  instrumentId3 = null,
+  encodedInstrumentId3 = null;
 
 const newName = "ESS2.5";
 
-describe("Instrument: Instrument management", () => {
+describe("0900: Instrument: instrument management, creation, update, deletion and search", () => {
   beforeEach((done) => {
     utils.getToken(
       appUrl,
@@ -19,7 +25,7 @@ describe("Instrument: Instrument management", () => {
         password: "aman",
       },
       (tokenVal) => {
-        accessToken = tokenVal;
+        accessTokenIngestor = tokenVal;
         utils.getToken(
           appUrl,
           {
@@ -28,94 +34,312 @@ describe("Instrument: Instrument management", () => {
           },
           (tokenVal) => {
             accessTokenArchiveManager = tokenVal;
-            done();
+            utils.getToken(
+              appUrl,
+              {
+                username: "user1",
+                password: "a609316768619f154ef58db4d847b75e",
+              },
+              (tokenVal) => {
+                accessTokenUser1 = tokenVal;
+                done();
+              },
+            );
           },
         );
       },
     );
   });
 
-  it("adds new instrument", async () => {
+  it("0010: adds new instrument #1 as ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Instruments")
-      .send(TestData.InstrumentCorrect)
+      .send(TestData.InstrumentCorrect1)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessToken}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(201)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
           .property("name")
-          .and.be.equal(TestData.InstrumentCorrect.name);
+          .and.be.equal(TestData.InstrumentCorrect1.name);
         res.body.should.have.property("pid").and.be.string;
-        instrumentId = res.body["pid"];
+        instrumentId1 = res.body["pid"];
+        encodedInstrumentId1 = encodeURIComponent(instrumentId1);
       });
   });
 
-  it("should fetch this new instrument", async () => {
+  it("0020: adds new instrument #2 as ingestor", async () => {
     return request(appUrl)
-      .get("/api/v3/Instruments/" + instrumentId)
+      .post("/api/v3/Instruments")
+      .send(TestData.InstrumentCorrect2)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessToken}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(201)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect2.name);
+        res.body.should.have.property("pid").and.be.string;
+        instrumentId2 = res.body["pid"];
+        encodedInstrumentId2 = encodeURIComponent(instrumentId2);
+      });
+  });
+
+  it("0030: adds new instrument #3 as ingestor", async () => {
+    return request(appUrl)
+      .post("/api/v3/Instruments")
+      .send(TestData.InstrumentCorrect3)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(201)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect3.name);
+        res.body.should.have.property("pid").and.be.string;
+        instrumentId3 = res.body["pid"];
+        encodedInstrumentId3 = encodeURIComponent(instrumentId3);
+      });
+  });
+
+  it("0040: adds instrument #2 again as ingestor, which should fail", async () => {
+    return request(appUrl)
+      .post("/api/v3/Instruments")
+      .send(TestData.InstrumentCorrect2)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(400);
+  });
+
+  it("0050: adds invalid instrument as ingestor, which should fail", async () => {
+    return request(appUrl)
+      .post("/api/v3/Instruments")
+      .send(TestData.InstrumentWrong1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(400);
+  });
+
+  it("0060: adds instrument #2 as user1 (non admin), which should fail", async () => {
+    return request(appUrl)
+      .post("/api/v3/Instruments")
+      .send(TestData.InstrumentCorrect2)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(403);
+  });
+
+  it("0070: should fetch instrument #1 as ingestor", async () => {
+    return request(appUrl)
+      .get("/api/v3/Instruments/" + instrumentId1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
           .property("name")
-          .and.be.equal(TestData.InstrumentCorrect.name);
-        res.body.should.have.property("pid").and.be.equal(instrumentId);
+          .and.be.equal(TestData.InstrumentCorrect1.name);
+        res.body.should.have.property("pid").and.be.equal(instrumentId1);
       });
   });
 
-  it("should fetch all instruments", async () => {
+  it("0080: should fetch instrument #2 as ingestor", async () => {
+    return request(appUrl)
+      .get("/api/v3/Instruments/" + instrumentId2)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("name")
+          .and.be.equal(TestData.InstrumentCorrect2.name);
+        res.body.should.have.property("pid").and.be.equal(instrumentId2);
+      });
+  });
+
+  it("0090: should fetch all instruments as ingestor", async () => {
     return request(appUrl)
       .get("/api/v3/Instruments")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessToken}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.length(3);
+      });
+  });
+
+  it("0100: should fetch all instruments with main_user as ESS as ingestor", async () => {
+    const filter = {
+      where: {
+        "customMetadata.main_user": "ESS",
+      },
+    };
+
+    return request(appUrl)
+      .get("/api/v3/Instruments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .query({ filter: JSON.stringify(filter) })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.length(2);
+        res.body.forEach((v) => {
+          v.customMetadata.main_user.should.be.equal("ESS");
+        });
+      });
+  });
+
+  it("0110: should fetch one instruments as ingestor", async () => {
+    return request(appUrl)
+      .get("/api/v3/Instruments/findOne")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.pid.should.be.oneOf([ instrumentId1, instrumentId2, instrumentId3 ]);
+      });
+  });
+
+  it("0120: should fetch one instruments with main_user as ESS as admin", async () => {
+    const filter = {
+      where: {
+        "customMetadata.main_user": "ESS",
+      },
+    };
+
+    return request(appUrl)
+      .get("/api/v3/Instruments/findOne")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .query({ filter: JSON.stringify(filter) })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.pid.should.be.oneOf([ instrumentId1, instrumentId2 ]);
+        res.body.customMetadata.main_user.should.be.equal("ESS");
+      });
+  });
+
+  it("0130: should fetch all instruments which main user containing the word 'somebody' as ingestor", async () => {
+    const filter = {
+      where: {
+        "customMetadata.main_user": {like : "somebody"},
+      },
+    };
+
+    return request(appUrl)
+      .get("/api/v3/Instruments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .query({ filter: JSON.stringify(filter) })
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.an("array").to.have.length(1);
-        res.body[0].should.have
-          .property("name")
-          .and.be.equal(TestData.InstrumentCorrect.name);
-        res.body[0].should.have.property("pid").and.be.equal(instrumentId);
+        res.body[0].pid.should.be.equal(instrumentId3);
+        res.body[0].customMetadata.main_user.should.be.contain("somebody");
       });
   });
 
-  it("should update the instrument name", async () => {
+  it("0140: should fetch all instruments as user1", async () => {
     return request(appUrl)
-      .patch("/api/v3/Instruments/" + instrumentId)
+      .get("/api/v3/Instruments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.length(3);
+      });
+  });
+
+  it("0150: should update name for instrument #2 as ingestor", async () => {
+    return request(appUrl)
+      .patch("/api/v3/Instruments/" + instrumentId2)
       .send({ name: newName })
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessToken}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("name").and.be.equal(newName);
-        res.body.should.have.property("pid").and.be.equal(instrumentId);
+        res.body.should.have.property("pid").and.be.equal(instrumentId2);
       });
   });
 
-  it("should fetch this same instrument", async () => {
+  it("0160: should fetch same instrument by id as ingestor", async () => {
     return request(appUrl)
-      .get("/api/v3/Instruments/" + instrumentId)
+      .get("/api/v3/Instruments/" + instrumentId2)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessToken}` })
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
       .expect(200)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("name").and.be.equal(newName);
-        res.body.should.have.property("pid").and.be.equal(instrumentId);
+        res.body.should.have.property("pid").and.be.equal(instrumentId2);
       });
   });
 
-  it("should delete this instrument", async () => {
+  it("0170: should fetch same instrument by name", async () => {
+    const filter = {
+      where: {
+        name: newName
+      },
+    };
+
     return request(appUrl)
-      .delete("/api/v3/Instruments/" + instrumentId)
+      .get("/api/v3/Instruments/")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .query({ filter: JSON.stringify(filter) })
+      .expect(200)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.length(1);
+        res.body.forEach((v) => {
+          v.should.have.property("name").and.be.equal(newName);
+          v.should.have.property("pid").and.be.equal(instrumentId2);
+        });
+      });
+  });
+
+  it("0180: should delete instrument #1 as admin, which should fail", async () => {
+    return request(appUrl)
+      .delete("/api/v3/Instruments/" + instrumentId1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(403);
+  });
+
+  it("0190: should delete instrument #1 as user allowed to delete", async () => {
+    return request(appUrl)
+      .delete("/api/v3/Instruments/" + instrumentId1)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
-      .expect(200)
-      .expect("Content-Type", /json/);
+      .expect(200);
+  });
+
+  it("0200: should delete instrument #2 as user allowed to delete", async () => {
+    return request(appUrl)
+      .delete("/api/v3/Instruments/" + instrumentId2)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(200);
+  });
+
+  it("0210: should delete instrument #3 as user allowed to delete", async () => {
+    return request(appUrl)
+      .delete("/api/v3/Instruments/" + instrumentId3)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(200);
   });
 });

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -712,13 +712,34 @@ const TestData = {
     status: "pending_registration",
   },
 
-  InstrumentCorrect: {
+  InstrumentCorrect1: {
     name: "ESS1",
     customMetadata: {
-      institute: "An immaginary intitution",
-      department: "An immaginary department",
+      institute: "An immaginary intitution #1",
+      department: "An immaginary department #1",
+      main_user: "ESS",
     },
   },
+  InstrumentCorrect2: {
+    name: "ESS2",
+    customMetadata: {
+      institute: "An immaginary intitution #2",
+      department: "An immaginary department #2",
+      main_user: "ESS",
+    },
+  },
+  InstrumentCorrect3: {
+    name: "ESS3",
+    customMetadata: {
+      institute: "An immaginary intitution #3",
+      department: "An immaginary department #3",
+      main_user: "somebody else",
+    },
+  },
+  InstrumentWrong1: {
+    instrumentName: "ESS-wrong",
+  },
+
 };
 
 module.exports = { TestData };


### PR DESCRIPTION
## Description
This PR fixes the filter issues on Instrument endpoint and extends the API tests.

## Motivation
Instrument endpoint was returning the incorrect instrument when filtering was applied or when the instrument id was being passed. Same for the patch one.

## Fixes:
* filtering in main endpoint, path and findone

## Changes:
* casl ability factory
* instrument controller, service, and schema
* data for test
* instrument tests

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [X] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
