### PR TITLE
fix: add index for the attachment collection

### DIFF
--- a/src/attachments/schemas/attachment.schema.ts
+++ b/src/attachments/schemas/attachment.schema.ts
@@ -62,3 +62,5 @@ export class Attachment extends OwnableClass {
 }
 
 export const AttachmentSchema = SchemaFactory.createForClass(Attachment);
+
+AttachmentSchema.index({ "relationships.targetId": 1 });


### PR DESCRIPTION
## Description
* In `attachment.schema` mongoDB index was added on `relationships.targetId`

## Motivation
To improve attachment lookup performance

## Fixes

* Bug fixed (#X)

## Changes:

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
