### PR TITLE
Swap 3226 2: add unique name to instrument

### DIFF
--- a/src/instruments/dto/create-instrument.dto.ts
+++ b/src/instruments/dto/create-instrument.dto.ts
@@ -5,6 +5,14 @@ import { IsObject, IsOptional, IsString } from "class-validator";
 export class CreateInstrumentDto {
   @ApiProperty({
     type: String,
+    uniqueItems: true,
+    required: true,
+  })
+  @IsString()
+  readonly uniqueName: string;
+
+  @ApiProperty({
+    type: String,
     required: true,
   })
   @IsString()

--- a/src/instruments/instruments.controller.ts
+++ b/src/instruments/instruments.controller.ts
@@ -59,7 +59,7 @@ export class InstrumentsController {
       return instrument;
     } catch (e) {
       throw new HttpException(
-        "Instrument with the same name already exists",
+        "Instrument with the same unique name already exists",
         HttpStatus.BAD_REQUEST,
       );
     }
@@ -134,7 +134,15 @@ export class InstrumentsController {
     @Param("id") id: string,
     @Body() updateInstrumentDto: UpdateInstrumentDto,
   ): Promise<Instrument | null> {
-    return this.instrumentsService.update({ _id: id }, updateInstrumentDto);
+    try {
+      const instrument = await this.instrumentsService.update({ _id: id }, updateInstrumentDto);
+      return instrument;
+    } catch (e) {
+      throw new HttpException(
+        "Instrument with the same unique name already exists",
+        HttpStatus.BAD_REQUEST,
+      );
+    }
   }
 
   @UseGuards(PoliciesGuard)

--- a/src/instruments/instruments.controller.ts
+++ b/src/instruments/instruments.controller.ts
@@ -135,7 +135,10 @@ export class InstrumentsController {
     @Body() updateInstrumentDto: UpdateInstrumentDto,
   ): Promise<Instrument | null> {
     try {
-      const instrument = await this.instrumentsService.update({ _id: id }, updateInstrumentDto);
+      const instrument = await this.instrumentsService.update(
+        { _id: id },
+        updateInstrumentDto,
+      );
       return instrument;
     } catch (e) {
       throw new HttpException(

--- a/src/instruments/instruments.service.spec.ts
+++ b/src/instruments/instruments.service.spec.ts
@@ -7,6 +7,7 @@ import { Instrument } from "./schemas/instrument.schema";
 const mockInstrument: Instrument = {
   _id: "testPid",
   pid: "testPid",
+  uniqueName: "Test",
   name: "Test",
   customMetadata: {},
 };

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -40,7 +40,8 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: "The unique name of the instrument. This name has to be unique within the scicat instance.",
+    description: 
+      "The unique name of the instrument. This name has to be unique within the scicat instance.",
   })
   @Prop({
     type: String,
@@ -52,7 +53,8 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: "The common name of the instrument. This name can be non unique as it is the name that users use to commnoly refer to this instrument.",
+    description: 
+      "The common name of the instrument. This name can be non unique as it is the name that users use to commnoly refer to this instrument.",
   })
   @Prop({
     type: String,

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -40,11 +40,22 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: "The name of the instrument. The name has to be unique.",
+    description: "The unique name of the instrument. This name has to be unique within the scicat instance.",
   })
   @Prop({
     type: String,
     unique: true,
+    required: true,
+  })
+  uniqueName: string;
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "The common name of the instrument. This name can be non unique as it is the name that users use to commnoly refer to this instrument.",
+  })
+  @Prop({
+    type: String,
     required: true,
   })
   name: string;

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -40,7 +40,7 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: 
+    description:
       "The unique name of the instrument. This name has to be unique within the scicat instance.",
   })
   @Prop({
@@ -53,7 +53,7 @@ export class Instrument {
   @ApiProperty({
     type: String,
     required: true,
-    description: 
+    description:
       "The common name of the instrument. This name can be non unique as it is the name that users use to commnoly refer to this instrument.",
   })
   @Prop({

--- a/test/Instrument.js
+++ b/test/Instrument.js
@@ -14,7 +14,7 @@ let accessTokenIngestor = null,
   instrumentId3 = null,
   encodedInstrumentId3 = null;
 
-const newName = "ESS2.5";
+const newName = "ESS3-1";
 
 describe("0900: Instrument: instrument management, creation, update, deletion and search", () => {
   beforeEach((done) => {
@@ -105,7 +105,7 @@ describe("0900: Instrument: instrument management, creation, update, deletion an
       });
   });
 
-  it("0040: adds instrument #2 again as ingestor, which should fail", async () => {
+  it("0040: adds instrument #2 again as ingestor, which should fail because uniqueName is not unique", async () => {
     return request(appUrl)
       .post("/api/v3/Instruments")
       .send(TestData.InstrumentCorrect2)
@@ -114,7 +114,7 @@ describe("0900: Instrument: instrument management, creation, update, deletion an
       .expect(400);
   });
 
-  it("0050: adds invalid instrument as ingestor, which should fail", async () => {
+  it("0050: adds invalid instrument as ingestor, which should fail because it is missing the uniqeName", async () => {
     return request(appUrl)
       .post("/api/v3/Instruments")
       .send(TestData.InstrumentWrong1)
@@ -273,6 +273,15 @@ describe("0900: Instrument: instrument management, creation, update, deletion an
         res.body.should.have.property("name").and.be.equal(newName);
         res.body.should.have.property("pid").and.be.equal(instrumentId2);
       });
+  });
+
+  it("0155: update unique name for instrument #2 as ingestor to ESS3-1, which should fail becuase is not unique ", async () => {
+    return request(appUrl)
+      .patch("/api/v3/Instruments/" + instrumentId2)
+      .send({ uniqueName: newName })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenIngestor}` })
+      .expect(400);
   });
 
   it("0160: should fetch same instrument by id as ingestor", async () => {

--- a/test/InstrumentsFilter.js
+++ b/test/InstrumentsFilter.js
@@ -22,23 +22,24 @@ let instrumentPid1 = null,
 
 
 const InstrumentCorrect1 = {
-  ...TestData.InstrumentCorrect,
+  ...TestData.InstrumentCorrect1,
   name: "ESS instrument one",
 };
   
 const InstrumentCorrect2 = {
-  ...TestData.InstrumentCorrect,
+  ...TestData.InstrumentCorrect2,
   name: "ESS instrument two",
 };
 
 const InstrumentCorrect3 = {
-  ...TestData.InstrumentCorrect,
+  ...TestData.InstrumentCorrect3,
   name: "Another instrument at ESS, number three",
 };
   
 const InstrumentCorrect4 = {
-  ...TestData.InstrumentCorrect,
-  name: "Yet another instrument at ESS, number four",
+  ...TestData.InstrumentCorrect3,
+  uniqueName: "ESS3-2",
+  name: "Yet another instrument at ESS, a new number three different from the other",
 };
 
 describe("InstrumentFilter: Test retrieving instruments using filtering capabilities", () => {

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -713,6 +713,7 @@ const TestData = {
   },
 
   InstrumentCorrect1: {
+    uniqueName: "ESS1-1",
     name: "ESS1",
     customMetadata: {
       institute: "An immaginary intitution #1",
@@ -721,6 +722,7 @@ const TestData = {
     },
   },
   InstrumentCorrect2: {
+    uniqueName: "ESS2-1",
     name: "ESS2",
     customMetadata: {
       institute: "An immaginary intitution #2",
@@ -729,7 +731,8 @@ const TestData = {
     },
   },
   InstrumentCorrect3: {
-    name: "ESS3",
+    uniqueName: "ESS3-1",
+    name: "ESS1",
     customMetadata: {
       institute: "An immaginary intitution #3",
       department: "An immaginary department #3",
@@ -737,7 +740,7 @@ const TestData = {
     },
   },
   InstrumentWrong1: {
-    instrumentName: "ESS-wrong",
+    name: "ESS-wrong",
   },
 
 };


### PR DESCRIPTION
## Description
This PR add the field unique name to the instrument, so an instrument can be uniquely identified by its id and unique name. The field name is allowed to be non unique

## Motivation
Following a discussion at the collaborator meeting, it has been noted that facilities can benefits from a unique instrument name and more user friendly name
 
## Fixes:
* added uniqueName to instrument model
* updated tests

## Changes:
* instrument model, controller, service and tests

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
