### PR TITLE
fix: respect the `PublishedData.status` when creating with /api/v3

### DIFF
--- a/src/published-data/published-data.controller.spec.ts
+++ b/src/published-data/published-data.controller.spec.ts
@@ -5,6 +5,7 @@ import { AttachmentsService } from "src/attachments/attachments.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { ProposalsService } from "src/proposals/proposals.service";
+import { PublishedDataStatus } from "./interfaces/published-data.interface";
 import { PublishedDataController } from "./published-data.controller";
 import { PublishedDataService } from "./published-data.service";
 
@@ -42,5 +43,46 @@ describe("PublishedDataController", () => {
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  it("should result in PublishedDataStatus.REGISTERED", () => {
+    expect(controller.convertObsoleteStatusToCurrent("registered")).toEqual(
+      PublishedDataStatus.REGISTERED,
+    );
+  });
+  it("should result in PublishedDataStatus.PRIVATE", () => {
+    expect(
+      controller.convertObsoleteStatusToCurrent("pending_registration"),
+    ).toEqual(PublishedDataStatus.PRIVATE);
+  });
+  it("should result in PublishedDataStatus.PRIVATE", () => {
+    expect(controller.convertObsoleteStatusToCurrent("invalid_status")).toEqual(
+      PublishedDataStatus.PRIVATE,
+    );
+  });
+  it("should result in 'pending_registration'", () => {
+    expect(controller.convertCurrentStatusToObsolete(undefined)).toEqual(
+      "pending_registration",
+    );
+  });
+  it("should result in 'pending_registration'", () => {
+    expect(
+      controller.convertCurrentStatusToObsolete(PublishedDataStatus.PRIVATE),
+    ).toEqual("pending_registration");
+  });
+  it("should result in 'pending_registration'", () => {
+    expect(
+      controller.convertCurrentStatusToObsolete(PublishedDataStatus.PUBLIC),
+    ).toEqual("pending_registration");
+  });
+  it("should result in 'registered'", () => {
+    expect(
+      controller.convertCurrentStatusToObsolete(PublishedDataStatus.REGISTERED),
+    ).toEqual("registered");
+  });
+  it("should result in 'registered'", () => {
+    expect(
+      controller.convertCurrentStatusToObsolete(PublishedDataStatus.AMENDED),
+    ).toEqual("registered");
   });
 });

--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -1,25 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpService } from "@nestjs/axios";
 import {
-  Controller,
-  Get,
-  Post,
+  BadRequestException,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
-  UseGuards,
-  Query,
+  Get,
   HttpException,
   HttpStatus,
+  Logger,
   NotFoundException,
-  BadRequestException,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
 } from "@nestjs/common";
-import { PublishedDataService } from "./published-data.service";
-import { CreatePublishedDataDto } from "./dto/create-published-data.dto";
-import {
-  PartialUpdatePublishedDataDto,
-  UpdatePublishedDataDto,
-} from "./dto/update-published-data.dto";
+import { ConfigService } from "@nestjs/config";
 import {
   ApiBearerAuth,
   ApiBody,
@@ -29,43 +26,47 @@ import {
   ApiResponse,
   ApiTags,
 } from "@nestjs/swagger";
-import { PoliciesGuard } from "src/casl/guards/policies.guard";
-import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
-import { AppAbility } from "src/casl/casl-ability.factory";
+import { FilterQuery, QueryOptions } from "mongoose";
+import { firstValueFrom } from "rxjs";
+import { AttachmentsService } from "src/attachments/attachments.service";
+import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 import { Action } from "src/casl/action.enum";
+import { AppAbility } from "src/casl/casl-ability.factory";
+import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
+import { PoliciesGuard } from "src/casl/guards/policies.guard";
+import { FilterPipe } from "src/common/pipes/filter.pipe";
+import { handleAxiosRequestError } from "src/common/utils";
+import { DatasetsService } from "src/datasets/datasets.service";
+import { DatasetClass } from "src/datasets/schemas/dataset.schema";
+import { ProposalsService } from "src/proposals/proposals.service";
+import { CreatePublishedDataDto } from "./dto/create-published-data.dto";
+import { CreatePublishedDataV4Dto } from "./dto/create-published-data.v4.dto";
+import { PublishedDataObsoleteDto } from "./dto/published-data.obsolete.dto";
 import {
-  PublishedData,
-  PublishedDataDocument,
-} from "./schemas/published-data.schema";
+  PartialUpdatePublishedDataDto,
+  UpdatePublishedDataDto,
+} from "./dto/update-published-data.dto";
 import {
-  ICount,
+  PartialUpdatePublishedDataV4Dto,
+  UpdatePublishedDataV4Dto,
+} from "./dto/update-published-data.v4.dto";
+import {
   FormPopulateData,
+  ICount,
   IPublishedDataFilters,
   IRegister,
   PublishedDataStatus,
 } from "./interfaces/published-data.interface";
-import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 import {
   IdToDoiPipe,
   RegisteredFilterPipe,
   RegisteredPipe,
 } from "./pipes/registered.pipe";
-import { FilterQuery, QueryOptions } from "mongoose";
-import { DatasetsService } from "src/datasets/datasets.service";
-import { ProposalsService } from "src/proposals/proposals.service";
-import { AttachmentsService } from "src/attachments/attachments.service";
-import { HttpService } from "@nestjs/axios";
-import { ConfigService } from "@nestjs/config";
-import { firstValueFrom } from "rxjs";
-import { handleAxiosRequestError } from "src/common/utils";
-import { DatasetClass } from "src/datasets/schemas/dataset.schema";
-import { CreatePublishedDataV4Dto } from "./dto/create-published-data.v4.dto";
+import { PublishedDataService } from "./published-data.service";
 import {
-  PartialUpdatePublishedDataV4Dto,
-  UpdatePublishedDataV4Dto,
-} from "./dto/update-published-data.v4.dto";
-import { PublishedDataObsoleteDto } from "./dto/published-data.obsolete.dto";
-import { FilterPipe } from "src/common/pipes/filter.pipe";
+  PublishedData,
+  PublishedDataDocument,
+} from "./schemas/published-data.schema";
 
 @ApiBearerAuth()
 @ApiTags("published data")
@@ -79,6 +80,34 @@ export class PublishedDataController {
     private readonly proposalsService: ProposalsService,
     private readonly publishedDataService: PublishedDataService,
   ) {}
+
+  convertObsoleteStatusToCurrent(obsoleteStatus: string): PublishedDataStatus {
+    switch (obsoleteStatus) {
+      case "registered":
+        return PublishedDataStatus.REGISTERED;
+      case "pending_registration":
+        return PublishedDataStatus.PRIVATE;
+      default:
+        Logger.error(
+          `Unknown PublishedData.status '${obsoleteStatus}' defaulting to PublishedDataStatus.PRIVATE`,
+        );
+        return PublishedDataStatus.PRIVATE;
+    }
+  }
+
+  convertCurrentStatusToObsolete(
+    currentStatus: PublishedDataStatus | undefined,
+  ): string {
+    switch (currentStatus) {
+      case undefined:
+      case PublishedDataStatus.PRIVATE:
+      case PublishedDataStatus.PUBLIC:
+        return "pending_registration";
+      case PublishedDataStatus.REGISTERED:
+      case PublishedDataStatus.AMENDED:
+        return "registered";
+    }
+  }
 
   convertObsoleteToCurrentSchema(
     inputObsoletePublishedData:
@@ -168,11 +197,13 @@ export class PublishedDataController {
       propertiesModifier.datasetPids = inputObsoletePublishedData.pidArray;
     }
 
-    if ("status" in inputObsoletePublishedData) {
-      propertiesModifier.status =
-        inputObsoletePublishedData.status === "registered"
-          ? "registered"
-          : "private";
+    if (
+      "status" in inputObsoletePublishedData &&
+      typeof inputObsoletePublishedData.status === "string"
+    ) {
+      propertiesModifier.status = this.convertObsoleteStatusToCurrent(
+        inputObsoletePublishedData.status,
+      );
     }
 
     let outputPublishedData:
@@ -183,19 +214,16 @@ export class PublishedDataController {
     if (inputObsoletePublishedData instanceof CreatePublishedDataDto) {
       outputPublishedData = {
         ...propertiesModifier,
-        status: PublishedDataStatus.PRIVATE,
       } as CreatePublishedDataV4Dto;
     } else if (inputObsoletePublishedData instanceof UpdatePublishedDataDto) {
       outputPublishedData = {
         ...propertiesModifier,
-        status: inputObsoletePublishedData.status,
       } as UpdatePublishedDataV4Dto;
     } else if (
       inputObsoletePublishedData instanceof PartialUpdatePublishedDataDto
     ) {
       outputPublishedData = {
         ...propertiesModifier,
-        status: inputObsoletePublishedData.status,
       } as PartialUpdatePublishedDataV4Dto;
     }
 
@@ -241,10 +269,7 @@ export class PublishedDataController {
         inputPublishedData.metadata?.relatedIdentifiers as object[]
       )?.map((identifier: any) => identifier.relatedIdentifier),
       pidArray: inputPublishedData.datasetPids,
-      status:
-        inputPublishedData.status === "registered"
-          ? "registered"
-          : "pending_registration",
+      status: this.convertCurrentStatusToObsolete(inputPublishedData.status),
     };
 
     return propertiesModifier;


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Improve the mapping between v3 and v4 `status` and no longer default to `PublishedDataStatus.PRIVATE`

## Motivation
<!-- Background on use case, changes needed -->
Importing PublishedData that are already registered from other repositories 

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->
Creating a PublishedData with the v3 api was not respecting the `status` in the DTO and always creating the instance with
`PublishedDataStatus.PRIVATE`

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
