### PR TITLE
fixed orig datablock and datafile dto

### DIFF
--- a/src/common/dto/datafile.dto.ts
+++ b/src/common/dto/datafile.dto.ts
@@ -1,29 +1,65 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { IsDateString, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class DataFileDto {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "Relative path of the file within the dataset folder.",
+  })
   @IsString()
   readonly path: string;
 
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: "Uncompressed file size in bytes.",
+  })
   @IsNumber()
-  @IsOptional()
   readonly size: number;
 
+  @ApiProperty({
+    type: Date,
+    required: true,
+    description:
+      "Time of file creation on disk, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+  })
   @IsDateString()
-  @IsOptional()
   readonly time: Date;
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Checksum for the file, e.g. its sha-2 hashstring. The hash algorithm should be encoded in the (Orig)Datablock.",
+  })
   @IsString()
   @IsOptional()
   readonly chk: string;
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "User ID name as seen on filesystem.",
+  })
   @IsString()
   @IsOptional()
   readonly uid: string;
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Group ID name as seen on filesystem.",
+  })
   @IsString()
   @IsOptional()
   readonly gid: string;
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Posix permission bits.",
+  })
   @IsString()
   @IsOptional()
   readonly perm: string;

--- a/src/origdatablocks/dto/create-origdatablock.dto.ts
+++ b/src/origdatablocks/dto/create-origdatablock.dto.ts
@@ -11,19 +11,44 @@ import {
 import { DataFileDto } from "src/common/dto/datafile.dto";
 import { OwnableDto } from "src/common/dto/ownable.dto";
 import { DataFile } from "../../common/schemas/datafile.schema";
+import { ApiProperty, getSchemaPath } from "@nestjs/swagger";
 
 export class CreateOrigDatablockDto extends OwnableDto {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      "Persistent identifier of the dataset this orig datablock belongs to.",
+  })
   @IsString()
   readonly datasetId: string;
 
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description: "Total size of the files in this orig datablock",
+  })
   @IsInt()
   readonly size: number;
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Name of the hasing algorithm used to compute the hash for each file.",
+  })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
   readonly chkAlg: string;
 
+  @ApiProperty({
+    type: "array",
+    items: { $ref: getSchemaPath(DataFile) },
+    required: true,
+    description:
+      "Name of the hasing algorithm used to compute the hash for each file.",
+  })
   @IsArray()
   @ArrayNotEmpty()
   @ValidateNested({ each: true })


### PR DESCRIPTION
## Description
This PR updates the model and dto for origdatablock and datafiles, so the swagger interface matches the requirements.

## Motivation
While working on Scitacean, we realized that the swagger interface was not matching the model requirements.

## Fixes:
* datafile.dto.ts
* create-origdatablock.dto.ts

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
