### PR TITLE
chore: refactor findOneComplete to avoid dup

### DIFF
--- a/src/common/interfaces/common.interface.ts
+++ b/src/common/interfaces/common.interface.ts
@@ -35,9 +35,9 @@ export interface IProposalAcceptedMessage {
 }
 
 export interface ILimitsFilter {
-  limit: number;
-  skip: number;
-  order: string;
+  limit?: number;
+  skip?: number;
+  order?: string;
 }
 
 export interface IFilters<T, Y = null> {
@@ -69,14 +69,17 @@ export interface IDatafileFilter {
   type?: string;
 }
 
-export type IFiltersV4<T, Y = null, Z = null> = IFilters<T, Y> & {
+export type IFiltersV4<T, Y = null, Z = null> = Pick<
+  IFilters<T, Y>,
+  "where"
+> & {
   include?: Z;
   limits?: ILimitsV4<T>;
   fields?: (keyof Y)[];
 };
 
 export interface ILimitsV4<T = null> {
-  limit: number;
-  skip: number;
-  sort: Record<keyof T, "asc" | "desc">;
+  limit?: number;
+  skip?: number;
+  sort?: Record<keyof T, "asc" | "desc">;
 }

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -55,6 +55,8 @@ export interface IDatasetRelation {
   scope: IDatasetScopes;
 }
 
-export type IDatasetFiltersV4<T, Y = null> = IFiltersV4<T, Y> & {
-  include?: DatasetLookupKeysEnum[] | IDatasetRelation[];
-};
+export type IDatasetFiltersV4<T, Y = null> = IFiltersV4<
+  T,
+  Y,
+  DatasetLookupKeysEnum[] | IDatasetRelation[]
+>;

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -853,6 +853,7 @@ describe("2500: Datasets v4 tests", () => {
           skip: 0,
           sort: {
             datasetName: "asc",
+            createdAt: "asc",
           },
         },
       };


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Avoids logic duplication and reuses existing more generic function

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* refactor findOneComplete

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
