### PR TITLE
feat: enable dataset access for shared emails

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -429,6 +429,10 @@ export const createFullqueryFilter = <T>(
           accessGroups: searchExpression<T>(model, "accessGroups", fields[key]),
         },
       ];
+    } else if (key === "sharedWith") {
+      filterQuery["$or"]?.push({
+        sharedWith: searchExpression<T>(model, "sharedWith", fields[key]),
+      });
     } else {
       filterQuery[key as keyof FilterQuery<T>] = searchExpression<T>(
         model,

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -506,6 +506,7 @@ export class DatasetsController {
       if (!canViewAll && !fields.isPublished) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
+        fields.sharedWith = user.email;
       }
     }
 

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -16,5 +16,6 @@ export interface IDatasetFields {
   metadataKey?: string;
   _id?: string;
   userGroups?: string[];
+  sharedWith?: string;
   [key: string]: unknown;
 }

--- a/src/users/user-identities.controller.ts
+++ b/src/users/user-identities.controller.ts
@@ -58,8 +58,6 @@ export class UserIdentitiesController {
       authenticatedUser,
     );
 
-    //console.log(ability.can(Action.UserReadAny, User));
-    //console.log(ability.can(Action.UserReadOwn, User));
     if (
       !ability.can(Action.UserReadAny, User) &&
       ability.can(Action.UserReadOwn, User)


### PR DESCRIPTION
## Description

This PR aims to make shared datasets available for users. Also prevents all users for being able to update datasets and leave that ability only for owners.

## Motivation

Anyone that has access to dataset could update or share it and people in sharedWith field were not able to access the datasets.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-3274

## Changes:

* changes made

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
