### PR TITLE
fix: migrate affected datasets where size numberOfFiles packedSize and numberOfFilesArchived were overwritten

### DIFF
--- a/migrations/20250423114619-populate-overwritten-datasets-size.js
+++ b/migrations/20250423114619-populate-overwritten-datasets-size.js
@@ -122,7 +122,7 @@ module.exports = {
 
     await db
       .collection("Dataset")
-      .find({ packedSize: 0 })
+      .find({ numberOfFilesArchived: 0 })
       .forEach(async (dataset) => {
         const datablocks = await db
           .collection("Datablock")

--- a/migrations/20250423114619-populate-overwritten-datasets-size.js
+++ b/migrations/20250423114619-populate-overwritten-datasets-size.js
@@ -1,0 +1,156 @@
+module.exports = {
+  async up(db, client) {
+    await db
+      .collection("Dataset")
+      .find({ size: 0 })
+      .forEach(async (dataset) => {
+        const origDatablocks = await db
+          .collection("OrigDatablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+        const origDatablockSizeSum = origDatablocks.reduce(
+          (acc, origDatablock) => acc + origDatablock.size,
+          0,
+        );
+
+        const datablocks = await db
+          .collection("Datablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+
+        const datablockSizeSum = datablocks.reduce(
+          (acc, datablock) => acc + datablock.size,
+          0,
+        );
+
+        const datasetSizeSum = origDatablockSizeSum + datablockSizeSum;
+
+        console.log(
+          `Updating Dataset (Id: ${dataset._id}) with size =>${datasetSizeSum}<=`,
+        );
+        await db.collection("Dataset").updateOne(
+          {
+            _id: dataset._id,
+          },
+          {
+            $set: {
+              size: datasetSizeSum,
+            },
+          },
+        );
+      });
+
+    await db
+      .collection("Dataset")
+      .find({ numberOfFiles: 0 })
+      .forEach(async (dataset) => {
+        const origDatablocks = await db
+          .collection("OrigDatablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+        const origDatablockNumberOfFilesSum = origDatablocks.reduce(
+          (acc, origDatablock) => acc + origDatablock.dataFileList.length,
+          0,
+        );
+
+        const datablocks = await db
+          .collection("Datablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+
+        const datablockNumberOfFilesSum = datablocks.reduce(
+          (acc, datablock) => acc + datablock.dataFileList.length,
+          0,
+        );
+
+        const datasetNumberOfFilesSum =
+          origDatablockNumberOfFilesSum + datablockNumberOfFilesSum;
+
+        console.log(
+          `Updating Dataset (Id: ${dataset._id}) with numberOfFiles =>${datasetNumberOfFilesSum}<=`,
+        );
+        await db.collection("Dataset").updateOne(
+          {
+            _id: dataset._id,
+          },
+          {
+            $set: {
+              numberOfFiles: datasetNumberOfFilesSum,
+            },
+          },
+        );
+      });
+
+    await db
+      .collection("Dataset")
+      .find({ packedSize: 0 })
+      .forEach(async (dataset) => {
+        const datablocks = await db
+          .collection("Datablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+
+        const datablockPackedSizeSum = datablocks.reduce(
+          (acc, datablock) => acc + datablock.packedSize,
+          0,
+        );
+
+        console.log(
+          `Updating Dataset (Id: ${dataset._id}) with packedSize =>${datablockPackedSizeSum}<=`,
+        );
+        await db.collection("Dataset").updateOne(
+          {
+            _id: dataset._id,
+          },
+          {
+            $set: {
+              packedSize: datablockPackedSizeSum,
+            },
+          },
+        );
+      });
+
+    await db
+      .collection("Dataset")
+      .find({ packedSize: 0 })
+      .forEach(async (dataset) => {
+        const datablocks = await db
+          .collection("Datablock")
+          .find({
+            datasetId: dataset._id,
+          })
+          .toArray();
+
+        const datablockNumberOfFilesArchivedSum = datablocks.reduce(
+          (acc, datablock) => acc + datablock.dataFileList.length,
+          0,
+        );
+
+        console.log(
+          `Updating Dataset (Id: ${dataset._id}) with numberOfFilesArchived =>${datablockNumberOfFilesArchivedSum}<=`,
+        );
+        await db.collection("Dataset").updateOne(
+          {
+            _id: dataset._id,
+          },
+          {
+            $set: {
+              numberOfFilesArchived: datablockNumberOfFilesArchivedSum,
+            },
+          },
+        );
+      });
+  },
+
+  async down(db, client) {},
+};


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR aims to provide a migration script for datasets properties that were overwritten by a bug that was found and fixed in the code.

## Motivation
`size`, `numberOfFiles`, `packedSize` and `numberOfFilesArchived` were all overwritten by a bug in the code and those needed to be fixed.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* https://jira.ess.eu/browse/SWAP-4629
* https://github.com/SciCatProject/scicat-backend-next/issues/1688

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* Added new mongo migration script

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
