### PR TITLE
fix: pass URL directly to include qwargs

### DIFF
--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -5,16 +5,9 @@ if (!MONGODB_URI) {
   throw new Error("Environment variable MONGODB_URI not set");
 }
 
-const lastSlashIndex = MONGODB_URI.lastIndexOf("/");
-// NOTE: Get the database url and name from the MONGODB_URI and use them instead of defining new variables.
-const DATABASE_URL = MONGODB_URI.substring(0, lastSlashIndex);
-const DATABASE_NAME = MONGODB_URI.substring(lastSlashIndex + 1);
-
 const config = {
   mongodb: {
-    url: DATABASE_URL,
-
-    databaseName: DATABASE_NAME,
+    url: MONGODB_URI,
 
     options: {
       useNewUrlParser: true, // removes a deprecation warning when connecting


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Splitting the URL to get URI and DB drops all qwargs after the DB, e.g. TLS options, authSource etc. This allows to keep them

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* avoid splitting the DB URI in migration

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
