### PR TITLE
feat: add proposal count endpoint

### DIFF
--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -54,8 +54,10 @@ import {
 import { plainToInstance } from "class-transformer";
 import { validate, ValidatorOptions } from "class-validator";
 import {
+  CountApiResponse,
   filterDescription,
   filterExample,
+  FullFacetFilters,
   FullFacetResponse,
   fullQueryExampleLimits,
   FullQueryFilters,
@@ -65,6 +67,7 @@ import {
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { IDatasetFields } from "src/datasets/interfaces/dataset-filters.interface";
 import { FindByIdAccessResponse } from "src/samples/samples.controller";
+import { FilterPipe } from "src/common/pipes/filter.pipe";
 
 @ApiBearerAuth()
 @ApiTags("proposals")
@@ -368,6 +371,38 @@ export class ProposalsController {
     return this.proposalsService.findAll(proposalFilters);
   }
 
+  // GET /proposals/count
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("proposals", (ability: AppAbility) =>
+    ability.can(Action.ProposalsRead, ProposalClass),
+  )
+  @Get("/count")
+  @ApiOperation({
+    summary: "It returns the number of proposals.",
+    description:
+      "It returns a number of proposals matching the where filter if provided.",
+  })
+  @ApiQuery({
+    name: "filters",
+    description:
+      "Database filters to apply when retrieving count for proposals",
+    required: false,
+    type: String,
+    example: '{"where": {"proposalId": "189691"}}',
+  })
+  @ApiResponse({
+    status: 200,
+    type: CountApiResponse,
+    description:
+      "Return the number of proposals in the following format: { count: integer }",
+  })
+  async count(@Req() request: Request, @Query("filters") filters?: string) {
+    const proposalFilters: IFilters<ProposalDocument, IProposalFields> =
+      this.updateFiltersForList(request, JSON.parse(filters ?? "{}"));
+
+    return this.proposalsService.count(proposalFilters);
+  }
+
   // GET /proposals/fullquery
   @UseGuards(PoliciesGuard)
   @CheckPolicies("proposals", (ability: AppAbility) =>
@@ -454,7 +489,7 @@ export class ProposalsController {
       "Full facet query filters to apply when retrieving proposals\n" +
       proposalsFullQueryDescriptionFields,
     required: false,
-    type: String,
+    type: FullFacetFilters,
     example: proposalsFullQueryExampleFields,
   })
   @ApiResponse({

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -67,7 +67,6 @@ import {
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { IDatasetFields } from "src/datasets/interfaces/dataset-filters.interface";
 import { FindByIdAccessResponse } from "src/samples/samples.controller";
-import { FilterPipe } from "src/common/pipes/filter.pipe";
 
 @ApiBearerAuth()
 @ApiTags("proposals")

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -57,6 +57,16 @@ export class ProposalsService {
       .exec();
   }
 
+  async count(
+    filter: IFilters<ProposalDocument, IProposalFields>,
+  ): Promise<{ count: number }> {
+    const whereFilter: FilterQuery<ProposalDocument> = filter.where ?? {};
+
+    const count = await this.proposalModel.countDocuments(whereFilter).exec();
+
+    return { count };
+  }
+
   async fullquery(
     filter: IFilters<ProposalDocument, IProposalFields>,
   ): Promise<ProposalClass[]> {

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -176,6 +176,32 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
+  it("0091: should get proposal count", async () => {
+    return request(appUrl)
+      .get("/api/v3/Proposals/count")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body["count"].should.be.greaterThan(0);
+      });
+  });
+
+  it("0091: should get proposal count using filters", async () => {
+    const query = { where: { proposalId: { $in: [proposalId] } } };
+    return request(appUrl)
+      .get("/api/v3/Proposals/count")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .query("filter=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body["count"].should.be.equal(1);
+      });
+  });
+
   it("0100: should add a new attachment to this proposal", async () => {
     let testAttachment = { ...TestData.AttachmentCorrect };
     testAttachment.proposalId = defaultProposalId;


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Added the count endpoint for the proposals.

## Motivation
There was no count endpoint for the proposals and we needed it in the frontend

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes are only in the proposals controller and service

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
