### PR TITLE
fix: or filter in the proposals count endpoint to be able to get the related proposals easier

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -32,6 +32,9 @@ export class FullFacetResponse implements IFullFacets {
 export class ProposalCountFilters {
   @ApiPropertyOptional()
   fields?: string;
+
+  @ApiPropertyOptional()
+  filter?: string;
 }
 
 export class CountApiResponse {

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -233,12 +233,42 @@ export class ProposalsController {
           ProposalClass,
         );
         if (canViewAccess) {
-          mergedFilters.where["$or"] = [
-            { ownerGroup: { $in: user.currentGroups } },
-            { accessGroups: { $in: user.currentGroups } },
-          ];
+          if (!mergedFilters.where["$and"]) {
+            if (mergedFilters.where["$or"]) {
+              mergedFilters.where["$and"] = [
+                {
+                  $or: mergedFilters.where["$or"],
+                },
+                {
+                  $or: [
+                    { ownerGroup: { $in: user.currentGroups } },
+                    { accessGroups: { $in: user.currentGroups } },
+                  ],
+                },
+              ];
+            } else {
+              mergedFilters.where["$or"] = [
+                { ownerGroup: { $in: user.currentGroups } },
+                { accessGroups: { $in: user.currentGroups } },
+              ];
+            }
+          } else {
+            mergedFilters.where["$and"].push({
+              $or: [
+                { ownerGroup: { $in: user.currentGroups } },
+                { accessGroups: { $in: user.currentGroups } },
+              ],
+            });
+          }
         } else if (canViewOwner) {
-          mergedFilters.where = { ownerGroup: { $in: user.currentGroups } };
+          if (mergedFilters.where) {
+            mergedFilters.where = {
+              ...mergedFilters.where,
+              ownerGroup: { $in: user.currentGroups },
+            };
+          } else {
+            mergedFilters.where = { ownerGroup: { $in: user.currentGroups } };
+          }
         } else if (canViewPublic) {
           mergedFilters.where.isPublished = true;
         }

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -402,33 +402,31 @@ export class ProposalsController {
     const user: JWTUser = request.user as JWTUser;
     const fields: IProposalFields = JSON.parse(filters.fields ?? "{}");
 
-    if (user) {
-      const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
-      const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
+    const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
+    const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
 
-      if (!canViewAll) {
-        const canViewAccess = ability.can(
-          Action.ProposalsReadManyAccess,
-          ProposalClass,
-        );
-        const canViewOwner = ability.can(
-          Action.ProposalsReadManyOwner,
-          ProposalClass,
-        );
-        const canViewPublic = ability.can(
-          Action.ProposalsReadManyPublic,
-          ProposalClass,
-        );
-        if (canViewAccess) {
-          fields.userGroups = fields.userGroups ?? [];
-          fields.userGroups.push(...user.currentGroups);
-          // fields.sharedWith = user.email;
-        } else if (canViewOwner) {
-          fields.ownerGroup = fields.ownerGroup ?? [];
-          fields.ownerGroup.push(...user.currentGroups);
-        } else if (canViewPublic) {
-          fields.isPublished = true;
-        }
+    if (!canViewAll) {
+      const canViewAccess = ability.can(
+        Action.ProposalsReadManyAccess,
+        ProposalClass,
+      );
+      const canViewOwner = ability.can(
+        Action.ProposalsReadManyOwner,
+        ProposalClass,
+      );
+      const canViewPublic = ability.can(
+        Action.ProposalsReadManyPublic,
+        ProposalClass,
+      );
+      if (canViewAccess) {
+        fields.userGroups = fields.userGroups ?? [];
+        fields.userGroups.push(...user.currentGroups);
+        // fields.sharedWith = user.email;
+      } else if (canViewOwner) {
+        fields.ownerGroup = fields.ownerGroup ?? [];
+        fields.ownerGroup.push(...user.currentGroups);
+      } else if (canViewPublic) {
+        fields.isPublished = true;
       }
     }
 
@@ -466,33 +464,31 @@ export class ProposalsController {
     const user: JWTUser = request.user as JWTUser;
     const fields: IProposalFields = JSON.parse(filters.fields ?? "{}");
     const limits: ILimitsFilter = JSON.parse(filters.limits ?? "{}");
-    if (user) {
-      const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
-      const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
+    const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
+    const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
 
-      if (!canViewAll) {
-        const canViewAccess = ability.can(
-          Action.ProposalsReadManyAccess,
-          ProposalClass,
-        );
-        const canViewOwner = ability.can(
-          Action.ProposalsReadManyOwner,
-          ProposalClass,
-        );
-        const canViewPublic = ability.can(
-          Action.ProposalsReadManyPublic,
-          ProposalClass,
-        );
-        if (canViewAccess) {
-          fields.userGroups = fields.userGroups ?? [];
-          fields.userGroups.push(...user.currentGroups);
-          // fields.sharedWith = user.email;
-        } else if (canViewOwner) {
-          fields.ownerGroup = fields.ownerGroup ?? [];
-          fields.ownerGroup.push(...user.currentGroups);
-        } else if (canViewPublic) {
-          fields.isPublished = true;
-        }
+    if (!canViewAll) {
+      const canViewAccess = ability.can(
+        Action.ProposalsReadManyAccess,
+        ProposalClass,
+      );
+      const canViewOwner = ability.can(
+        Action.ProposalsReadManyOwner,
+        ProposalClass,
+      );
+      const canViewPublic = ability.can(
+        Action.ProposalsReadManyPublic,
+        ProposalClass,
+      );
+      if (canViewAccess) {
+        fields.userGroups = fields.userGroups ?? [];
+        fields.userGroups.push(...user.currentGroups);
+        // fields.sharedWith = user.email;
+      } else if (canViewOwner) {
+        fields.ownerGroup = fields.ownerGroup ?? [];
+        fields.ownerGroup.push(...user.currentGroups);
+      } else if (canViewPublic) {
+        fields.isPublished = true;
       }
     }
 
@@ -537,33 +533,31 @@ export class ProposalsController {
     const user: JWTUser = request.user as JWTUser;
     const fields: IProposalFields = JSON.parse(filters.fields ?? "{}");
     const facets = JSON.parse(filters.facets ?? "[]");
-    if (user) {
-      const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
-      const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
+    const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
+    const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
 
-      if (!canViewAll) {
-        const canViewAccess = ability.can(
-          Action.ProposalsReadManyAccess,
-          ProposalClass,
-        );
-        const canViewOwner = ability.can(
-          Action.ProposalsReadManyOwner,
-          ProposalClass,
-        );
-        const canViewPublic = ability.can(
-          Action.ProposalsReadManyPublic,
-          ProposalClass,
-        );
-        if (canViewAccess) {
-          fields.userGroups = fields.userGroups ?? [];
-          fields.userGroups.push(...user.currentGroups);
-          // fields.sharedWith = user.email;
-        } else if (canViewOwner) {
-          fields.ownerGroup = fields.ownerGroup ?? [];
-          fields.ownerGroup.push(...user.currentGroups);
-        } else if (canViewPublic) {
-          fields.isPublished = true;
-        }
+    if (!canViewAll) {
+      const canViewAccess = ability.can(
+        Action.ProposalsReadManyAccess,
+        ProposalClass,
+      );
+      const canViewOwner = ability.can(
+        Action.ProposalsReadManyOwner,
+        ProposalClass,
+      );
+      const canViewPublic = ability.can(
+        Action.ProposalsReadManyPublic,
+        ProposalClass,
+      );
+      if (canViewAccess) {
+        fields.userGroups = fields.userGroups ?? [];
+        fields.userGroups.push(...user.currentGroups);
+        // fields.sharedWith = user.email;
+      } else if (canViewOwner) {
+        fields.ownerGroup = fields.ownerGroup ?? [];
+        fields.ownerGroup.push(...user.currentGroups);
+      } else if (canViewPublic) {
+        fields.isPublished = true;
       }
     }
 

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -390,7 +390,7 @@ export class ProposalsController {
       "Database filters to apply when retrieving count for proposals",
     required: false,
     type: ProposalCountFilters,
-    example: `{ fields: ${proposalsFullQueryExampleFields}}`,
+    example: `{ fields: ${proposalsFullQueryExampleFields}, filter: ${filterExample}}`,
   })
   @ApiResponse({
     status: 200,
@@ -398,9 +398,13 @@ export class ProposalsController {
     description:
       "Return the number of proposals in the following format: { count: integer }",
   })
-  async count(@Req() request: Request, @Query() filters: { fields?: string }) {
+  async count(
+    @Req() request: Request,
+    @Query() filters: { fields?: string; filter?: string },
+  ) {
     const user: JWTUser = request.user as JWTUser;
     const fields: IProposalFields = JSON.parse(filters.fields ?? "{}");
+    const filter: IProposalFields = JSON.parse(filters.filter ?? "{}");
 
     const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
     const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
@@ -430,7 +434,7 @@ export class ProposalsController {
       }
     }
 
-    return this.proposalsService.count({ fields });
+    return this.proposalsService.count({ fields, where: filter });
   }
 
   // GET /proposals/fullquery

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -67,6 +67,13 @@ export class ProposalsService {
         filter.fields,
       );
 
+    // NOTE: This is fix for the related proposals count.
+    // Maybe the total count should be refactored and be part of the fullquery or another separate endpoint that includes both data and the totalCount instead of making multiple requests.
+    if (filterQuery.$or) {
+      filterQuery.$or =
+        (filter.fields as FilterQuery<ProposalDocument>)?.$or || [];
+    }
+
     const count = await this.proposalModel.countDocuments(filterQuery).exec();
 
     return { count };

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -66,15 +66,15 @@ export class ProposalsService {
         "proposalId",
         filter.fields,
       );
+    let countFilter = { ...filterQuery };
 
     // NOTE: This is fix for the related proposals count.
     // Maybe the total count should be refactored and be part of the fullquery or another separate endpoint that includes both data and the totalCount instead of making multiple requests.
-    if (filterQuery.$or) {
-      filterQuery.$or =
-        (filter.fields as FilterQuery<ProposalDocument>)?.$or || [];
+    if (filter.where) {
+      countFilter = { $and: [{ ...countFilter }, filter.where] };
     }
 
-    const count = await this.proposalModel.countDocuments(filterQuery).exec();
+    const count = await this.proposalModel.countDocuments(countFilter).exec();
 
     return { count };
   }

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -188,8 +188,8 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
-  it("0091: should get proposal count using filters", async () => {
-    const query = { where: { proposalId: { $in: [proposalId] } } };
+  it("0091:shouldgetproposal count using filters", async () => {
+    const query = { proposalId: { $in: [proposalId] } };
     return request(appUrl)
       .get("/api/v3/Proposals/count")
       .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
@@ -266,6 +266,26 @@ describe("1500: Proposal: Simple Proposal", () => {
         proposalWithParentId = res.body.proposalId;
         res.body.should.have.property("parentProposalId").and.be.string;
         res.body.parentProposalId.should.be.equal(proposalId);
+      });
+  });
+
+  it("01150:shouldgetproposal count using $or filters", async () => {
+    const query = {
+      $or: [
+        { proposalId: { $in: [proposalId] } },
+        { parentProposalId: { $in: [proposalId] } },
+      ],
+    };
+
+    return request(appUrl)
+      .get("/api/v3/Proposals/count")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .query("filter=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body["count"].should.be.equal(2);
       });
   });
 

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -188,7 +188,7 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
-  it("0091:shouldgetproposal count using filters", async () => {
+  it("0091: should get proposal count using filters", async () => {
     const query = { proposalId: { $in: [proposalId] } };
     return request(appUrl)
       .get("/api/v3/Proposals/count")
@@ -269,7 +269,7 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
-  it("01150:shouldgetproposal count using $or filters", async () => {
+  it("01150: should get proposal count using $or filters", async () => {
     const query = {
       $or: [
         { proposalId: { $in: [proposalId] } },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Fix the permissions for count, fullquery and fullfacet proposal endpoints and allow $or filter to work in the proposal count.

## Motivation
Permissions were not correct and the $or filter in count didn't work as expected

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
