### PR TITLE
feat: add Å to SI accepted units

### DIFF
--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,49 +1,47 @@
 // Currently only covers converToSI
-import { convertToSI } from './utils';
-import { createUnit, Unit } from 'mathjs';
+import { convertToSI } from "./utils";
 
-
-describe('convertToSI', () => {
-  it('should convert a known unit to SI successfully', () => {
-    const result = convertToSI(1, 'cm');
+describe("convertToSI", () => {
+  it("should convert a known unit to SI successfully", () => {
+    const result = convertToSI(1, "cm");
     expect(result.valueSI).toBeCloseTo(0.01);
-    expect(result.unitSI).toEqual('m');
+    expect(result.unitSI).toEqual("m");
   });
 
-  it('should convert angstrom to SI successfully', () => {
-    const result = convertToSI(1, 'Å');
+  it("should convert angstrom to SI successfully", () => {
+    const result = convertToSI(1, "Å");
     expect(result.valueSI).toBeCloseTo(1e-10);
-    expect(result.unitSI).toEqual('m');
+    expect(result.unitSI).toEqual("m");
   });
 
-  it('should handle different versions of Å in unicode', () => {
-    const inputUnit = '\u212B'; // Old unicode representation of "Å", is not boolean equal to the one we added.
+  it("should handle different versions of Å in unicode", () => {
+    const inputUnit = "\u212B"; // Old unicode representation of "Å", is not boolean equal to the one we added.
     const result = convertToSI(1, inputUnit);
     expect(result.valueSI).toBeCloseTo(1e-10);
-    expect(result.unitSI).toEqual('m');
+    expect(result.unitSI).toEqual("m");
   });
 
-  it('should return the input value and unit if conversion fails', () => {
-    const result = convertToSI(1, 'invalidUnit');
+  it("should return the input value and unit if conversion fails", () => {
+    const result = convertToSI(1, "invalidUnit");
     expect(result.valueSI).toEqual(1);
-    expect(result.unitSI).toEqual('invalidUnit');
+    expect(result.unitSI).toEqual("invalidUnit");
   });
 
-  it('should convert SI units correctly', () => {
-    const result = convertToSI(1000, 'g');
+  it("should convert SI units correctly", () => {
+    const result = convertToSI(1000, "g");
     expect(result.valueSI).toBeCloseTo(1);
-    expect(result.unitSI).toEqual('kg');
+    expect(result.unitSI).toEqual("kg");
   });
 
-  it('should handle already normalized units', () => {
-    const result = convertToSI(1, 'm');
+  it("should handle already normalized units", () => {
+    const result = convertToSI(1, "m");
     expect(result.valueSI).toEqual(1);
-    expect(result.unitSI).toEqual('m');
+    expect(result.unitSI).toEqual("m");
   });
 
-  it('should handle negative values properly', () => {
-    const result = convertToSI(-5, 'cm');
+  it("should handle negative values properly", () => {
+    const result = convertToSI(-5, "cm");
     expect(result.valueSI).toBeCloseTo(-0.05);
-    expect(result.unitSI).toEqual('m');
+    expect(result.unitSI).toEqual("m");
   });
 });

--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,0 +1,49 @@
+// Currently only covers converToSI
+import { convertToSI } from './utils';
+import { createUnit, Unit } from 'mathjs';
+
+
+describe('convertToSI', () => {
+  it('should convert a known unit to SI successfully', () => {
+    const result = convertToSI(1, 'cm');
+    expect(result.valueSI).toBeCloseTo(0.01);
+    expect(result.unitSI).toEqual('m');
+  });
+
+  it('should convert angstrom to SI successfully', () => {
+    const result = convertToSI(1, 'Å');
+    expect(result.valueSI).toBeCloseTo(1e-10);
+    expect(result.unitSI).toEqual('m');
+  });
+
+  it('should handle different versions of Å in unicode', () => {
+    const inputUnit = '\u212B'; // Old unicode representation of "Å", is not boolean equal to the one we added.
+    const result = convertToSI(1, inputUnit);
+    expect(result.valueSI).toBeCloseTo(1e-10);
+    expect(result.unitSI).toEqual('m');
+  });
+
+  it('should return the input value and unit if conversion fails', () => {
+    const result = convertToSI(1, 'invalidUnit');
+    expect(result.valueSI).toEqual(1);
+    expect(result.unitSI).toEqual('invalidUnit');
+  });
+
+  it('should convert SI units correctly', () => {
+    const result = convertToSI(1000, 'g');
+    expect(result.valueSI).toBeCloseTo(1);
+    expect(result.unitSI).toEqual('kg');
+  });
+
+  it('should handle already normalized units', () => {
+    const result = convertToSI(1, 'm');
+    expect(result.valueSI).toEqual(1);
+    expect(result.unitSI).toEqual('m');
+  });
+
+  it('should handle negative values properly', () => {
+    const result = convertToSI(-5, 'cm');
+    expect(result.valueSI).toBeCloseTo(-0.05);
+    expect(result.unitSI).toEqual('m');
+  });
+});

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -25,8 +25,7 @@ export const convertToSI = (
   inputUnit: string,
 ): { valueSI: number; unitSI: string } => {
   try {
-    // catch and normalize the different versions of Å in unicode
-    const normalizedUnit = inputUnit.normalize('NFC');
+    const normalizedUnit = inputUnit.normalize('NFC'); // catch and normalize the different versions of Å in unicode
     // Workaround related to a bug reported at https://github.com/josdejong/mathjs/issues/3097 and https://github.com/josdejong/mathjs/issues/2499
     const quantity = unit(inputValue, normalizedUnit)
       .to(unit(normalizedUnit).toSI().toJSON().unit)

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -14,18 +14,18 @@ import {
 import { ScientificRelation } from "./scientific-relation.enum";
 
 // add Å to mathjs accepted units as equivalent to angstrom
-const isAlphaOriginal = Unit.isValidAlpha
+const isAlphaOriginal = Unit.isValidAlpha;
 Unit.isValidAlpha = function (c) {
-  return isAlphaOriginal(c) ||  c == 'Å'
-}
-createUnit('Å', '1 angstrom')
+  return isAlphaOriginal(c) || c == "Å";
+};
+createUnit("Å", "1 angstrom");
 
 export const convertToSI = (
   inputValue: number,
   inputUnit: string,
 ): { valueSI: number; unitSI: string } => {
   try {
-    const normalizedUnit = inputUnit.normalize('NFC'); // catch and normalize the different versions of Å in unicode
+    const normalizedUnit = inputUnit.normalize("NFC"); // catch and normalize the different versions of Å in unicode
     // Workaround related to a bug reported at https://github.com/josdejong/mathjs/issues/3097 and https://github.com/josdejong/mathjs/issues/2499
     const quantity = unit(inputValue, normalizedUnit)
       .to(unit(normalizedUnit).toSI().toJSON().unit)


### PR DESCRIPTION
## Description

Added Å as accepted mathjs unit, equivalent to angstrom

## Motivation

Required for the correct interpretation of certain metadata, can be easily extended for other special character units.

## Fixes:
Please provide a list of the fixes implemented by this PR

## Changes:

* Changed /src/common/utils.ts to allow for new unit.
* added testing for convertToSI

## Tests included

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


