### PR TITLE
Fixed data properties for orig datablocks file

### DIFF
--- a/src/common/schemas/datafile.schema.ts
+++ b/src/common/schemas/datafile.schema.ts
@@ -10,9 +10,9 @@ export class DataFile {
     required: true,
     description: "Relative path of the file within the dataset folder.",
   })
-  @Prop({ 
-    type: String, 
-    required: true 
+  @Prop({
+    type: String,
+    required: true,
   })
   path: string;
 
@@ -29,13 +29,13 @@ export class DataFile {
 
   @ApiProperty({
     type: Date,
-    required: true
+    required: true,
     description:
       "Time of file creation on disk, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
   @Prop({
     type: Date,
-    required: true
+    required: true,
   })
   time: Date;
 
@@ -47,7 +47,7 @@ export class DataFile {
   })
   @Prop({
     type: String,
-    required: false
+    required: false,
   })
   chk: string;
 
@@ -58,7 +58,7 @@ export class DataFile {
   })
   @Prop({
     type: String,
-    required: false
+    required: false,
   })
   uid: string;
 
@@ -69,18 +69,18 @@ export class DataFile {
   })
   @Prop({
     type: String,
-    required: false
+    required: false,
   })
   gid: string;
 
-  @ApiProperty({ 
-    type: String, 
+  @ApiProperty({
+    type: String,
     required: false,
-    description: "Posix permission bits." 
+    description: "Posix permission bits.",
   })
   @Prop({
-    type: String, 
-    required: false
+    type: String,
+    required: false,
   })
   perm: string;
 }

--- a/src/common/schemas/datafile.schema.ts
+++ b/src/common/schemas/datafile.schema.ts
@@ -7,50 +7,81 @@ export type DataFileDocument = DataFile & Document;
 export class DataFile {
   @ApiProperty({
     type: String,
+    required: true,
     description: "Relative path of the file within the dataset folder.",
   })
-  @Prop({ type: String, required: true })
+  @Prop({ 
+    type: String, 
+    required: true 
+  })
   path: string;
 
   @ApiProperty({
     type: Number,
+    required: true,
     description: "Uncompressed file size in bytes.",
   })
-  @Prop()
+  @Prop({
+    type: Number,
+    required: true,
+  })
   size: number;
 
   @ApiProperty({
     type: Date,
+    required: true
     description:
       "Time of file creation on disk, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
-  @Prop()
+  @Prop({
+    type: Date,
+    required: true
+  })
   time: Date;
 
   @ApiProperty({
     type: String,
+    required: false,
     description:
       "Checksum for the file, e.g. its sha-2 hashstring. The hash algorithm should be encoded in the (Orig)Datablock.",
   })
-  @Prop()
+  @Prop({
+    type: String,
+    required: false
+  })
   chk: string;
 
   @ApiProperty({
     type: String,
+    required: false,
     description: "User ID name as seen on filesystem.",
   })
-  @Prop()
+  @Prop({
+    type: String,
+    required: false
+  })
   uid: string;
 
   @ApiProperty({
     type: String,
+    required: false,
     description: "Group ID name as seen on filesystem.",
   })
-  @Prop()
+  @Prop({
+    type: String,
+    required: false
+  })
   gid: string;
 
-  @ApiProperty({ type: String, description: "Posix permission bits." })
-  @Prop()
+  @ApiProperty({ 
+    type: String, 
+    required: false,
+    description: "Posix permission bits." 
+  })
+  @Prop({
+    type: String, 
+    required: false
+  })
   perm: string;
 }
 


### PR DESCRIPTION
## Description
The properties for data file were not correctly set and all of them were marked as required.
This PR explicitly define if a field is required or not


## Motivation
During the development of Scitacean, we discovered that all the properties of DataFiles are required, which is not true.

## Fixes:
* Define explicitly the required property in the DataFile schema

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
