### PR TITLE
add new operator to 20230309145701-update-user-indentity-entries.js

### DIFF
--- a/migrations/20230309145701-update-user-indentity-entries.js
+++ b/migrations/20230309145701-update-user-indentity-entries.js
@@ -14,7 +14,7 @@ module.exports = {
         console.log(`Updating User Identity ${identity.externalId} (${identity.userId}) with authStrategy: ${authStrategy}`);
         db.collection("UserIdentity").updateOne(
           {
-            _id: ObjectId(identity._id),
+            _id: new ObjectId(identity._id),
           },
           {
             $set: {


### PR DESCRIPTION
## Description
We had some Errors an this will fixed it. 

## Fixes:

*  Error: Could not migrate up 20230309145701-update-user-indentity-entries.js: Class constructor ObjectId cannot be invoked without 'new'

## Changes:

* add new operator

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated? not needed
- [ ] New packages used/requires npm install?  no
- [ ] Toggle added for new features?
