### PR TITLE
fix: proposals endpoint access fix and improvement

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -685,61 +685,68 @@ export class CaslAbilityFactory {
       cannot(Action.ProposalsAttachmentCreate, ProposalClass);
       cannot(Action.ProposalsAttachmentUpdate, ProposalClass);
       cannot(Action.ProposalsAttachmentDelete, ProposalClass);
-    } else if (
-      user.currentGroups.some((g) => this.accessGroups?.delete.includes(g))
-    ) {
-      /*
+    } else {
+      if (
+        user.currentGroups.some((g) => this.accessGroups?.admin.includes(g))
+      ) {
+        /**
+         * authenticated users belonging to any of the group listed in ADMIN_GROUPS
+         */
+
+        can(Action.ProposalsRead, ProposalClass);
+        can(Action.ProposalsCreate, ProposalClass);
+        can(Action.ProposalsUpdate, ProposalClass);
+        can(Action.ProposalsAttachmentRead, ProposalClass);
+        can(Action.ProposalsAttachmentCreate, ProposalClass);
+        can(Action.ProposalsAttachmentUpdate, ProposalClass);
+        can(Action.ProposalsAttachmentDelete, ProposalClass);
+      } else if (
+        user.currentGroups.some((g) => {
+          return this.accessGroups?.proposal.includes(g);
+        })
+      ) {
+        /**
+         * authenticated users belonging to any of the group listed in PROPOSAL_GROUPS
+         */
+
+        can(Action.ProposalsRead, ProposalClass);
+        can(Action.ProposalsCreate, ProposalClass);
+        can(Action.ProposalsUpdate, ProposalClass);
+        can(Action.ProposalsAttachmentRead, ProposalClass);
+        can(Action.ProposalsAttachmentCreate, ProposalClass);
+        can(Action.ProposalsAttachmentUpdate, ProposalClass);
+        can(Action.ProposalsAttachmentDelete, ProposalClass);
+        cannot(Action.ProposalsDatasetRead, ProposalClass);
+      } else if (user) {
+        /**
+         * authenticated users
+         */
+
+        can(Action.ProposalsRead, ProposalClass);
+        cannot(Action.ProposalsCreate, ProposalClass);
+        cannot(Action.ProposalsUpdate, ProposalClass);
+        can(Action.ProposalsAttachmentRead, ProposalClass);
+        cannot(Action.ProposalsAttachmentCreate, ProposalClass);
+        cannot(Action.ProposalsAttachmentUpdate, ProposalClass);
+        cannot(Action.ProposalsAttachmentDelete, ProposalClass);
+        can(Action.ProposalsDatasetRead, ProposalClass);
+      }
+
+      if (
+        user.currentGroups.some((g) => this.accessGroups?.delete.includes(g))
+      ) {
+        /*
         / user that belongs to any of the group listed in DELETE_GROUPS
         */
 
-      can(Action.ProposalsDelete, ProposalClass);
-    } else if (
-      user.currentGroups.some((g) => this.accessGroups?.admin.includes(g))
-    ) {
-      /**
-       * authenticated users belonging to any of the group listed in ADMIN_GROUPS
-       */
+        can(Action.ProposalsDelete, ProposalClass);
+      } else {
+        /*
+        /  user that does not belong to any of the group listed in DELETE_GROUPS
+        */
 
-      can(Action.ProposalsRead, ProposalClass);
-      can(Action.ProposalsCreate, ProposalClass);
-      can(Action.ProposalsUpdate, ProposalClass);
-      cannot(Action.ProposalsDelete, ProposalClass);
-      can(Action.ProposalsAttachmentRead, ProposalClass);
-      can(Action.ProposalsAttachmentCreate, ProposalClass);
-      can(Action.ProposalsAttachmentUpdate, ProposalClass);
-      can(Action.ProposalsAttachmentDelete, ProposalClass);
-    } else if (
-      user.currentGroups.some((g) => {
-        return this.accessGroups?.proposal.includes(g);
-      })
-    ) {
-      /**
-       * authenticated users belonging to any of the group listed in PROPOSAL_GROUPS
-       */
-
-      can(Action.ProposalsRead, ProposalClass);
-      can(Action.ProposalsCreate, ProposalClass);
-      can(Action.ProposalsUpdate, ProposalClass);
-      cannot(Action.ProposalsDelete, ProposalClass);
-      can(Action.ProposalsAttachmentRead, ProposalClass);
-      can(Action.ProposalsAttachmentCreate, ProposalClass);
-      can(Action.ProposalsAttachmentUpdate, ProposalClass);
-      can(Action.ProposalsAttachmentDelete, ProposalClass);
-      cannot(Action.ProposalsDatasetRead, ProposalClass);
-    } else if (user) {
-      /**
-       * authenticated users
-       */
-
-      can(Action.ProposalsRead, ProposalClass);
-      cannot(Action.ProposalsCreate, ProposalClass);
-      cannot(Action.ProposalsUpdate, ProposalClass);
-      cannot(Action.ProposalsDelete, ProposalClass);
-      can(Action.ProposalsAttachmentRead, ProposalClass);
-      cannot(Action.ProposalsAttachmentCreate, ProposalClass);
-      cannot(Action.ProposalsAttachmentUpdate, ProposalClass);
-      cannot(Action.ProposalsAttachmentDelete, ProposalClass);
-      can(Action.ProposalsDatasetRead, ProposalClass);
+        cannot(Action.ProposalsDelete, ProposalClass);
+      }
     }
     return build({
       detectSubjectType: (item) =>


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR aims to fix and improve the proposals endpoint access.

## Motivation
We have experienced some issues with the previous setup where for example if you define `ADMIN_GROUPS=admin, globalaccess` and `DELETE_GROUPS=admin, archivemanager` (admin is part of both) the `DELETE_GROUPS` condition in the `casl-ability.factory.ts` overwrites all other access that the user has as an admin.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* proposals endpoint access for admin and other logged in users

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes are only in the `casl-ability.factory.ts` where we add the improvement for proposals endpoint access management.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
