### PR TITLE
chore: refactor pipelines for syntax compatible with mongo <5

### DIFF
--- a/src/datasets/datasets-access.service.ts
+++ b/src/datasets/datasets-access.service.ts
@@ -149,8 +149,9 @@ export class DatasetsAccessService {
     if (access) {
       const { canViewAny, canViewAccess, canViewOwner } = access;
       if (!canViewAny) {
+        let pipeline: PipelineStage.Lookup["$lookup"]["pipeline"];
         if (canViewAccess) {
-          fieldValue.$lookup.pipeline = [
+          pipeline = [
             {
               $match: {
                 $or: [
@@ -163,7 +164,7 @@ export class DatasetsAccessService {
             },
           ];
         } else if (canViewOwner) {
-          fieldValue.$lookup.pipeline = [
+          pipeline = [
             {
               $match: {
                 ownerGroup: { $in: currentUser.currentGroups },
@@ -171,7 +172,7 @@ export class DatasetsAccessService {
             },
           ];
         } else {
-          fieldValue.$lookup.pipeline = [
+          pipeline = [
             {
               $match: {
                 isPublished: true,
@@ -179,6 +180,8 @@ export class DatasetsAccessService {
             },
           ];
         }
+        fieldValue.$lookup.pipeline = fieldValue.$lookup.pipeline ?? [];
+        fieldValue.$lookup.pipeline.push(...pipeline);
       }
     }
   }

--- a/src/datasets/types/dataset-lookup.ts
+++ b/src/datasets/types/dataset-lookup.ts
@@ -28,33 +28,35 @@ export const DATASET_LOOKUP_FIELDS: Record<
   instruments: {
     $lookup: {
       from: "Instrument",
-      localField: "instrumentIds",
-      foreignField: "pid",
       as: "",
+      let: { instrumentIds: { $ifNull: ["$instrumentIds", []] } },
+      pipeline: [{ $match: { $expr: { $in: ["$pid", "$$instrumentIds"] } } }],
     },
   },
   proposals: {
     $lookup: {
       from: "Proposal",
-      localField: "proposalIds",
-      foreignField: "proposalId",
       as: "",
+      let: { proposalIds: { $ifNull: ["$proposalIds", []] } },
+      pipeline: [
+        { $match: { $expr: { $in: ["$proposalId", "$$proposalIds"] } } },
+      ],
     },
   },
   origdatablocks: {
     $lookup: {
       from: "OrigDatablock",
-      localField: "pid",
-      foreignField: "datasetId",
       as: "",
+      let: { pid: "$pid" },
+      pipeline: [{ $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }],
     },
   },
   datablocks: {
     $lookup: {
       from: "Datablock",
-      localField: "pid",
-      foreignField: "datasetId",
       as: "",
+      let: { pid: "$pid" },
+      pipeline: [{ $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }],
     },
   },
   attachments: {
@@ -87,9 +89,9 @@ export const DATASET_LOOKUP_FIELDS: Record<
   samples: {
     $lookup: {
       from: "Sample",
-      localField: "sampleIds",
-      foreignField: "sampleId",
       as: "",
+      let: { sampleIds: { $ifNull: ["$sampleIds", []] } },
+      pipeline: [{ $match: { $expr: { $in: ["$sampleId", "$$sampleIds"] } } }],
     },
   },
   all: undefined,

--- a/src/jobs/types/job-lookup.ts
+++ b/src/jobs/types/job-lookup.ts
@@ -74,19 +74,21 @@ export const JOB_LOOKUP_FIELDS: Record<
           {
             $lookup: {
               from: "OrigDatablock",
-              localField: "pid",
-              foreignField: "datasetId",
               as: "origdatablocks",
-              pipeline: [],
+              let: { pid: "$pid" },
+              pipeline: [
+                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }
+              ]
             },
           },
           {
             $lookup: {
               from: "Datablock",
-              localField: "pid",
-              foreignField: "datasetId",
               as: "datablocks",
-              pipeline: [],
+              let: { pid: "$pid" },
+              pipeline: [
+                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }
+              ]
             },
           },
           {

--- a/src/jobs/types/job-lookup.ts
+++ b/src/jobs/types/job-lookup.ts
@@ -33,10 +33,8 @@ export const JOB_LOOKUP_FIELDS: Record<
       $lookup: {
         from: "Dataset",
         as: "datasets",
-        let: { datasetIds: "$datasetIds" },
-        pipeline: [
-          { $match: { $expr: { $in: ["$pid", "$$datasetIds"] } } }
-        ]
+        let: { datasetIds: { $ifNull: ["$datasetIds", []] } },
+        pipeline: [{ $match: { $expr: { $in: ["$pid", "$$datasetIds"] } } }],
       },
     },
   ],
@@ -62,14 +60,14 @@ export const JOB_LOOKUP_FIELDS: Record<
       $lookup: {
         from: "Dataset",
         as: "datasetDetails",
-        let: { datasetIds: "$datasetIds" },
+        let: { datasetIds: { $ifNull: ["$datasetIds", []] } },
         pipeline: [
           {
             $match: {
               $expr: {
-                $in: ["$pid", "$$datasetIds"]
-              }
-            }
+                $in: ["$pid", "$$datasetIds"],
+              },
+            },
           },
           {
             $lookup: {
@@ -77,8 +75,8 @@ export const JOB_LOOKUP_FIELDS: Record<
               as: "origdatablocks",
               let: { pid: "$pid" },
               pipeline: [
-                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }
-              ]
+                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } },
+              ],
             },
           },
           {
@@ -87,8 +85,8 @@ export const JOB_LOOKUP_FIELDS: Record<
               as: "datablocks",
               let: { pid: "$pid" },
               pipeline: [
-                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } }
-              ]
+                { $match: { $expr: { $eq: ["$datasetId", "$$pid"] } } },
+              ],
             },
           },
           {

--- a/src/jobs/types/job-lookup.ts
+++ b/src/jobs/types/job-lookup.ts
@@ -32,10 +32,11 @@ export const JOB_LOOKUP_FIELDS: Record<
     {
       $lookup: {
         from: "Dataset",
-        localField: "datasetIds",
-        foreignField: "pid",
         as: "datasets",
-        pipeline: [],
+        let: { datasetIds: "$datasetIds" },
+        pipeline: [
+          { $match: { $expr: { $in: ["$pid", "$$datasetIds"] } } }
+        ]
       },
     },
   ],
@@ -60,10 +61,16 @@ export const JOB_LOOKUP_FIELDS: Record<
     {
       $lookup: {
         from: "Dataset",
-        localField: "datasetIds",
-        foreignField: "pid",
         as: "datasetDetails",
+        let: { datasetIds: "$datasetIds" },
         pipeline: [
+          {
+            $match: {
+              $expr: {
+                $in: ["$pid", "$$datasetIds"]
+              }
+            }
+          },
           {
             $lookup: {
               from: "OrigDatablock",

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -167,9 +167,9 @@ export class OrigDatablocksService {
     pipeline.push({
       $lookup: {
         from: "Dataset",
-        localField: "datasetId",
-        foreignField: "pid",
         as: "dataset_temp",
+        let: { datasetId: "$datasetId" },
+        pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
       },
     });
 
@@ -280,9 +280,9 @@ export class OrigDatablocksService {
       {
         $lookup: {
           from: "Dataset",
-          localField: "datasetId",
-          foreignField: "pid",
           as: "Dataset",
+          let: { datasetId: "$datasetId" },
+          pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
         },
       },
       {

--- a/src/origdatablocks/types/origdatablock-lookup.ts
+++ b/src/origdatablocks/types/origdatablock-lookup.ts
@@ -14,9 +14,9 @@ export const ORIGDATABLOCK_LOOKUP_FIELDS: Record<
   dataset: {
     $lookup: {
       from: "Dataset",
-      localField: "datasetId",
-      foreignField: "pid",
       as: "",
+      let: { datasetId: "$datasetId" },
+      pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
     },
   },
   all: undefined,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The current aggregation pipelines used simplified mongo>5 syntax which allowed both "joining" on foreignKeys and have pipelines. This is not allowed in mongo <5, thus this change avoids using foreignKeys and does everything in match stage.

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* all foreignKeys removed
* add match pipeline to replace join logic
* avoid overriding the pipeline when adding permissions

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
