### PR TITLE
fix: error handling in PublishedData v3 register endpoint

### DIFF
--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -708,7 +708,7 @@ export class PublishedDataController {
           handleAxiosRequestError(err, "PublishedDataController.register");
           throw new HttpException(
             `Error occurred: ${err}`,
-            err.response.status || HttpStatus.FAILED_DEPENDENCY,
+            err.response?.status || HttpStatus.FAILED_DEPENDENCY,
           );
         }
 


### PR DESCRIPTION
## Description
Tiny fix for a bug in error handling for one branch of the `api/v3/publisheddata/:id/register` endpoint. Prevents a 500 error in the BE and instead returns the correct error message returned from the DataCite API.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated
