### PR TITLE
fix: remove 409 on same lifecycle patch

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -36,7 +36,6 @@ import {
 import { ClassConstructor, plainToInstance } from "class-transformer";
 import { validate, ValidationError, ValidatorOptions } from "class-validator";
 import { Request } from "express";
-import { isEqual } from "lodash";
 import { MongoError } from "mongodb";
 import { UpdateQuery } from "mongoose";
 import { AttachmentsService } from "src/attachments/attachments.service";
@@ -1662,22 +1661,6 @@ export class DatasetsController {
       ...currentLifecycle,
       ...updateDatasetLifecycleDto,
     };
-    const sameValue = Object.entries(updatedLifecycle).every(([key, value]) => {
-      const foundValue =
-        currentLifecycle?.[key as keyof PartialUpdateDatasetLifecycleDto];
-      if (foundValue instanceof Date) {
-        return value === foundValue.toISOString();
-      } else if (typeof foundValue === "object" && typeof value === "object") {
-        return isEqual(value, foundValue);
-      }
-      return value === foundValue;
-    });
-
-    if (sameValue) {
-      throw new ConflictException(
-        `dataset: ${foundDataset.pid} already has the same lifecycle`,
-      );
-    }
     foundDataset.datasetlifecycle = updatedLifecycle;
 
     const datasetInstance =

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -909,32 +909,6 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
     if (!foundDataset) {
       throw new NotFoundException(`dataset with pid ${pid} not found`);
     }
-    const sameValue = Object.entries(updateDatasetLifecycleDto).every(
-      ([key, value]) => {
-        const foundValue =
-          foundDataset.datasetlifecycle?.[
-            key as keyof PartialUpdateDatasetLifecycleDto
-          ];
-        if (foundValue instanceof Date) {
-          return value === foundValue.toISOString();
-        } else if (
-          typeof foundValue === "object" &&
-          typeof value === "object"
-        ) {
-          return isEqual(value, foundValue);
-        } else if (value === null) {
-          // resetting property to default
-          return false;
-        }
-        return value === foundValue;
-      },
-    );
-
-    if (sameValue) {
-      throw new ConflictException(
-        `dataset: ${foundDataset.pid} already has the same lifecycle`,
-      );
-    }
     await this.checkPermissionsForDatasetExtended(
       request,
       foundDataset,

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -89,8 +89,6 @@ import { LifecycleClass } from "./schemas/lifecycle.schema";
 import { RelationshipClass } from "./schemas/relationship.schema";
 import { TechniqueClass } from "./schemas/technique.schema";
 
-import { isEqual } from "lodash";
-
 @ApiBearerAuth()
 @ApiExtraModels(
   CreateDatasetDto,

--- a/test/DatasetLifecycle.js
+++ b/test/DatasetLifecycle.js
@@ -616,29 +616,6 @@ describe("0500: DatasetLifecycle: Test facet and filter queries", () => {
         });
     });
 
-    it("0110: shouldn't  be able to update lifecycle of dataset if it's not changing the body of datasetlifecycle", () => {
-      const updatedDataset = {
-        archivable: true,
-      };
-
-      return request(appUrl)
-        .patch(
-          `/api/v3/datasets/${encodeURIComponent(rawDatasetWithMetadataPid)}/datasetlifecycle`,
-        )
-        .send(updatedDataset)
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.ConflictStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.a("object"); //dataset: ${foundDataset.pid} already has the same lifecycle
-          res.body.should.have
-            .property("message")
-            .and.equal(
-              `dataset: ${rawDatasetWithMetadataPid} already has the same lifecycle`,
-            );
-        });
-    });
-
     it("0111: should  be able to update lifecycle of dataset as a user from admin groups", () => {
       const updatedDataset = {
         publishable: true,

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -1510,30 +1510,6 @@ describe("2500: Datasets v4 tests", () => {
         });
     });
 
-    it("0620: shouldn't  be able to update lifecycle of dataset if it's not changing the body of datasetlifecycle", () => {
-      const updatedDataset = {
-        archivable: true,
-      };
-
-      return request(appUrl)
-        .patch(
-          `/api/v4/datasets/${encodeURIComponent(derivedDatasetMinPid)}/datasetlifecycle`,
-        )
-        .set("Content-type", "application/merge-patch+json")
-        .send(updatedDataset)
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.ConflictStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.a("object"); //dataset: ${foundDataset.pid} already has the same lifecycle
-          res.body.should.have
-            .property("message")
-            .and.equal(
-              `dataset: ${derivedDatasetMinPid} already has the same lifecycle`,
-            );
-        });
-    });
-
     it("0621: should  be able to update lifecycle of dataset as a user from admin groups", () => {
       const updatedDataset = {
         publishable: true,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Our archivers people reported 409 makes the lifecycle update more complex. They need to add additional logic on subsequent patches and ues try catch. This PR removes the 409 and runs the same logic on already done updates.

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* avoid 409 on same content

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
