### PR TITLE
added migration script to add uniqueName for instruments

### DIFF
--- a/migrations/20230424064803-add-instrument-unique-name.js
+++ b/migrations/20230424064803-add-instrument-unique-name.js
@@ -1,0 +1,27 @@
+import {v4 as uuidv4} from 'uuid';
+const ObjectId = require('bson').ObjectId;
+
+module.exports = {
+  async up(db, client) {
+    await db.collection("Instruments")
+      .find({})
+      .forEach(instrument => {
+        const uniqueName = instrument.name + " " + uuidv4().split("-")[4];
+        console.log(`Updating Instrument ${instrument.name} (Id: ${instrument.id}) with unique name =>${uniqueName}<=`);
+        db.collection("Instruments").updateOne(
+          {
+            _id: ObjectId(instrument._id),
+          },
+          {
+            $set: {
+              uniqueName: uniqueName,
+            }
+          }
+        )
+      });
+  },
+
+  async down(db, client) {
+    // no path backward
+  }
+};

--- a/migrations/20230424064803-add-instrument-unique-name.js
+++ b/migrations/20230424064803-add-instrument-unique-name.js
@@ -1,16 +1,17 @@
-import {v4 as uuidv4} from 'uuid';
+//import {v4 as uuidv4} from 'uuid';
+const uuidv4 = require('uuid').v4;
 const ObjectId = require('bson').ObjectId;
 
 module.exports = {
   async up(db, client) {
-    await db.collection("Instruments")
+    await db.collection("Instrument")
       .find({})
       .forEach(instrument => {
         const uniqueName = instrument.name + " " + uuidv4().split("-")[4];
         console.log(`Updating Instrument ${instrument.name} (Id: ${instrument.id}) with unique name =>${uniqueName}<=`);
-        db.collection("Instruments").updateOne(
+        db.collection("Instrument").updateOne(
           {
-            _id: ObjectId(instrument._id),
+            _id: instrument._id,
           },
           {
             $set: {

--- a/migrations/20230424064803-add-instrument-unique-name.js
+++ b/migrations/20230424064803-add-instrument-unique-name.js
@@ -1,6 +1,4 @@
-//import {v4 as uuidv4} from 'uuid';
 const uuidv4 = require('uuid').v4;
-const ObjectId = require('bson').ObjectId;
 
 module.exports = {
   async up(db, client) {


### PR DESCRIPTION
## Description
This PR add the mongo migrate script to add the instrument unique name.

## Motivation
In this new backend, we added a unique name for instrument which did not exists in the old backend. We need to automatically create unique names.

## Changes:
* added mongo migrate script

## Tests included/Docs Updated?
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
