### PR TITLE
fix: error for jobs with invalid type in v3

### DIFF
--- a/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
+++ b/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
@@ -14,7 +14,7 @@ import { DatasetListDto } from "../dto/dataset-list.dto";
 import { UsersService } from "src/users/users.service";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { JobConfigService } from "src/config/job-config/jobconfig.service";
-import { JobsControllerUtils } from "src/jobs/jobs.controller.utils"
+import { JobsControllerUtils } from "src/jobs/jobs.controller.utils";
 
 interface JobParams {
   datasetList: DatasetListDto[];
@@ -44,7 +44,9 @@ export class CreateJobV3MappingInterceptor implements NestInterceptor {
     const dtoV3 = request.body as CreateJobDtoV3;
     const requestUser = request.user as JWTUser;
 
-    const jobConfig = this.jobsControllerUtils.getJobTypeConfiguration(dtoV3.type);
+    const jobConfig = this.jobsControllerUtils.getJobTypeConfiguration(
+      dtoV3.type,
+    );
     if (jobConfig) {
       // ensure datasetList comes from a top level field in the dto and not from jobParams
       if (

--- a/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
+++ b/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
@@ -14,6 +14,7 @@ import { DatasetListDto } from "../dto/dataset-list.dto";
 import { UsersService } from "src/users/users.service";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { JobConfigService } from "src/config/job-config/jobconfig.service";
+import { JobsControllerUtils } from "src/jobs/jobs.controller.utils"
 
 interface JobParams {
   datasetList: DatasetListDto[];
@@ -32,6 +33,7 @@ export class CreateJobV3MappingInterceptor implements NestInterceptor {
     @Inject(UsersService) readonly usersService: UsersService,
     @Inject(DatasetsService) readonly datasetsService: DatasetsService,
     @Inject(JobConfigService) readonly jobConfigService: JobConfigService,
+    private readonly jobsControllerUtils: JobsControllerUtils,
   ) {}
 
   async intercept(
@@ -42,7 +44,7 @@ export class CreateJobV3MappingInterceptor implements NestInterceptor {
     const dtoV3 = request.body as CreateJobDtoV3;
     const requestUser = request.user as JWTUser;
 
-    const jobConfig = this.jobConfigService.get(dtoV3.type);
+    const jobConfig = this.jobsControllerUtils.getJobTypeConfiguration(dtoV3.type);
     if (jobConfig) {
       // ensure datasetList comes from a top level field in the dto and not from jobParams
       if (

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -118,6 +118,46 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       });
   });
 
+  it("0021: Add via /api/v3 a new job with invalid type, as a user from ADMIN_GROUPS, which should fail", async () => {
+    const newJob = {
+      type: "invalid_type",
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal("Invalid job type: invalid_type");
+      });
+  });
+
+  it("0022: Add via /api/v3 a new job without type, as a user from ADMIN_GROUPS, which should fail", async () => {
+    const newJob = {
+      datasetList: [{ pid: datasetPid1, files: [] }],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal("Invalid job type: undefined");
+      });
+  });
+
   it("0030: Add via /api/v3 a new job without datasetList, as a user from ADMIN_GROUPS, which should fail", async () => {
     const newJob = {
       ...jobOwnerAccess,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Fixes error handling for creation of jobs with no type or with invalid type, in V3.

## Motivation
<!-- Background on use case, changes needed -->
See https://github.com/SciCatProject/scicat-backend-next/issues/2171

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->
We were checking the type, but were not throwing the error when it was invalid.

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->
* updated `create-job-v3-mapping.interceptor`
* added relevant tests

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [x] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
https://github.com/SciCatProject/documentation/pull/86
