### PR TITLE
feat: introduce public dataset endpoints

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -98,17 +98,34 @@ export class CaslAbilityFactory {
       /*  unauthenticated users
       **/
 
+      can(Action.DatasetReadManyPublic, DatasetClass);
+      can(Action.DatasetReadOnePublic, DatasetClass, {
+        isPublished: true,
+      });
+      // -
+      can(Action.DatasetAttachmentReadPublic, DatasetClass, {
+        isPublished: true,
+      });
+      // -
+      can(Action.DatasetOrigdatablockReadPublic, DatasetClass, {
+        isPublished: true,
+      });
+      // -
+      can(Action.DatasetDatablockReadPublic, DatasetClass, {
+        isPublished: true,
+      });
+
       cannot(Action.DatasetCreate, DatasetClass);
-      can(Action.DatasetRead, DatasetClass);
+      cannot(Action.DatasetRead, DatasetClass);
       cannot(Action.DatasetUpdate, DatasetClass);
       // -
       cannot(Action.DatasetAttachmentCreate, DatasetClass);
-      can(Action.DatasetAttachmentRead, DatasetClass);
+      cannot(Action.DatasetAttachmentRead, DatasetClass);
       cannot(Action.DatasetAttachmentUpdate, DatasetClass);
       cannot(Action.DatasetAttachmentDelete, DatasetClass);
       // -
       cannot(Action.DatasetOrigdatablockCreate, DatasetClass);
-      can(Action.DatasetOrigdatablockRead, DatasetClass);
+      cannot(Action.DatasetOrigdatablockRead, DatasetClass);
       cannot(Action.DatasetOrigdatablockUpdate, DatasetClass);
       // -
       cannot(Action.DatasetDatablockCreate, DatasetClass);

--- a/src/datasets/datasets-public.v4.controller.ts
+++ b/src/datasets/datasets-public.v4.controller.ts
@@ -1,0 +1,245 @@
+import { Controller, Get, Param, Query, HttpStatus } from "@nestjs/common";
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import { DatasetsService } from "./datasets.service";
+import { DatasetDocument } from "./schemas/dataset.schema";
+import {
+  IDatasetFields,
+  IDatasetFiltersV4,
+} from "./interfaces/dataset-filters.interface";
+import { IFilters } from "src/common/interfaces/common.interface";
+
+import { HistoryClass } from "./schemas/history.schema";
+import { TechniqueClass } from "./schemas/technique.schema";
+import { RelationshipClass } from "./schemas/relationship.schema";
+import { OutputDatasetDto } from "./dto/output-dataset.dto";
+import { CountApiResponse } from "src/common/types";
+import { DatasetLookupKeysEnum } from "./types/dataset-lookup";
+import { IncludeValidationPipe } from "./pipes/include-validation.pipe";
+import { FilterValidationPipe } from "./pipes/filter-validation.pipe";
+import { getSwaggerDatasetFilterContent } from "./types/dataset-filter-content";
+
+@ApiExtraModels(HistoryClass, TechniqueClass, RelationshipClass)
+@ApiTags("datasets public v4")
+@Controller({ path: "datasets/public", version: "4" })
+export class DatasetsPublicV4Controller {
+  constructor(private datasetsService: DatasetsService) {}
+
+  addPublicFilter(filter: IDatasetFiltersV4<DatasetDocument, IDatasetFields>) {
+    if (!filter.where) {
+      filter.where = {};
+    }
+
+    filter.where = { ...filter.where, isPublished: true };
+  }
+
+  // GET /datasets/public
+  @Get()
+  @ApiOperation({
+    summary: "It returns a list of public datasets.",
+    description:
+      "It returns a list of public datasets. The list returned can be modified by providing a filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving the public datasets",
+    required: false,
+    type: String,
+    content: getSwaggerDatasetFilterContent(),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    isArray: true,
+    description: "Return the datasets requested",
+  })
+  async findAllPublic(
+    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
+    queryFilter: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    const datasets = await this.datasetsService.findAllComplete(parsedFilter);
+
+    return datasets;
+  }
+
+  // GET /datasets/public/metadataKeys
+  @Get("/metadataKeys")
+  @ApiOperation({
+    summary:
+      "It returns a list of metadata keys contained in the public datasets matching the filter provided.",
+    description:
+      "It returns a list of metadata keys contained in the public datasets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
+  })
+  @ApiQuery({
+    name: "fields",
+    description:
+      "Define the filter conditions by specifying the name of values of fields requested. There is also support for a `text` search to look for strings anywhere in the dataset.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "limits",
+    description: "Define further query parameters like skip, limit, order",
+    required: false,
+    type: String,
+    example: '{ "skip": 0, "limit": 25, "order": "creationTime:desc" }',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: String,
+    isArray: true,
+    description: "Return metadata keys for list of public datasets selected",
+  })
+  // NOTE: This one needs to be discussed as well but it gets the metadata keys from the dataset but it doesnt do it with the nested fields. Think about it
+  async publicMetadataKeys(
+    @Query() filters: { fields?: string; limits?: string },
+  ) {
+    let fields: IDatasetFields = JSON.parse(filters.fields ?? "{}");
+
+    fields = { ...fields, isPublished: true };
+
+    const parsedFilters: IFilters<DatasetDocument, IDatasetFields> = {
+      fields: fields,
+      limits: JSON.parse(filters.limits ?? "{}"),
+    };
+
+    return this.datasetsService.metadataKeys(parsedFilters);
+  }
+
+  // GET /datasets/public/findOne
+  @Get("/findOne")
+  @ApiOperation({
+    summary: "It returns the first public dataset found.",
+    description:
+      "It returns the first public dataset of the ones that matches the filter provided. The list returned can be modified by providing a filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description: "Database filters to apply when retrieving public dataset",
+    required: true,
+    type: String,
+    content: getSwaggerDatasetFilterContent({
+      where: true,
+      include: true,
+      fields: true,
+      limits: true,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    description: "Return the datasets requested",
+  })
+  async findOnePublic(
+    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
+    queryFilter: string,
+  ): Promise<OutputDatasetDto | null> {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    const foundDataset =
+      await this.datasetsService.findOneComplete(parsedFilter);
+
+    if (!foundDataset) {
+      // TODO: Do we want to throw here if the dataset is not found!?
+      // something like: throw new NotFoundException(`Dataset with provided filters: ${queryFilter} was not found. Please check your filter and try again`);
+    }
+
+    return foundDataset;
+  }
+
+  // GET /datasets/public/count
+  @Get("/count")
+  @ApiOperation({
+    summary: "It returns the number of public datasets.",
+    description:
+      "It returns a number of public datasets matching the where filter if provided.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving count for public datasets",
+    required: false,
+    type: String,
+    content: getSwaggerDatasetFilterContent({
+      where: true,
+      include: false,
+      fields: false,
+      limits: false,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: CountApiResponse,
+    description:
+      "Return the number of public datasets in the following format: { count: integer }",
+  })
+  async countPublic(
+    @Query(
+      "filter",
+      new FilterValidationPipe({
+        where: true,
+        include: false,
+        fields: false,
+        limits: false,
+      }),
+    )
+    queryFilter?: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    return this.datasetsService.count(parsedFilter);
+  }
+
+  // GET /datasets/public/:id
+  @Get("/:pid")
+  @ApiParam({
+    name: "pid",
+    description: "Id of the public dataset to return",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    isArray: false,
+    description: "Return public dataset with pid specified",
+  })
+  @ApiQuery({
+    name: "include",
+    enum: DatasetLookupKeysEnum,
+    type: String,
+    required: false,
+    isArray: true,
+  })
+  async findByIdPublic(
+    @Param("pid") id: string,
+    @Query("include", new IncludeValidationPipe())
+    include: DatasetLookupKeysEnum[] | DatasetLookupKeysEnum,
+  ) {
+    const includeArray = Array.isArray(include)
+      ? include
+      : include && Array(include);
+
+    const dataset = await this.datasetsService.findOneComplete({
+      where: { pid: id, isPublished: true },
+      include: includeArray,
+    });
+
+    return dataset;
+  }
+}

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -858,8 +858,11 @@ export class DatasetsController {
 
   // GET /datasets
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadManyPublic, DatasetClass),
   )
   @UseInterceptors(MainDatasetsPublicInterceptor)
   @Get()
@@ -946,8 +949,11 @@ export class DatasetsController {
 
   // GET /datasets/fullquery
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadManyPublic, DatasetClass),
   )
   @UseInterceptors(SubDatasetsPublicInterceptor, FullQueryInterceptor)
   @Get("/fullquery")
@@ -1009,8 +1015,11 @@ export class DatasetsController {
 
   // GET /fullfacets
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadManyPublic, DatasetClass),
   )
   @UseInterceptors(SubDatasetsPublicInterceptor)
   @Get("/fullfacet")
@@ -1067,8 +1076,11 @@ export class DatasetsController {
 
   // GET /datasets/metadataKeys
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadManyPublic, DatasetClass),
   )
   @UseInterceptors(SubDatasetsPublicInterceptor)
   @Get("/metadataKeys")
@@ -1146,8 +1158,11 @@ export class DatasetsController {
 
   // GET /datasets/findOne
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadOnePublic, DatasetClass),
   )
   @Get("/findOne")
   @ApiOperation({
@@ -1221,8 +1236,11 @@ export class DatasetsController {
 
   // GET /datasets/count
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadManyPublic, DatasetClass),
   )
   @Get("/count")
   @ApiOperation({
@@ -1262,8 +1280,11 @@ export class DatasetsController {
   // GET /datasets/:id
   //@UseGuards(PoliciesGuard)
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadOnePublic, DatasetClass),
   )
   @Get("/:pid")
   @ApiParam({
@@ -1628,8 +1649,11 @@ export class DatasetsController {
 
   // GET /datasets/:id/thumbnail
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadOnePublic, DatasetClass),
   )
   // @UseGuards(PoliciesGuard)
   @Get("/:pid/thumbnail")

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -13,6 +13,7 @@ import { PoliciesService } from "src/policies/policies.service";
 import { PoliciesModule } from "src/policies/policies.module";
 import { ElasticSearchModule } from "src/elastic-search/elastic-search.module";
 import { DatasetsV4Controller } from "./datasets.v4.controller";
+import { DatasetsPublicV4Controller } from "./datasets-public.v4.controller";
 
 @Module({
   imports: [
@@ -63,7 +64,11 @@ import { DatasetsV4Controller } from "./datasets.v4.controller";
     ]),
   ],
   exports: [DatasetsService],
-  controllers: [DatasetsController, DatasetsV4Controller],
+  controllers: [
+    DatasetsPublicV4Controller,
+    DatasetsController,
+    DatasetsV4Controller,
+  ],
   providers: [DatasetsService, CaslAbilityFactory],
 })
 export class DatasetsModule {}

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -412,12 +412,23 @@ export class DatasetsService {
   ): Promise<OutputDatasetDto | null> {
     const whereFilter: FilterQuery<DatasetDocument> = filter.where ?? {};
     const fieldsProjection: string[] = filter.fields ?? {};
+    const limits: QueryOptions<DatasetDocument> = filter.limits ?? {
+      skip: 0,
+      sort: undefined,
+    };
 
     const pipeline: PipelineStage[] = [{ $match: whereFilter }];
     if (!isEmpty(fieldsProjection)) {
       const projection = parsePipelineProjection(fieldsProjection);
       pipeline.push({ $project: projection });
     }
+
+    if (!isEmpty(limits.sort)) {
+      const sort = parsePipelineSort(limits.sort);
+      pipeline.push({ $sort: sort });
+    }
+
+    pipeline.push({ $skip: limits.skip || 0 });
 
     this.addLookupFields(pipeline, filter.include);
 

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -261,7 +261,7 @@ export class DatasetsService {
     const fieldsProjection: string[] = filter.fields ?? {};
     const limits: QueryOptions<DatasetDocument> = filter.limits ?? {
       skip: 0,
-      sort: undefined,
+      sort: { createdAt: "desc" },
     };
 
     const pipeline: PipelineStage[] = [{ $match: whereFilter }];

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -37,10 +37,7 @@ import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
 import { IDatasetFields } from "./interfaces/dataset-filters.interface";
-import {
-  MainDatasetsPublicInterceptor,
-  SubDatasetsPublicInterceptor,
-} from "./interceptors/datasets-public.interceptor";
+import { SubDatasetsPublicInterceptor } from "./interceptors/datasets-public.interceptor";
 import { CreateAttachmentDto } from "src/attachments/dto/create-attachment.dto";
 import { UTCTimeInterceptor } from "src/common/interceptors/utc-time.interceptor";
 import { FormatPhysicalQuantitiesInterceptor } from "src/common/interceptors/format-physical-quantities.interceptor";
@@ -208,10 +205,6 @@ export class DatasetsV4Controller {
       Action.DatasetReadManyAccess,
       DatasetClass,
     );
-    const canViewPublic = ability.can(
-      Action.DatasetReadManyPublic,
-      DatasetClass,
-    );
 
     if (!filter.where) {
       filter.where = {};
@@ -245,12 +238,18 @@ export class DatasetsV4Controller {
           ...filter.where,
           ownerGroup: { $in: user.currentGroups },
         };
-      } else if (canViewPublic) {
-        filter.where = { ...filter.where, isPublished: true };
       }
     }
 
     return filter;
+  }
+
+  addPublicFilter(filter: IDatasetFiltersV4<DatasetDocument, IDatasetFields>) {
+    if (!filter.where) {
+      filter.where = {};
+    }
+
+    filter.where = { ...filter.where, isPublished: true };
   }
 
   // POST /api/v4/datasets
@@ -358,12 +357,45 @@ export class DatasetsV4Controller {
     return { valid: valid };
   }
 
+  // GET /datasets/public
+  @Get("/public")
+  @ApiOperation({
+    summary: "It returns a list of public datasets.",
+    description:
+      "It returns a list of public datasets. The list returned can be modified by providing a filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving the public datasets",
+    required: false,
+    type: String,
+    content: getSwaggerDatasetFilterContent(),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    isArray: true,
+    description: "Return the datasets requested",
+  })
+  async findAllPublic(
+    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
+    queryFilter: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    const datasets = await this.datasetsService.findAllComplete(parsedFilter);
+
+    return datasets;
+  }
+
   // GET /datasets
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>
     ability.can(Action.DatasetRead, DatasetClass),
   )
-  @UseInterceptors(MainDatasetsPublicInterceptor)
   @Get()
   @ApiOperation({
     summary: "It returns a list of datasets.",
@@ -401,6 +433,7 @@ export class DatasetsV4Controller {
 
   // GET /fullfacets
   @UseGuards(PoliciesGuard)
+  // TODO: Check if this should be closed or oppened endpoint for public!?
   @CheckPolicies("datasets", (ability: AppAbility) =>
     ability.can(Action.DatasetRead, DatasetClass),
   )
@@ -490,7 +523,7 @@ export class DatasetsV4Controller {
     status: HttpStatus.OK,
     type: String,
     isArray: true,
-    description: "Return metadata keys  for list of datasets selected",
+    description: "Return metadata keys for list of datasets selected",
   })
   // NOTE: This one needs to be discussed as well but it gets the metadata keys from the dataset but it doesnt do it with the nested fields. Think about it
   async metadataKeys(
@@ -527,6 +560,51 @@ export class DatasetsV4Controller {
     return this.datasetsService.metadataKeys(parsedFilters);
   }
 
+  // GET /datasets/public/metadataKeys
+  @Get("/public/metadataKeys")
+  @ApiOperation({
+    summary:
+      "It returns a list of metadata keys contained in the public datasets matching the filter provided.",
+    description:
+      "It returns a list of metadata keys contained in the public datasets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
+  })
+  @ApiQuery({
+    name: "fields",
+    description:
+      "Define the filter conditions by specifying the name of values of fields requested. There is also support for a `text` search to look for strings anywhere in the dataset.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "limits",
+    description: "Define further query parameters like skip, limit, order",
+    required: false,
+    type: String,
+    example: '{ "skip": 0, "limit": 25, "order": "creationTime:desc" }',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: String,
+    isArray: true,
+    description: "Return metadata keys for list of public datasets selected",
+  })
+  // NOTE: This one needs to be discussed as well but it gets the metadata keys from the dataset but it doesnt do it with the nested fields. Think about it
+  async publicMetadataKeys(
+    @Query() filters: { fields?: string; limits?: string },
+  ) {
+    let fields: IDatasetFields = JSON.parse(filters.fields ?? "{}");
+
+    fields = { ...fields, isPublished: true };
+
+    const parsedFilters: IFilters<DatasetDocument, IDatasetFields> = {
+      fields: fields,
+      limits: JSON.parse(filters.limits ?? "{}"),
+    };
+
+    return this.datasetsService.metadataKeys(parsedFilters);
+  }
+
   // GET /datasets/findOne
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>
@@ -540,7 +618,7 @@ export class DatasetsV4Controller {
   })
   @ApiQuery({
     name: "filter",
-    description: "Database filters to apply when retrieving datasets",
+    description: "Database filters to apply when retrieving dataset",
     required: true,
     type: String,
     content: getSwaggerDatasetFilterContent({
@@ -557,16 +635,7 @@ export class DatasetsV4Controller {
   })
   async findOne(
     @Req() request: Request,
-    @Query(
-      "filter",
-      new FilterValidationPipe({
-        where: true,
-        include: true,
-        fields: true,
-        limits: true,
-      }),
-      new IncludeValidationPipe(),
-    )
+    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
     queryFilter: string,
   ): Promise<OutputDatasetDto | null> {
     const parsedFilter = JSON.parse(queryFilter ?? "{}");
@@ -578,6 +647,49 @@ export class DatasetsV4Controller {
 
     const foundDataset =
       await this.datasetsService.findOneComplete(mergedFilters);
+
+    if (!foundDataset) {
+      // TODO: Do we want to throw here if the dataset is not found!?
+      // something like: throw new NotFoundException(`Dataset with provided filters: ${queryFilter} was not found. Please check your filter and try again`);
+    }
+
+    return foundDataset;
+  }
+
+  // GET /datasets/findOne/public
+  @Get("/findOne/public")
+  @ApiOperation({
+    summary: "It returns the first public dataset found.",
+    description:
+      "It returns the first public dataset of the ones that matches the filter provided. The list returned can be modified by providing a filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description: "Database filters to apply when retrieving public dataset",
+    required: true,
+    type: String,
+    content: getSwaggerDatasetFilterContent({
+      where: true,
+      include: true,
+      fields: true,
+      limits: true,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    description: "Return the datasets requested",
+  })
+  async findOnePublic(
+    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
+    queryFilter: string,
+  ): Promise<OutputDatasetDto | null> {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    const foundDataset =
+      await this.datasetsService.findOneComplete(parsedFilter);
 
     if (!foundDataset) {
       // TODO: Do we want to throw here if the dataset is not found!?
@@ -616,7 +728,6 @@ export class DatasetsV4Controller {
     description:
       "Return the number of datasets in the following format: { count: integer }",
   })
-  // TODO: Maybe we need to make the filters more granular and allow only needed ones. For example here we need only where filter.
   async count(
     @Req() request: Request,
     @Query(
@@ -638,6 +749,51 @@ export class DatasetsV4Controller {
     );
 
     return this.datasetsService.count(finalFilters);
+  }
+
+  // GET /datasets/count/public
+  @Get("/count/public")
+  @ApiOperation({
+    summary: "It returns the number of public datasets.",
+    description:
+      "It returns a number of public datasets matching the where filter if provided.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving count for public datasets",
+    required: false,
+    type: String,
+    content: getSwaggerDatasetFilterContent({
+      where: true,
+      include: false,
+      fields: false,
+      limits: false,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: CountApiResponse,
+    description:
+      "Return the number of public datasets in the following format: { count: integer }",
+  })
+  async countPublic(
+    @Query(
+      "filter",
+      new FilterValidationPipe({
+        where: true,
+        include: false,
+        fields: false,
+        limits: false,
+      }),
+    )
+    queryFilter?: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    this.addPublicFilter(parsedFilter);
+
+    return this.datasetsService.count(parsedFilter);
   }
 
   // GET /datasets/:id
@@ -685,6 +841,43 @@ export class DatasetsV4Controller {
       dataset,
       Action.DatasetRead,
     );
+
+    return dataset;
+  }
+
+  // GET /datasets/public/:id
+  @Get("public/:pid")
+  @ApiParam({
+    name: "pid",
+    description: "Id of the public dataset to return",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OutputDatasetDto,
+    isArray: false,
+    description: "Return public dataset with pid specified",
+  })
+  @ApiQuery({
+    name: "include",
+    enum: DatasetLookupKeysEnum,
+    type: String,
+    required: false,
+    isArray: true,
+  })
+  async findByIdPublic(
+    @Param("pid") id: string,
+    @Query("include", new IncludeValidationPipe())
+    include: DatasetLookupKeysEnum[] | DatasetLookupKeysEnum,
+  ) {
+    const includeArray = Array.isArray(include)
+      ? include
+      : include && Array(include);
+
+    const dataset = await this.datasetsService.findOneComplete({
+      where: { pid: id, isPublished: true },
+      include: includeArray,
+    });
 
     return dataset;
   }

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -377,7 +377,6 @@ export class DatasetsV4Controller {
 
   // GET /fullfacets
   @UseGuards(PoliciesGuard)
-  // TODO: Check if this should be closed or oppened endpoint for public!?
   @CheckPolicies("datasets", (ability: AppAbility) =>
     ability.can(Action.DatasetRead, DatasetClass),
   )
@@ -544,15 +543,7 @@ export class DatasetsV4Controller {
       parsedFilter,
     );
 
-    const foundDataset =
-      await this.datasetsService.findOneComplete(mergedFilters);
-
-    if (!foundDataset) {
-      // TODO: Do we want to throw here if the dataset is not found!?
-      // something like: throw new NotFoundException(`Dataset with provided filters: ${queryFilter} was not found. Please check your filter and try again`);
-    }
-
-    return foundDataset;
+    return this.datasetsService.findOneComplete(mergedFilters);
   }
 
   // GET /datasets/count

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -36,16 +36,15 @@ import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
-import { IDatasetFields } from "./interfaces/dataset-filters.interface";
+import {
+  IDatasetFields,
+  IDatasetFiltersV4,
+} from "./interfaces/dataset-filters.interface";
 import { SubDatasetsPublicInterceptor } from "./interceptors/datasets-public.interceptor";
 import { CreateAttachmentDto } from "src/attachments/dto/create-attachment.dto";
 import { UTCTimeInterceptor } from "src/common/interceptors/utc-time.interceptor";
 import { FormatPhysicalQuantitiesInterceptor } from "src/common/interceptors/format-physical-quantities.interceptor";
-import {
-  IFacets,
-  IFilters,
-  ILimitsFilter,
-} from "src/common/interfaces/common.interface";
+import { IFacets, IFilters } from "src/common/interfaces/common.interface";
 import { validate } from "class-validator";
 import { HistoryInterceptor } from "src/common/interceptors/history.interceptor";
 
@@ -68,19 +67,11 @@ import {
   IsValidResponse,
 } from "src/common/types";
 import { DatasetLookupKeysEnum } from "./types/dataset-lookup";
-import { FilterQuery } from "mongoose";
 import { IncludeValidationPipe } from "./pipes/include-validation.pipe";
 import { PidValidationPipe } from "./pipes/pid-validation.pipe";
 import { FilterValidationPipe } from "./pipes/filter-validation.pipe";
 import { getSwaggerDatasetFilterContent } from "./types/dataset-filter-content";
 import { logger } from "@user-office-software/duo-logger";
-
-export interface IDatasetFiltersV4<T, Y = null> {
-  where?: FilterQuery<T>;
-  include?: DatasetLookupKeysEnum[];
-  fields?: Y;
-  limits?: ILimitsFilter;
-}
 
 @ApiBearerAuth()
 @ApiExtraModels(
@@ -244,14 +235,6 @@ export class DatasetsV4Controller {
     return filter;
   }
 
-  addPublicFilter(filter: IDatasetFiltersV4<DatasetDocument, IDatasetFields>) {
-    if (!filter.where) {
-      filter.where = {};
-    }
-
-    filter.where = { ...filter.where, isPublished: true };
-  }
-
   // POST /api/v4/datasets
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>
@@ -355,40 +338,6 @@ export class DatasetsV4Controller {
     const valid = errors.length === 0;
 
     return { valid: valid };
-  }
-
-  // GET /datasets/public
-  @Get("/public")
-  @ApiOperation({
-    summary: "It returns a list of public datasets.",
-    description:
-      "It returns a list of public datasets. The list returned can be modified by providing a filter.",
-  })
-  @ApiQuery({
-    name: "filter",
-    description:
-      "Database filters to apply when retrieving the public datasets",
-    required: false,
-    type: String,
-    content: getSwaggerDatasetFilterContent(),
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: OutputDatasetDto,
-    isArray: true,
-    description: "Return the datasets requested",
-  })
-  async findAllPublic(
-    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
-    queryFilter: string,
-  ) {
-    const parsedFilter = JSON.parse(queryFilter ?? "{}");
-
-    this.addPublicFilter(parsedFilter);
-
-    const datasets = await this.datasetsService.findAllComplete(parsedFilter);
-
-    return datasets;
   }
 
   // GET /datasets
@@ -560,51 +509,6 @@ export class DatasetsV4Controller {
     return this.datasetsService.metadataKeys(parsedFilters);
   }
 
-  // GET /datasets/public/metadataKeys
-  @Get("/public/metadataKeys")
-  @ApiOperation({
-    summary:
-      "It returns a list of metadata keys contained in the public datasets matching the filter provided.",
-    description:
-      "It returns a list of metadata keys contained in the public datasets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
-  })
-  @ApiQuery({
-    name: "fields",
-    description:
-      "Define the filter conditions by specifying the name of values of fields requested. There is also support for a `text` search to look for strings anywhere in the dataset.",
-    required: false,
-    type: String,
-    example: {},
-  })
-  @ApiQuery({
-    name: "limits",
-    description: "Define further query parameters like skip, limit, order",
-    required: false,
-    type: String,
-    example: '{ "skip": 0, "limit": 25, "order": "creationTime:desc" }',
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: String,
-    isArray: true,
-    description: "Return metadata keys for list of public datasets selected",
-  })
-  // NOTE: This one needs to be discussed as well but it gets the metadata keys from the dataset but it doesnt do it with the nested fields. Think about it
-  async publicMetadataKeys(
-    @Query() filters: { fields?: string; limits?: string },
-  ) {
-    let fields: IDatasetFields = JSON.parse(filters.fields ?? "{}");
-
-    fields = { ...fields, isPublished: true };
-
-    const parsedFilters: IFilters<DatasetDocument, IDatasetFields> = {
-      fields: fields,
-      limits: JSON.parse(filters.limits ?? "{}"),
-    };
-
-    return this.datasetsService.metadataKeys(parsedFilters);
-  }
-
   // GET /datasets/findOne
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>
@@ -647,49 +551,6 @@ export class DatasetsV4Controller {
 
     const foundDataset =
       await this.datasetsService.findOneComplete(mergedFilters);
-
-    if (!foundDataset) {
-      // TODO: Do we want to throw here if the dataset is not found!?
-      // something like: throw new NotFoundException(`Dataset with provided filters: ${queryFilter} was not found. Please check your filter and try again`);
-    }
-
-    return foundDataset;
-  }
-
-  // GET /datasets/findOne/public
-  @Get("/findOne/public")
-  @ApiOperation({
-    summary: "It returns the first public dataset found.",
-    description:
-      "It returns the first public dataset of the ones that matches the filter provided. The list returned can be modified by providing a filter.",
-  })
-  @ApiQuery({
-    name: "filter",
-    description: "Database filters to apply when retrieving public dataset",
-    required: true,
-    type: String,
-    content: getSwaggerDatasetFilterContent({
-      where: true,
-      include: true,
-      fields: true,
-      limits: true,
-    }),
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: OutputDatasetDto,
-    description: "Return the datasets requested",
-  })
-  async findOnePublic(
-    @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
-    queryFilter: string,
-  ): Promise<OutputDatasetDto | null> {
-    const parsedFilter = JSON.parse(queryFilter ?? "{}");
-
-    this.addPublicFilter(parsedFilter);
-
-    const foundDataset =
-      await this.datasetsService.findOneComplete(parsedFilter);
 
     if (!foundDataset) {
       // TODO: Do we want to throw here if the dataset is not found!?
@@ -751,51 +612,6 @@ export class DatasetsV4Controller {
     return this.datasetsService.count(finalFilters);
   }
 
-  // GET /datasets/count/public
-  @Get("/count/public")
-  @ApiOperation({
-    summary: "It returns the number of public datasets.",
-    description:
-      "It returns a number of public datasets matching the where filter if provided.",
-  })
-  @ApiQuery({
-    name: "filter",
-    description:
-      "Database filters to apply when retrieving count for public datasets",
-    required: false,
-    type: String,
-    content: getSwaggerDatasetFilterContent({
-      where: true,
-      include: false,
-      fields: false,
-      limits: false,
-    }),
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: CountApiResponse,
-    description:
-      "Return the number of public datasets in the following format: { count: integer }",
-  })
-  async countPublic(
-    @Query(
-      "filter",
-      new FilterValidationPipe({
-        where: true,
-        include: false,
-        fields: false,
-        limits: false,
-      }),
-    )
-    queryFilter?: string,
-  ) {
-    const parsedFilter = JSON.parse(queryFilter ?? "{}");
-
-    this.addPublicFilter(parsedFilter);
-
-    return this.datasetsService.count(parsedFilter);
-  }
-
   // GET /datasets/:id
   //@UseGuards(PoliciesGuard)
   @UseGuards(PoliciesGuard)
@@ -841,43 +657,6 @@ export class DatasetsV4Controller {
       dataset,
       Action.DatasetRead,
     );
-
-    return dataset;
-  }
-
-  // GET /datasets/public/:id
-  @Get("public/:pid")
-  @ApiParam({
-    name: "pid",
-    description: "Id of the public dataset to return",
-    type: String,
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: OutputDatasetDto,
-    isArray: false,
-    description: "Return public dataset with pid specified",
-  })
-  @ApiQuery({
-    name: "include",
-    enum: DatasetLookupKeysEnum,
-    type: String,
-    required: false,
-    isArray: true,
-  })
-  async findByIdPublic(
-    @Param("pid") id: string,
-    @Query("include", new IncludeValidationPipe())
-    include: DatasetLookupKeysEnum[] | DatasetLookupKeysEnum,
-  ) {
-    const includeArray = Array.isArray(include)
-      ? include
-      : include && Array(include);
-
-    const dataset = await this.datasetsService.findOneComplete({
-      where: { pid: id, isPublished: true },
-      include: includeArray,
-    });
 
     return dataset;
   }

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -1,4 +1,9 @@
-import { IScientificFilter } from "src/common/interfaces/common.interface";
+import { FilterQuery } from "mongoose";
+import {
+  ILimitsFilter,
+  IScientificFilter,
+} from "src/common/interfaces/common.interface";
+import { DatasetLookupKeysEnum } from "../types/dataset-lookup";
 
 export interface IDatasetFields {
   mode?: Record<string, unknown>;
@@ -19,4 +24,11 @@ export interface IDatasetFields {
   userGroups?: string[];
   sharedWith?: string[];
   [key: string]: unknown;
+}
+
+export interface IDatasetFiltersV4<T, Y = null> {
+  where?: FilterQuery<T>;
+  include?: DatasetLookupKeysEnum[];
+  fields?: Y;
+  limits?: ILimitsFilter;
 }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR aims to separate the public dataset endpoints and refactor the dataset relation fields access.

## Motivation
Querying the public datasets was part of the main endpoints which was a bit confusing as in swagger it shows that it needs authentication but if you are not logged in it returns the public datasets back.

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* adding new dataset controller for the public datasets and new dataset-access.service.ts for the relational fields access control.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
