### PR TITLE
feat: add global interceptor to recursively mask emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,65 +166,74 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `OIDC_SCOPE` | string | Yes | Space-separated list of info returned by the OIDC service. Example: "openid profile email". | |
 | `OIDC_SUCCESS_URL` | string | Yes | SciCat Frontend auth-callback URL. Required to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback. Must be `frontend-base-url/auth-callback` or `frontend-base-url/login` for the official SciCat frontend. | |
 | `OIDC_RETURN_URL` | string | Yes | The path segment within the SciCat Frontend to redirect to, passed as query param in `OIDC_SUCCESS_URL` and handled by frontend. Example: /datasets. | |
-| `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}_RETURN_URL` | |
-| `OIDC_ACCESS_GROUPS` | string | Yes | Functionality is still unclear. | |
-| `OIDC_ACCESS_GROUPS_PROPERTY` | string | Yes | Target field to get the access groups value from OIDC response. | |
-| `OIDC_USERINFO_MAPPING_FIELD_USERNAME` | string | Yes | Comma-separated list of fields from the OIDC response to use as the user's profile username. Example: `OIDC_USERINFO_MAPPING_FIELD_USERNAME="iss, sub"`. | "preferred_username" \|\| "name" |
-| `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME` | string | Yes | Field from the OIDC response to use as the user's profile display name. Example: `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME="preferred_username"`. | "name" |
-| `OIDC_USERINFO_MAPPING_FIELD_EMAIL` | string | Yes | Field from the OIDC response to use as the user's profile email. | "email" |
-| `OIDC_USERINFO_MAPPING_FIELD_FAMILYNAME` | string | Yes | Field from the OIDC response to use as the user's profile family name. | "family_name" |
-| `OIDC_USERINFO_MAPPING_FIELD_ID` | string | Yes | Field from the OIDC response to use as the user's profile ID. | "sub" \|\| "user_id" |
-| `OIDC_USERINFO_MAPPING_FIELD_THUMBNAILPHOTO`| string | Yes | Field from the OIDC response to use as the user's profile thumbnail photo. | "thumbnailPhoto" |
-| `OIDC_USERINFO_MAPPING_FIELD_PROVIDER` | string | Yes | Field from the OIDC response to use as the user's profile provider. | "iss" |
-| `OIDC_USERINFO_MAPPING_FIELD_GROUP` | string | Yes | Field from the OIDC response to use as the user's profile group. | "groups" |
-| `OIDC_USERQUERY_OPERATOR` | string | Yes | Specifies the operator ("or" or "and") for UserModel.findOne queries, determining the logic used to match fields like "username" or "email". Example: `UserModel.findOne({$or: {"username":"testUser", "email":"test@test.com"}})`. | "or" |
-| `OIDC_USERQUERY_FILTER` | string | Yes | Defines key-value pairs for UserModel.findOne queries, using a "key:value" format. Example: `OIDC_USERQUERY_FILTER="username:sub, email:email"`. | "username:username, email:email" |
-| `LOGBOOK_ENABLED` | string | Yes | Flag to enable/disable the Logbook endpoints. Values "yes" or "no". | "no" |
-| `LOGBOOK_BASE_URL` | string | Yes | The base URL to the Logbook API. Only required if Logbook is enabled. | |
-| `METADATA_KEYS_RETURN_LIMIT` | number | Yes | The return limit for the `/Datasets/metadataKeys` endpoint. | |
-| `METADATA_PARENT_INSTANCES_RETURN_LIMIT` | number | Yes | The return limit of Datasets to extract metadata keys from for the `/Datasets/metadataKeys` endpoint. | |
-| `MONGODB_URI` | string | | The URI for your MongoDB instance. | |
-| `OAI_PROVIDER_ROUTE` | string | Yes | URI to OAI provider, used for the `/publisheddata/:id/resync` endpoint. | |
-| `PID_PREFIX` | string | | The facility PID prefix, with trailing slash. | |
-| `PUBLIC_URL_PREFIX` | string | | The base URL to the facility Landing Page. | |
-| `PORT` | number | Yes | The port on which you want to access the app. | 3000 |
-| `RABBITMQ_ENABLED` | string | Yes | Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". | "no" |
-| `RABBITMQ_HOSTNAME` | string | Yes | The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-| `RABBITMQ_USERNAME` | string | Yes | The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-| `RABBITMQ_PASSWORD` | string | Yes | The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-| `REGISTER_DOI_URI` | string | | URI to the organization that registers the facility's DOIs. | |
-| `REGISTER_METADATA_URI` | string | | URI to the organization that registers the facility's published data metadata. | |
-| `SITE` | string | | The name of your site. | |
-| `EMAIL_TYPE` | string | Yes | The type of your email provider. Options are "smtp" or "ms365".  | "smtp" |
-| `EMAIL_FROM` | string | Yes | Email address that emails should be sent from. | |
-| `SMTP_HOST` | string | Yes | Host of SMTP server. | |
-| `SMTP_MESSAGE_FROM` | string | Yes | (Deprecated) Alternate spelling of EMAIL_FROM.| |
-| `SMTP_PORT` | number | Yes | Port of SMTP server. | 587 |
-| `SMTP_SECURE` | bool | Yes | Use encrypted SMTPS. | "no" |
-| `MS365_TENANT_ID` | string | Yes | Tenant ID for sending emails over Microsoft Graph API. | |
-| `MS365_CLIENT_ID` | string | Yes | Client ID for sending emails over Microsoft Graph API | |
-| `MS365_CLIENT_SECRET` | string | Yes | Client Secret for sending emails over Microsoft Graph API | |
-| `POLICY_PUBLICATION_SHIFT` | integer | Yes | Embargo period expressed in years. | 3 years |
-| `POLICY_RETENTION_SHIFT` | integer | Yes | Retention period (how long the facility will hold on to data) expressed in years. | -1 (indefinitely) |
-| `ELASTICSEARCH_ENABLED` | string | | Flag to enable/disable the Elasticsearch endpoints. Values "yes" or "no". | "no" |
-| `ES_HOST` | string | | Host of Elasticsearch server instance. | |
-| `ES_USERNAME` | string | Yes | Elasticsearch username. | "elastic" |
-| `ES_PASSWORD` | string | | Elasticsearch password. | |
-| `MONGODB_COLLECTION` | string | | Collection name to be mapped into specified Elasticsearch index. Used for data synchronization between MongoDB and Elasticsearch index. | |
-| `ES_MAX_RESULT` | number | | Maximum records that can be indexed into Elasticsearch. | 10000 |
-| `ES_FIELDS_LIMIT` | number | | The total number of fields in an index. | 1000 |
-| `ES_REFRESH` | string | | If set to `wait_for`, Elasticsearch will wait till data is inserted into the specified index before returning a response. | false |
-| `FRONTEND_CONFIG_FILE` | string | | The file name for frontend configuration, located in the `/src/config` directory by default. | "./src/config/frontend.config.json" |
-| `FRONTEND_THEME_FILE` | string | | The file name for frontend theme, located in the `/src/config` directory by default. | "./src/config/frontend.theme.json" |
-| `LOGGERS_CONFIG_FILE` | string | | The file name for loggers configuration, located in the project root directory. | "loggers.json" |
-| `PROPOSAL_TYPES_FILE` | string | | The file name for proposal types configuration, located in the project root directory. | "proposalTypes.json" |
-| `SWAGGER_PATH` | string | Yes | swaggerPath is the path where the swagger UI will be available. | "explorer"|
-| `MAX_FILE_UPLOAD_SIZE` | string | Yes | Maximum allowed file upload size. | "16mb"|
-| `FUNCTIONAL_ACCOUNTS_FILE` | string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
-| `JOB_CONFIGURATION_FILE` | string | Yes | Path of a job configuration file (conventionally `"jobConfig.yaml"`). If unset, jobs are disabled | |
-| `JOB_DEFAULT_STATUS_CODE` | string | Yes | Default statusCode for new jobs | "jobSubmitted" |
-| `JOB_DEFAULT_STATUS_MESSAGE` | string | Yes | Default statusMessage for new jobs | "Job submitted." |
-| `MASK_PERSONAL_INFO` | string | Yes | When enabled all emails and orcid from HTTP responses are masked. Values "yes" or "no". | "no" |
+| `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}\_RETURN_URL`| |
+|`OIDC_ACCESS_GROUPS`| string | Yes | Functionality is still unclear. | |
+|`OIDC_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from OIDC response. | |
+|`OIDC_USERINFO_MAPPING_FIELD_USERNAME`| string | Yes | Comma-separated list of fields from the OIDC response to use as the user's profile username. Example:`OIDC_USERINFO_MAPPING_FIELD_USERNAME="iss, sub"`. | "preferred_username" \|\| "name" |
+| `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME`| string | Yes | Field from the OIDC response to use as the user's profile display name. Example:`OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME="preferred_username"`. | "name" |
+| `OIDC_USERINFO_MAPPING_FIELD_EMAIL`| string | Yes | Field from the OIDC response to use as the user's profile email. | "email" |
+|`OIDC_USERINFO_MAPPING_FIELD_FAMILYNAME`| string | Yes | Field from the OIDC response to use as the user's profile family name. | "family_name" |
+|`OIDC_USERINFO_MAPPING_FIELD_ID`| string | Yes | Field from the OIDC response to use as the user's profile ID. | "sub" \|\| "user_id" |
+|`OIDC_USERINFO_MAPPING_FIELD_THUMBNAILPHOTO`| string | Yes | Field from the OIDC response to use as the user's profile thumbnail photo. | "thumbnailPhoto" |
+| `OIDC_USERINFO_MAPPING_FIELD_PROVIDER`| string | Yes | Field from the OIDC response to use as the user's profile provider. | "iss" |
+|`OIDC_USERINFO_MAPPING_FIELD_GROUP`| string | Yes | Field from the OIDC response to use as the user's profile group. | "groups" |
+|`OIDC_USERQUERY_OPERATOR`| string | Yes | Specifies the operator ("or" or "and") for UserModel.findOne queries, determining the logic used to match fields like "username" or "email". Example:`UserModel.findOne({$or: {"username":"testUser", "email":"test@test.com"}})`. | "or" |
+| `OIDC_USERQUERY_FILTER`| string | Yes | Defines key-value pairs for UserModel.findOne queries, using a "key:value" format. Example:`OIDC_USERQUERY_FILTER="username:sub, email:email"`. | "username:username, email:email" |
+| `LOGBOOK_ENABLED`| string | Yes | Flag to enable/disable the Logbook endpoints. Values "yes" or "no". | "no" |
+|`LOGBOOK_BASE_URL`| string | Yes | The base URL to the Logbook API. Only required if Logbook is enabled. | |
+|`METADATA_KEYS_RETURN_LIMIT`| number | Yes | The return limit for the`/Datasets/metadataKeys`endpoint. | |
+|`METADATA_PARENT_INSTANCES_RETURN_LIMIT`| number | Yes | The return limit of Datasets to extract metadata keys from for the`/Datasets/metadataKeys`endpoint. | |
+|`MONGODB_URI`| string | | The URI for your MongoDB instance. | |
+|`OAI_PROVIDER_ROUTE`| string | Yes | URI to OAI provider, used for the`/publisheddata/:id/resync`endpoint. | |
+|`PID_PREFIX`| string | | The facility PID prefix, with trailing slash. | |
+|`PUBLIC_URL_PREFIX`| string | | The base URL to the facility Landing Page. | | 
+|`PORT`| number | Yes | The port on which you want to access the app. | 3000 |
+|`RABBITMQ_ENABLED`| string | Yes | Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". | "no" |
+|`RABBITMQ_HOSTNAME`| string | Yes | The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+|`RABBITMQ_USERNAME`| string | Yes | The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+|`RABBITMQ_PASSWORD`| string | Yes | The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+|`RABBITMQ_PORT`| number | Yes | The port of the RabbitMQ message broker. Only required if RabbitMQ is enabled. |5672|
+|`REGISTER_DOI_URI`| string | | URI to the organization that registers the facility's DOIs. |"https://mds.test.datacite.org/doi"|
+|`REGISTER_METADATA_URI`| string | | URI to the organization that registers the facility's published data metadata. |"https://mds.test.datacite.org/metadata"|
+|`DOI_USERNAME`| string | Yes | DOI Username. |"username"|
+|`DOI_PASSWORD`| string | Yes | DOI Password. |"password"|
+|`SITE`| string | | The name of your site. | |
+|`EMAIL_TYPE`| string | Yes | The type of your email provider. Options are "smtp" or "ms365".  | "smtp" |
+|`EMAIL_FROM`| string | Yes | Email address that emails should be sent from. | |
+|`SMTP_HOST`| string | Yes | Host of SMTP server. | |
+|`SMTP_MESSAGE_FROM`| string | Yes | (Deprecated) Alternate spelling of EMAIL_FROM.| |
+|`SMTP_PORT`| number | Yes | Port of SMTP server. | 587 |
+|`SMTP_SECURE`| bool | Yes | Use encrypted SMTPS. | "no" |
+|`MS365_TENANT_ID`| string | Yes | Tenant ID for sending emails over Microsoft Graph API. | |
+|`MS365_CLIENT_ID`| string | Yes | Client ID for sending emails over Microsoft Graph API | |
+|`MS365_CLIENT_SECRET`| string | Yes | Client Secret for sending emails over Microsoft Graph API | |
+|`POLICY_PUBLICATION_SHIFT`| integer | Yes | Embargo period expressed in years. | 3 years |
+|`POLICY_RETENTION_SHIFT`| integer | Yes | Retention period (how long the facility will hold on to data) expressed in years. | -1 (indefinitely) |
+|`ELASTICSEARCH_ENABLED`| string | | Flag to enable/disable the Elasticsearch endpoints. Values "yes" or "no". | "no" |
+|`ES_HOST`| string | | Host of Elasticsearch server instance. |"https://localhost:9200"|
+|`ES_USERNAME`| string | Yes | Elasticsearch username. | "elastic" |
+|`ES_PASSWORD`| string | | Elasticsearch password. |"duo-password"|
+|`ES_PORT`| number | | Elasticsearch port. |9200|
+|`MONGODB_COLLECTION`| string | | Collection name to be mapped into specified Elasticsearch index. Used for data synchronization between MongoDB and Elasticsearch index. |"Dataset"|
+|`ES_MAX_RESULT`| number | Yes | Maximum records that can be indexed into Elasticsearch. | 10000 |
+|`ES_FIELDS_LIMIT`| number | Yes | The total number of fields in an index. | 1000 |
+|`ES_INDEX`| string | | Setting default index for the application |"dataset"|
+|`ES_REFRESH`| string | | If set to`wait_for`, Elasticsearch will wait till data is inserted into the specified index before returning a response. | false |
+|`STACK_VERSION` | string | Yes | Defines the Elasticsearch version to deploy | "8.8.2" |
+|`CLUSTER_NAME` | string | Yes | Sets the name of the Elasticsearch cluster | "es-cluster" |
+|`MEM_LIMIT` | string | Yes | Specifies the max memory for Elasticsearch container (or process) | "4G" |
+| `FRONTEND_CONFIG_FILE`| string | | The file name for frontend configuration, located in the`/src/config`directory by default. | "./src/config/frontend.config.json" |
+|`FRONTEND_THEME_FILE`| string | | The file name for frontend theme, located in the`/src/config`directory by default. | "./src/config/frontend.theme.json" |
+|`LOGGERS_CONFIG_FILE`| string | | The file name for loggers configuration, located in the project root directory. | "loggers.json" |
+|`PROPOSAL_TYPES_FILE`| string | | The file name for proposal types configuration, located in the project root directory. | "proposalTypes.json" |
+|`DATASET_TYPES_FILE`| string | | | "datasetTypes.json" |
+|`SWAGGER_PATH`| string | Yes | swaggerPath is the path where the swagger UI will be available. | "explorer"|
+|`MAX_FILE_UPLOAD_SIZE`| string | Yes | Maximum allowed file upload size. | "16mb"|
+|`FUNCTIONAL_ACCOUNTS_FILE`| string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
+|`JOB_CONFIGURATION_FILE`| string | Yes | Path of a job configuration file (conventionally`"jobConfig.yaml"`). If unset, jobs are disabled | |
+| `JOB_DEFAULT_STATUS_CODE`| string | Yes | Default statusCode for new jobs | "jobSubmitted" |
+|`JOB_DEFAULT_STATUS_MESSAGE` | string | Yes | Default statusMessage for new jobs | "Job submitted." |
+|`MASK_PERSONAL_INFO` | string | Yes | When enabled all emails and orcid from HTTP responses are masked. Values "yes" or "no". | "no" |
 
 ## Migrating from the old SciCat Backend
 

--- a/README.md
+++ b/README.md
@@ -166,74 +166,65 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `OIDC_SCOPE` | string | Yes | Space-separated list of info returned by the OIDC service. Example: "openid profile email". | |
 | `OIDC_SUCCESS_URL` | string | Yes | SciCat Frontend auth-callback URL. Required to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback. Must be `frontend-base-url/auth-callback` or `frontend-base-url/login` for the official SciCat frontend. | |
 | `OIDC_RETURN_URL` | string | Yes | The path segment within the SciCat Frontend to redirect to, passed as query param in `OIDC_SUCCESS_URL` and handled by frontend. Example: /datasets. | |
-| `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}\_RETURN_URL`| |
-|`OIDC_ACCESS_GROUPS`| string | Yes | Functionality is still unclear. | |
-|`OIDC_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from OIDC response. | |
-|`OIDC_USERINFO_MAPPING_FIELD_USERNAME`| string | Yes | Comma-separated list of fields from the OIDC response to use as the user's profile username. Example:`OIDC_USERINFO_MAPPING_FIELD_USERNAME="iss, sub"`. | "preferred_username" \|\| "name" |
-| `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME`| string | Yes | Field from the OIDC response to use as the user's profile display name. Example:`OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME="preferred_username"`. | "name" |
-| `OIDC_USERINFO_MAPPING_FIELD_EMAIL`| string | Yes | Field from the OIDC response to use as the user's profile email. | "email" |
-|`OIDC_USERINFO_MAPPING_FIELD_FAMILYNAME`| string | Yes | Field from the OIDC response to use as the user's profile family name. | "family_name" |
-|`OIDC_USERINFO_MAPPING_FIELD_ID`| string | Yes | Field from the OIDC response to use as the user's profile ID. | "sub" \|\| "user_id" |
-|`OIDC_USERINFO_MAPPING_FIELD_THUMBNAILPHOTO`| string | Yes | Field from the OIDC response to use as the user's profile thumbnail photo. | "thumbnailPhoto" |
-| `OIDC_USERINFO_MAPPING_FIELD_PROVIDER`| string | Yes | Field from the OIDC response to use as the user's profile provider. | "iss" |
-|`OIDC_USERINFO_MAPPING_FIELD_GROUP`| string | Yes | Field from the OIDC response to use as the user's profile group. | "groups" |
-|`OIDC_USERQUERY_OPERATOR`| string | Yes | Specifies the operator ("or" or "and") for UserModel.findOne queries, determining the logic used to match fields like "username" or "email". Example:`UserModel.findOne({$or: {"username":"testUser", "email":"test@test.com"}})`. | "or" |
-| `OIDC_USERQUERY_FILTER`| string | Yes | Defines key-value pairs for UserModel.findOne queries, using a "key:value" format. Example:`OIDC_USERQUERY_FILTER="username:sub, email:email"`. | "username:username, email:email" |
-| `LOGBOOK_ENABLED`| string | Yes | Flag to enable/disable the Logbook endpoints. Values "yes" or "no". | "no" |
-|`LOGBOOK_BASE_URL`| string | Yes | The base URL to the Logbook API. Only required if Logbook is enabled. | |
-|`METADATA_KEYS_RETURN_LIMIT`| number | Yes | The return limit for the`/Datasets/metadataKeys`endpoint. | |
-|`METADATA_PARENT_INSTANCES_RETURN_LIMIT`| number | Yes | The return limit of Datasets to extract metadata keys from for the`/Datasets/metadataKeys`endpoint. | |
-|`MONGODB_URI`| string | | The URI for your MongoDB instance. | |
-|`OAI_PROVIDER_ROUTE`| string | Yes | URI to OAI provider, used for the`/publisheddata/:id/resync`endpoint. | |
-|`PID_PREFIX`| string | | The facility PID prefix, with trailing slash. | |
-|`PUBLIC_URL_PREFIX`| string | | The base URL to the facility Landing Page. | | 
-|`PORT`| number | Yes | The port on which you want to access the app. | 3000 |
-|`RABBITMQ_ENABLED`| string | Yes | Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". | "no" |
-|`RABBITMQ_HOSTNAME`| string | Yes | The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-|`RABBITMQ_USERNAME`| string | Yes | The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-|`RABBITMQ_PASSWORD`| string | Yes | The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
-|`RABBITMQ_PORT`| number | Yes | The port of the RabbitMQ message broker. Only required if RabbitMQ is enabled. |5672|
-|`REGISTER_DOI_URI`| string | | URI to the organization that registers the facility's DOIs. |"https://mds.test.datacite.org/doi"|
-|`REGISTER_METADATA_URI`| string | | URI to the organization that registers the facility's published data metadata. |"https://mds.test.datacite.org/metadata"|
-|`DOI_USERNAME`| string | Yes | DOI Username. |"username"|
-|`DOI_PASSWORD`| string | Yes | DOI Password. |"password"|
-|`SITE`| string | | The name of your site. | |
-|`EMAIL_TYPE`| string | Yes | The type of your email provider. Options are "smtp" or "ms365".  | "smtp" |
-|`EMAIL_FROM`| string | Yes | Email address that emails should be sent from. | |
-|`SMTP_HOST`| string | Yes | Host of SMTP server. | |
-|`SMTP_MESSAGE_FROM`| string | Yes | (Deprecated) Alternate spelling of EMAIL_FROM.| |
-|`SMTP_PORT`| number | Yes | Port of SMTP server. | 587 |
-|`SMTP_SECURE`| bool | Yes | Use encrypted SMTPS. | "no" |
-|`MS365_TENANT_ID`| string | Yes | Tenant ID for sending emails over Microsoft Graph API. | |
-|`MS365_CLIENT_ID`| string | Yes | Client ID for sending emails over Microsoft Graph API | |
-|`MS365_CLIENT_SECRET`| string | Yes | Client Secret for sending emails over Microsoft Graph API | |
-|`POLICY_PUBLICATION_SHIFT`| integer | Yes | Embargo period expressed in years. | 3 years |
-|`POLICY_RETENTION_SHIFT`| integer | Yes | Retention period (how long the facility will hold on to data) expressed in years. | -1 (indefinitely) |
-|`ELASTICSEARCH_ENABLED`| string | | Flag to enable/disable the Elasticsearch endpoints. Values "yes" or "no". | "no" |
-|`ES_HOST`| string | | Host of Elasticsearch server instance. |"https://localhost:9200"|
-|`ES_USERNAME`| string | Yes | Elasticsearch username. | "elastic" |
-|`ES_PASSWORD`| string | | Elasticsearch password. |"duo-password"|
-|`ES_PORT`| number | | Elasticsearch port. |9200|
-|`MONGODB_COLLECTION`| string | | Collection name to be mapped into specified Elasticsearch index. Used for data synchronization between MongoDB and Elasticsearch index. |"Dataset"|
-|`ES_MAX_RESULT`| number | Yes | Maximum records that can be indexed into Elasticsearch. | 10000 |
-|`ES_FIELDS_LIMIT`| number | Yes | The total number of fields in an index. | 1000 |
-|`ES_INDEX`| string | | Setting default index for the application |"dataset"|
-|`ES_REFRESH`| string | | If set to`wait_for`, Elasticsearch will wait till data is inserted into the specified index before returning a response. | false |
-|`STACK_VERSION` | string | Yes | Defines the Elasticsearch version to deploy | "8.8.2" |
-|`CLUSTER_NAME` | string | Yes | Sets the name of the Elasticsearch cluster | "es-cluster" |
-|`MEM_LIMIT` | string | Yes | Specifies the max memory for Elasticsearch container (or process) | "4G" |
-| `FRONTEND_CONFIG_FILE`| string | | The file name for frontend configuration, located in the`/src/config`directory by default. | "./src/config/frontend.config.json" |
-|`FRONTEND_THEME_FILE`| string | | The file name for frontend theme, located in the`/src/config`directory by default. | "./src/config/frontend.theme.json" |
-|`LOGGERS_CONFIG_FILE`| string | | The file name for loggers configuration, located in the project root directory. | "loggers.json" |
-|`PROPOSAL_TYPES_FILE`| string | | The file name for proposal types configuration, located in the project root directory. | "proposalTypes.json" |
-|`DATASET_TYPES_FILE`| string | | | "datasetTypes.json" |
-|`SWAGGER_PATH`| string | Yes | swaggerPath is the path where the swagger UI will be available. | "explorer"|
-|`MAX_FILE_UPLOAD_SIZE`| string | Yes | Maximum allowed file upload size. | "16mb"|
-|`FUNCTIONAL_ACCOUNTS_FILE`| string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
-|`JOB_CONFIGURATION_FILE`| string | Yes | Path of a job configuration file (conventionally`"jobConfig.yaml"`). If unset, jobs are disabled | |
-| `JOB_DEFAULT_STATUS_CODE`| string | Yes | Default statusCode for new jobs | "jobSubmitted" |
-|`JOB_DEFAULT_STATUS_MESSAGE` | string | Yes | Default statusMessage for new jobs | "Job submitted." |
-
+| `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}_RETURN_URL` | |
+| `OIDC_ACCESS_GROUPS` | string | Yes | Functionality is still unclear. | |
+| `OIDC_ACCESS_GROUPS_PROPERTY` | string | Yes | Target field to get the access groups value from OIDC response. | |
+| `OIDC_USERINFO_MAPPING_FIELD_USERNAME` | string | Yes | Comma-separated list of fields from the OIDC response to use as the user's profile username. Example: `OIDC_USERINFO_MAPPING_FIELD_USERNAME="iss, sub"`. | "preferred_username" \|\| "name" |
+| `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME` | string | Yes | Field from the OIDC response to use as the user's profile display name. Example: `OIDC_USERINFO_MAPPING_FIELD_DISPLAYNAME="preferred_username"`. | "name" |
+| `OIDC_USERINFO_MAPPING_FIELD_EMAIL` | string | Yes | Field from the OIDC response to use as the user's profile email. | "email" |
+| `OIDC_USERINFO_MAPPING_FIELD_FAMILYNAME` | string | Yes | Field from the OIDC response to use as the user's profile family name. | "family_name" |
+| `OIDC_USERINFO_MAPPING_FIELD_ID` | string | Yes | Field from the OIDC response to use as the user's profile ID. | "sub" \|\| "user_id" |
+| `OIDC_USERINFO_MAPPING_FIELD_THUMBNAILPHOTO`| string | Yes | Field from the OIDC response to use as the user's profile thumbnail photo. | "thumbnailPhoto" |
+| `OIDC_USERINFO_MAPPING_FIELD_PROVIDER` | string | Yes | Field from the OIDC response to use as the user's profile provider. | "iss" |
+| `OIDC_USERINFO_MAPPING_FIELD_GROUP` | string | Yes | Field from the OIDC response to use as the user's profile group. | "groups" |
+| `OIDC_USERQUERY_OPERATOR` | string | Yes | Specifies the operator ("or" or "and") for UserModel.findOne queries, determining the logic used to match fields like "username" or "email". Example: `UserModel.findOne({$or: {"username":"testUser", "email":"test@test.com"}})`. | "or" |
+| `OIDC_USERQUERY_FILTER` | string | Yes | Defines key-value pairs for UserModel.findOne queries, using a "key:value" format. Example: `OIDC_USERQUERY_FILTER="username:sub, email:email"`. | "username:username, email:email" |
+| `LOGBOOK_ENABLED` | string | Yes | Flag to enable/disable the Logbook endpoints. Values "yes" or "no". | "no" |
+| `LOGBOOK_BASE_URL` | string | Yes | The base URL to the Logbook API. Only required if Logbook is enabled. | |
+| `METADATA_KEYS_RETURN_LIMIT` | number | Yes | The return limit for the `/Datasets/metadataKeys` endpoint. | |
+| `METADATA_PARENT_INSTANCES_RETURN_LIMIT` | number | Yes | The return limit of Datasets to extract metadata keys from for the `/Datasets/metadataKeys` endpoint. | |
+| `MONGODB_URI` | string | | The URI for your MongoDB instance. | |
+| `OAI_PROVIDER_ROUTE` | string | Yes | URI to OAI provider, used for the `/publisheddata/:id/resync` endpoint. | |
+| `PID_PREFIX` | string | | The facility PID prefix, with trailing slash. | |
+| `PUBLIC_URL_PREFIX` | string | | The base URL to the facility Landing Page. | |
+| `PORT` | number | Yes | The port on which you want to access the app. | 3000 |
+| `RABBITMQ_ENABLED` | string | Yes | Flag to enable/disable RabbitMQ consumer. Values "yes" or "no". | "no" |
+| `RABBITMQ_HOSTNAME` | string | Yes | The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+| `RABBITMQ_USERNAME` | string | Yes | The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+| `RABBITMQ_PASSWORD` | string | Yes | The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled. | |
+| `REGISTER_DOI_URI` | string | | URI to the organization that registers the facility's DOIs. | |
+| `REGISTER_METADATA_URI` | string | | URI to the organization that registers the facility's published data metadata. | |
+| `SITE` | string | | The name of your site. | |
+| `EMAIL_TYPE` | string | Yes | The type of your email provider. Options are "smtp" or "ms365".  | "smtp" |
+| `EMAIL_FROM` | string | Yes | Email address that emails should be sent from. | |
+| `SMTP_HOST` | string | Yes | Host of SMTP server. | |
+| `SMTP_MESSAGE_FROM` | string | Yes | (Deprecated) Alternate spelling of EMAIL_FROM.| |
+| `SMTP_PORT` | number | Yes | Port of SMTP server. | 587 |
+| `SMTP_SECURE` | bool | Yes | Use encrypted SMTPS. | "no" |
+| `MS365_TENANT_ID` | string | Yes | Tenant ID for sending emails over Microsoft Graph API. | |
+| `MS365_CLIENT_ID` | string | Yes | Client ID for sending emails over Microsoft Graph API | |
+| `MS365_CLIENT_SECRET` | string | Yes | Client Secret for sending emails over Microsoft Graph API | |
+| `POLICY_PUBLICATION_SHIFT` | integer | Yes | Embargo period expressed in years. | 3 years |
+| `POLICY_RETENTION_SHIFT` | integer | Yes | Retention period (how long the facility will hold on to data) expressed in years. | -1 (indefinitely) |
+| `ELASTICSEARCH_ENABLED` | string | | Flag to enable/disable the Elasticsearch endpoints. Values "yes" or "no". | "no" |
+| `ES_HOST` | string | | Host of Elasticsearch server instance. | |
+| `ES_USERNAME` | string | Yes | Elasticsearch username. | "elastic" |
+| `ES_PASSWORD` | string | | Elasticsearch password. | |
+| `MONGODB_COLLECTION` | string | | Collection name to be mapped into specified Elasticsearch index. Used for data synchronization between MongoDB and Elasticsearch index. | |
+| `ES_MAX_RESULT` | number | | Maximum records that can be indexed into Elasticsearch. | 10000 |
+| `ES_FIELDS_LIMIT` | number | | The total number of fields in an index. | 1000 |
+| `ES_REFRESH` | string | | If set to `wait_for`, Elasticsearch will wait till data is inserted into the specified index before returning a response. | false |
+| `FRONTEND_CONFIG_FILE` | string | | The file name for frontend configuration, located in the `/src/config` directory by default. | "./src/config/frontend.config.json" |
+| `FRONTEND_THEME_FILE` | string | | The file name for frontend theme, located in the `/src/config` directory by default. | "./src/config/frontend.theme.json" |
+| `LOGGERS_CONFIG_FILE` | string | | The file name for loggers configuration, located in the project root directory. | "loggers.json" |
+| `PROPOSAL_TYPES_FILE` | string | | The file name for proposal types configuration, located in the project root directory. | "proposalTypes.json" |
+| `SWAGGER_PATH` | string | Yes | swaggerPath is the path where the swagger UI will be available. | "explorer"|
+| `MAX_FILE_UPLOAD_SIZE` | string | Yes | Maximum allowed file upload size. | "16mb"|
+| `FUNCTIONAL_ACCOUNTS_FILE` | string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
+| `JOB_CONFIGURATION_FILE` | string | Yes | Path of a job configuration file (conventionally `"jobConfig.yaml"`). If unset, jobs are disabled | |
+| `JOB_DEFAULT_STATUS_CODE` | string | Yes | Default statusCode for new jobs | "jobSubmitted" |
+| `JOB_DEFAULT_STATUS_MESSAGE` | string | Yes | Default statusMessage for new jobs | "Job submitted." |
+| `MASK_PERSONAL_INFO` | string | Yes | When enabled all emails and orcid from HTTP responses are masked. Values "yes" or "no". | "no" |
 
 ## Migrating from the old SciCat Backend
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,6 +42,7 @@ import { HttpModule, HttpService } from "@nestjs/axios";
 import { MSGraphMailTransport } from "./common/graph-mail";
 import { TransportType } from "@nestjs-modules/mailer/dist/interfaces/mailer-options.interface";
 import { MetricsModule } from "./metrics/metrics.module";
+import { MaskSensitiveDataInterceptorModule } from "./common/interceptors/mask-sensitive-data.interceptor";
 
 @Module({
   imports: [
@@ -155,6 +156,10 @@ import { MetricsModule } from "./metrics/metrics.module";
     UsersModule,
     AdminModule,
     HealthModule,
+    ConditionalModule.registerWhen(
+      MaskSensitiveDataInterceptorModule,
+      (env: NodeJS.ProcessEnv) => env.MASK_PERSONAL_INFO === "yes",
+    ),
   ],
   controllers: [],
   providers: [

--- a/src/common/interceptors/mask-sensitive-data.interceptor.ts
+++ b/src/common/interceptors/mask-sensitive-data.interceptor.ts
@@ -12,7 +12,6 @@ import { map, Observable } from "rxjs";
 
 @Injectable()
 class MaskSensitiveDataInterceptor implements NestInterceptor {
-
   private maskSensitiveData<T>(data: T, ownEmail: string): T {
     if (Array.isArray(data)) {
       let allArrays = true;
@@ -29,9 +28,7 @@ class MaskSensitiveDataInterceptor implements NestInterceptor {
     if (!this.isPlainObject(data)) return data as T;
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(data)) {
-      if (
-        this.isToMaskEmail(value, ownEmail)
-      ) {
+      if (this.isToMaskEmail(value, ownEmail)) {
         result[key] = this.maskValue();
         continue;
       }

--- a/src/common/interceptors/mask-sensitive-data.interceptor.ts
+++ b/src/common/interceptors/mask-sensitive-data.interceptor.ts
@@ -1,0 +1,99 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Module,
+  NestInterceptor,
+} from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { instanceToPlain } from "class-transformer";
+import { isEmail } from "class-validator";
+import { map, Observable } from "rxjs";
+
+@Injectable()
+class MaskSensitiveDataInterceptor implements NestInterceptor {
+  private readonly keysToMask = ["orcidOfOwner"];
+
+  private maskSensitiveData<T>(data: T, ownEmail: string): T {
+    if (Array.isArray(data)) {
+      let allArrays = true;
+      const maskedData = data.map((item) => {
+        if (this.isToMaskEmail(item, ownEmail)) {
+          return this.maskValue();
+        }
+        allArrays = false;
+        return this.maskSensitiveData(item, ownEmail);
+      });
+      return ((allArrays && [...new Set(maskedData)]) || maskedData) as T;
+    }
+
+    if (!this.isPlainObject(data)) return data as T;
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (
+        this.keysToMask.includes(key) ||
+        this.isToMaskEmail(value, ownEmail)
+      ) {
+        result[key] = this.maskValue();
+        continue;
+      }
+      result[key] = this.maskSensitiveData(value, ownEmail);
+    }
+    return result as T;
+  }
+
+  private isPlainObject(input: unknown): input is Record<string, unknown> {
+    return (
+      typeof input === "object" &&
+      input !== null &&
+      !Array.isArray(input) &&
+      Object.getPrototypeOf(input) === Object.prototype
+    );
+  }
+
+  private isToMaskEmail(value: string | unknown, ownEmail: string) {
+    return typeof value === "string" && isEmail(value) && value !== ownEmail;
+  }
+
+  private maskValue(): string {
+    return "";
+  }
+
+  private toPlain<T extends { toObject?: () => object }>(value: T): T {
+    if (Array.isArray(value)) {
+      return value.map(this.toPlain) as unknown as T;
+    }
+
+    if (value && typeof value === "object") {
+      if (typeof value.toObject === "function") {
+        return value.toObject() as T;
+      }
+
+      try {
+        return instanceToPlain(value) as T;
+      } catch {
+        return value;
+      }
+    }
+
+    return value;
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    const ownEmail = request.user?.email;
+    return next.handle().pipe(
+      map((data) => {
+        const plainData = this.toPlain(data);
+        return this.maskSensitiveData(plainData, ownEmail);
+      }),
+    );
+  }
+}
+
+@Module({
+  providers: [
+    { provide: APP_INTERCEPTOR, useClass: MaskSensitiveDataInterceptor },
+  ],
+})
+export class MaskSensitiveDataInterceptorModule {}

--- a/src/common/interceptors/mask-sensitive-data.interceptor.ts
+++ b/src/common/interceptors/mask-sensitive-data.interceptor.ts
@@ -12,7 +12,6 @@ import { map, Observable } from "rxjs";
 
 @Injectable()
 class MaskSensitiveDataInterceptor implements NestInterceptor {
-  private readonly keysToMask = ["orcidOfOwner"];
 
   private maskSensitiveData<T>(data: T, ownEmail: string): T {
     if (Array.isArray(data)) {
@@ -31,7 +30,6 @@ class MaskSensitiveDataInterceptor implements NestInterceptor {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(data)) {
       if (
-        this.keysToMask.includes(key) ||
         this.isToMaskEmail(value, ownEmail)
       ) {
         result[key] = this.maskValue();
@@ -56,7 +54,7 @@ class MaskSensitiveDataInterceptor implements NestInterceptor {
   }
 
   private maskValue(): string {
-    return "";
+    return "*****";
   }
 
   private toPlain<T extends { toObject?: () => object }>(value: T): T {

--- a/test/jest-e2e-tests/accessGroups.e2e-spec.ts
+++ b/test/jest-e2e-tests/accessGroups.e2e-spec.ts
@@ -1,9 +1,8 @@
 import request from "supertest";
-import { Test } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
-import { AppModule } from "src/app.module";
 import { UsersService } from "src/users/users.service";
 import { User } from "src/users/schemas/user.schema";
+import { createTestingModuleFactory } from "./utlis";
 
 describe("Access groups test", () => {
   let app: INestApplication;
@@ -11,9 +10,7 @@ describe("Access groups test", () => {
   let u: User;
 
   beforeAll(async () => {
-    const moduleFixture = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    const moduleFixture = await createTestingModuleFactory().compile();
 
     app = moduleFixture.createNestApplication();
     app.setGlobalPrefix("api/v3");

--- a/test/jest-e2e-tests/datasets.e2e-spec.ts
+++ b/test/jest-e2e-tests/datasets.e2e-spec.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import { INestApplication } from "@nestjs/common";
 import { getConnectionToken } from "@nestjs/mongoose";
 import { Connection } from "mongoose";
-import { faker } from "@faker-js/faker/.";
+import { faker } from "@faker-js/faker";
 import { createTestingModuleFactory } from "./utlis";
 
 describe("HidePersonalInfo test", () => {

--- a/test/jest-e2e-tests/datasets.e2e-spec.ts
+++ b/test/jest-e2e-tests/datasets.e2e-spec.ts
@@ -63,9 +63,9 @@ describe("HidePersonalInfo test", () => {
       .expect(201)
       .then(
         (result) => (
-          expect(result.body.contactEmail).toEqual(""),
+          expect(result.body.contactEmail).toEqual("*****"),
           expect(result.body.ownerEmail).toEqual("admin@scicat.project"),
-          expect(result.body.accessGroups).toEqual([""])
+          expect(result.body.accessGroups).toEqual(["*****"])
         ),
       );
 
@@ -75,9 +75,9 @@ describe("HidePersonalInfo test", () => {
       .expect(200)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual(""),
+          expect(result.body[0].contactEmail).toEqual("*****"),
           expect(result.body[0].ownerEmail).toEqual("admin@scicat.project"),
-          expect(result.body[0].accessGroups).toEqual([""])
+          expect(result.body[0].accessGroups).toEqual(["*****"])
         ),
       );
   });
@@ -114,9 +114,9 @@ describe("HidePersonalInfo test", () => {
       .expect(200)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual(""),
+          expect(result.body[0].contactEmail).toEqual("*****"),
           expect(result.body[0].ownerEmail).toEqual("admin@scicat.project"),
-          expect(result.body[0].accessGroups).toEqual([""])
+          expect(result.body[0].accessGroups).toEqual(["*****"])
         ),
       );
   });
@@ -138,9 +138,9 @@ describe("HidePersonalInfo test", () => {
       .expect(200)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual(""),
-          expect(result.body[0].ownerEmail).toEqual(""),
-          expect(result.body[0].accessGroups).toEqual([""])
+          expect(result.body[0].contactEmail).toEqual("*****"),
+          expect(result.body[0].ownerEmail).toEqual("*****"),
+          expect(result.body[0].accessGroups).toEqual(["*****"])
         ),
       );
   });

--- a/test/jest-e2e-tests/datasets.e2e-spec.ts
+++ b/test/jest-e2e-tests/datasets.e2e-spec.ts
@@ -1,0 +1,150 @@
+import request from "supertest";
+import { Test } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import { AppModule } from "src/app.module";
+import { getConnectionToken } from "@nestjs/mongoose";
+import { Connection } from "mongoose";
+import { faker } from "@faker-js/faker/.";
+
+describe("HidePersonalInfo test", () => {
+  let app: INestApplication;
+  let mongoConnection: Connection;
+  let token: string;
+  process.env.MASK_PERSONAL_INFO = "yes";
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix("api/v3");
+    await app.init();
+    mongoConnection = await app.get<Promise<Connection>>(getConnectionToken());
+  });
+
+  beforeEach(async () => {
+    await request(app.getHttpServer())
+      .post("/api/v3/auth/login")
+      .send({ username: "admin", password: "27f5fd86ae68fe740eef42b8bbd1d7d5" })
+      .set("Accept", "application/json")
+      .expect(201)
+      .then((response) => (token = response.body.access_token));
+  });
+
+  afterAll(async () => {
+    if (mongoConnection.db) await mongoConnection.db.dropDatabase();
+    await app.close();
+  });
+
+  it("Check if users info are hidden from dataset", async () => {
+    const dataset = {
+      inputDatasets: [faker.string.uuid()],
+      usedSoftware: [faker.internet.url()],
+      isPublished: true,
+      owner: faker.internet.username(),
+      contactEmail: faker.internet.email(),
+      sourceFolder: faker.system.directoryPath(),
+      creationTime: faker.date.past(),
+      ownerGroup: faker.string.alphanumeric(6),
+      datasetName: `${faker.string.alphanumeric(20)} ${faker.string.sample()}`,
+      type: "raw",
+      principalInvestigator: faker.internet.username(),
+      investigator: faker.internet.username(),
+      ownerEmail: "admin@scicat.project",
+      orcidOfOwner: faker.string.alphanumeric(6),
+      creationLocation: faker.location.city(),
+      sampleId: "sample123",
+      accessGroups: [faker.internet.email(), faker.internet.email()],
+    };
+
+    await request(app.getHttpServer())
+      .post("/api/v3/datasets")
+      .send(dataset)
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(201)
+      .then(
+        (result) => (
+          expect(result.body.contactEmail).toEqual(""),
+          expect(result.body.ownerEmail).toEqual("admin@scicat.project"),
+          expect(result.body.accessGroups).toEqual([""])
+        ),
+      );
+
+    await request(app.getHttpServer())
+      .get("/api/v3/datasets")
+      .auth(token, { type: "bearer" })
+      .expect(200)
+      .then(
+        (result) => (
+          expect(result.body[0].contactEmail).toEqual(""),
+          expect(result.body[0].ownerEmail).toEqual("admin@scicat.project"),
+          expect(result.body[0].accessGroups).toEqual([""])
+        ),
+      );
+  });
+
+  it("Check if users info are hidden from dataset recursively", async () => {
+    const sample = {
+      owner: faker.internet.username(),
+      description: faker.lorem.sentence(),
+      sampleCharacteristics: {
+        chemical_formula: {
+          value: faker.science.chemicalElement,
+          unit: faker.science.unit,
+        },
+      },
+      ownerGroup: faker.string.alphanumeric(6),
+      accessGroups: [
+        faker.string.alphanumeric(6),
+        faker.string.alphanumeric(6),
+      ],
+      sampleId: "sample123",
+    };
+
+    await request(app.getHttpServer())
+      .post("/api/v3/samples")
+      .send(sample)
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get(`/api/v3/samples/${sample.sampleId}/datasets`)
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(200)
+      .then(
+        (result) => (
+          expect(result.body[0].contactEmail).toEqual(""),
+          expect(result.body[0].ownerEmail).toEqual("admin@scicat.project"),
+          expect(result.body[0].accessGroups).toEqual([""])
+        ),
+      );
+  });
+
+  it("Check that users info are not hidden for UserController", async () => {
+    await request(app.getHttpServer())
+      .get("/api/v3/users/my/self")
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(200)
+      .then((result) =>
+        expect(result.body.email).toEqual("admin@scicat.project"),
+      );
+  });
+
+  it("Check that everything is masked when no auth", async () => {
+    await request(app.getHttpServer())
+      .get("/api/v3/datasets")
+      .expect(200)
+      .then(
+        (result) => (
+          expect(result.body[0].contactEmail).toEqual(""),
+          expect(result.body[0].ownerEmail).toEqual(""),
+          expect(result.body[0].accessGroups).toEqual([""])
+        ),
+      );
+  });
+});

--- a/test/jest-e2e-tests/datasets.e2e-spec.ts
+++ b/test/jest-e2e-tests/datasets.e2e-spec.ts
@@ -1,10 +1,9 @@
 import request from "supertest";
-import { Test } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
-import { AppModule } from "src/app.module";
 import { getConnectionToken } from "@nestjs/mongoose";
 import { Connection } from "mongoose";
 import { faker } from "@faker-js/faker/.";
+import { createTestingModuleFactory } from "./utlis";
 
 describe("HidePersonalInfo test", () => {
   let app: INestApplication;
@@ -13,9 +12,7 @@ describe("HidePersonalInfo test", () => {
   process.env.MASK_PERSONAL_INFO = "yes";
 
   beforeAll(async () => {
-    const moduleFixture = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+    const moduleFixture = await createTestingModuleFactory().compile();
 
     app = moduleFixture.createNestApplication();
     app.setGlobalPrefix("api/v3");

--- a/test/jest-e2e-tests/utlis.ts
+++ b/test/jest-e2e-tests/utlis.ts
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker/.";
+import { faker } from "@faker-js/faker";
 import { ConfigService } from "@nestjs/config";
 import { Test } from "@nestjs/testing";
 import { AppModule } from "src/app.module";

--- a/test/jest-e2e-tests/utlis.ts
+++ b/test/jest-e2e-tests/utlis.ts
@@ -1,0 +1,23 @@
+import { faker } from "@faker-js/faker/.";
+import { ConfigService } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+import { AppModule } from "src/app.module";
+
+export class ConfigServiceDbMock extends ConfigService {
+  get(key: string) {
+    if (key === "mongodbUri") {
+      const uriParts = super.get(key).split("/");
+      uriParts[3] = `scicat-e2e-test-${faker.number.int()}`;
+      return uriParts.join("/");
+    }
+    return super.get(key);
+  }
+}
+
+export function createTestingModuleFactory(ConfigMock = ConfigServiceDbMock) {
+  return Test.createTestingModule({
+    imports: [AppModule],
+  })
+    .overrideProvider(ConfigService)
+    .useClass(ConfigMock);
+}


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
We have the requirement to hide emails for GDPR. This PR recursively removes emails from all fields (as well as orcid) from HTTP responses

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* global interceptor to recursively mask emails
* activated only when env is set
* email is not masked when === user's email

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
