### PR TITLE
feat: added run number field to dataset and relative tests

### DIFF
--- a/src/datasets/dto/update-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-dataset-obsolete.dto.ts
@@ -297,6 +297,16 @@ export class UpdateDatasetObsoleteDto extends OwnableDto {
   @IsOptional()
   @IsString()
   readonly proposalId?: string;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Run number assigned by the system to the data acquisition for the current dataset.",
+  })
+  @IsOptional()
+  @IsString()
+  readonly runNumber?: string;
 }
 
 export class PartialUpdateDatasetObsoleteDto extends PartialType(

--- a/src/datasets/dto/update-raw-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-raw-dataset-obsolete.dto.ts
@@ -52,15 +52,6 @@ export class UpdateRawDatasetObsoleteDto extends UpdateDatasetObsoleteDto {
   @IsString()
   readonly dataFormat?: string;
 
-  // @ApiProperty({
-  //   type: String,
-  //   required: false,
-  //   description: "The ID of the proposal to which the dataset belongs.",
-  // })
-  // @IsOptional()
-  // @IsString()
-  // readonly proposalId?: string;
-
   @ApiProperty({
     type: String,
     required: false,

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -324,38 +324,6 @@ export class DatasetClass extends OwnableClass {
   })
   sharedWith?: string[];
 
-  // @ApiProperty({
-  //   type: "array",
-  //   items: { $ref: getSchemaPath(Attachment) },
-  //   required: false,
-  //   description:
-  //     "Small, less than 16 MB attachments, envisaged for png/jpeg previews.",
-  // })
-  // @Prop({ type: [AttachmentSchema], default: [] })
-  // attachments?: Attachment[];
-
-  // @ApiProperty({
-  //   isArray: true,
-  //   type: OrigDatablock,
-  //   items: { $ref: getSchemaPath(OrigDatablock) },
-  //   required: false,
-  //   description:
-  //     "Containers that list all files and their attributes which make up a dataset. Usually filled at the time the dataset's metadata is created in the data catalog. Can be used by subsequent archiving processes to create the archived datasets.",
-  // })
-  // @Prop({ type: [OrigDatablockSchema], default: [] })
-  // origdatablocks: OrigDatablock[];
-
-  // @ApiProperty({
-  //   isArray: true,
-  //   type: Datablock,
-  //   items: { $ref: getSchemaPath(Datablock) },
-  //   required: false,
-  //   description:
-  //     "When archiving a dataset, all files contained in the dataset are listed here together with their checksum information. Several datablocks can be created if the file listing is too long for a single datablock. This partitioning decision is done by the archiving system to allow for chunks of datablocks with manageable sizes. E.g a datasets consisting of 10 TB of data could be split into 10 datablocks of about 1 TB each. The upper limit set by the data catalog system itself is given by the fact that documents must be smaller than 16 MB, which typically allows for datasets of about 100000 files.",
-  // })
-  // @Prop({ type: [DatablockSchema], default: [] })
-  // datablocks: Datablock[];
-
   @ApiProperty({
     type: Object,
     required: false,
@@ -388,9 +356,6 @@ export class DatasetClass extends OwnableClass {
   })
   dataQualityMetrics?: number;
 
-  /*
-   * fields related to Raw Datasets
-   */
   @ApiProperty({
     type: String,
     required: false,
@@ -437,6 +402,15 @@ export class DatasetClass extends OwnableClass {
   dataFormat?: string;
 
   @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Run number assigned by the system to the data acquisition for the current dataset.",
+  })
+  @Prop({ type: String, required: false })
+  runNumber?: string;
+
+  @ApiProperty({
     type: [String],
     required: false,
     description:
@@ -462,18 +436,6 @@ export class DatasetClass extends OwnableClass {
   })
   @Prop({ type: [String], ref: "Instrument", required: false })
   instrumentIds?: string[];
-
-  /*
-   * Derived Dataset
-   */
-  // @ApiProperty({
-  //   type: String,
-  //   required: false,
-  //   description:
-  //     "First name and last name of the person or people pursuing the data analysis. The string may contain a list of names, which should then be separated by semicolons.",
-  // })
-  // @Prop({ type: String, required: false, index: true })
-  // investigator?: string;
 
   @ApiProperty({
     type: [String],

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -96,6 +96,10 @@ describe("1900: RawDataset: Raw Datasets", () => {
         res.body.should.have.property("instrumentId").and.be.string;
         res.body.should.have.property("proposalId").and.be.string;
         res.body.should.have.property("sampleId").and.be.string;
+        res.body.should.have.property("runNumber").and.be.string;
+        res.body.should.have
+          .property("runNumber")
+          .and.be.equal(TestData.RawCorrect.runNumber);
         pid = encodeURIComponent(res.body["pid"]);
       });
   });

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -232,6 +232,7 @@ const TestData = {
     ownerGroup: "p13388",
     accessGroups: [],
     proposalId: "10.540.16635/20110123",
+    runNumber: "123456",
     instrumentId: "1f016ec4-7a73-11ef-ae3e-439013069377",
     sampleId: "20c32b4e-7a73-11ef-9aec-5b9688aa3791i",
     type: "raw",
@@ -319,6 +320,7 @@ const TestData = {
     proposalId: process.env.PID_PREFIX
       ? process.env.PID_PREFIX
       : "" + faker.string.numeric(6),
+    runNumber: faker.string.numeric(6),
     type: "raw",
     keywords: ["sls", "protein"],
   },
@@ -454,6 +456,7 @@ const TestData = {
     accessGroups: [],
     type: "derived",
     proposalId: "10.540.16635/20110123",
+    runNumber: "654321",
     //instrumentId: "1f016ec4-7a73-11ef-ae3e-439013069377",
     //sampleId: "20c32b4e-7a73-11ef-9aec-5b9688aa3791i",
   },


### PR DESCRIPTION
## Description
This PR adds the field runNumber to the high level fields of the datasets. The field is optional, but it has come up many times in our assessments with users that it makes sense to promote it to high level, making it easier to create the proper search functionalities.

## Motivation
In our assessments with users, they have mention run number as a piece of information with high relevance. 
So far it was included in the scientific metadata, but it had suffer from the variability introduced by the freedom provided by the field. 
Promoting  run number to high level field, it will allow us to reduce such variability and provide a more consistent search functionality.

## Changes:
* dataset schema
* dataset dtos
* raw dataset tests

## Tests included
- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated
