### PR TITLE
feat: allow url actions to ignore errors from remote calls

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1206,6 +1206,22 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
 
 /**
+ * Type guard for Record<string, string>
+ * @param obj
+ * @returns
+ */
+export function isStringRecord(obj: unknown): obj is Record<string, string> {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+  const rec = obj as Record<string, string>;
+
+  return Object.keys(rec).every(
+    (key) => typeof key === "string" && typeof rec[key] === "string",
+  );
+}
+
+/**
  * Helper function to generate HttpExceptions
  * @param message error message
  * @param status HTTP error code. Default: 400 BAD_REQUEST

--- a/src/config/job-config/actions/urlaction/urlaction.interface.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.interface.ts
@@ -1,3 +1,4 @@
+import { isStringRecord } from "src/common/utils";
 export const actionType = "url";
 
 export interface URLJobActionOptions {
@@ -6,6 +7,7 @@ export interface URLJobActionOptions {
   method?: "GET" | "POST" | "PUT" | "DELETE";
   headers?: Record<string, string>;
   body?: unknown;
+  ignoreErrors?: boolean;
 }
 
 /**
@@ -24,22 +26,7 @@ export function isURLJobActionOptions(
     typeof opts.url === "string" &&
     (opts.method === undefined ||
       ["GET", "POST", "PUT", "DELETE"].includes(opts.method)) &&
-    (opts.headers === undefined || isStringRecord(opts.headers))
-  );
-}
-
-/**
- * Type guard for Record<string, string>
- * @param obj
- * @returns
- */
-function isStringRecord(obj: unknown): obj is Record<string, string> {
-  if (typeof obj !== "object" || obj === null) {
-    return false;
-  }
-  const rec = obj as Record<string, string>;
-
-  return Object.keys(rec).every(
-    (key) => typeof key === "string" && typeof rec[key] === "string",
+    (opts.headers === undefined || isStringRecord(opts.headers)) &&
+    (opts.ignoreErrors === undefined || typeof opts.ignoreErrors === "boolean")
   );
 }

--- a/src/config/job-config/actions/urlaction/urlaction.spec.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.spec.ts
@@ -39,7 +39,7 @@ describe("URLJobAction", () => {
       text: jest.fn().mockResolvedValue("OK"),
     });
 
-    const context = { request: job, job, env: process.env };
+    const context = { request: job, job, env: process.env, datasets: [] };
     await action.perform(context);
 
     expect(global.fetch).toHaveBeenCalledWith(
@@ -63,10 +63,39 @@ describe("URLJobAction", () => {
       text: jest.fn().mockResolvedValue("Internal Server Error"),
     });
 
-    const context = { request: job, job, env: process.env };
+    const context = { request: job, job, env: process.env, datasets: [] };
     await expect(action.perform(context)).rejects.toThrow(
-      "Got response: Internal Server Error",
+      "A remote URL call failed with response: Internal Server Error",
     );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:3000/api/v3/health?jobid=12345",
+      {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          Authorization: "Bearer TheAuthToken",
+        },
+        body: "This is the body.",
+      },
+    );
+  });
+
+  it("should ignore errors if the ignoreError is set", async () => {
+    const job = { id: "12345" } as JobClass;
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: jest.fn().mockResolvedValue("Internal Server Error"),
+    });
+
+    const actionIgnore = new URLJobAction<CreateJobDto>({
+      ...config,
+      ignoreErrors: true,
+    });
+
+    const context = { request: job, job, env: process.env, datasets: [] };
+    await expect(actionIgnore.perform(context)).resolves.toBeUndefined();
 
     expect(global.fetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/v3/health?jobid=12345",

--- a/src/config/job-config/actions/urlaction/urlaction.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.ts
@@ -15,6 +15,7 @@ export class URLJobAction<T extends JobDto> implements JobAction<T> {
   private method = "GET";
   private headerTemplates?: Record<string, TemplateJob> = {};
   private bodyTemplate?: TemplateJob;
+  private ignoreErrors = false;
 
   getActionType(): string {
     return actionType;
@@ -37,20 +38,27 @@ export class URLJobAction<T extends JobDto> implements JobAction<T> {
       body: this.bodyTemplate ? this.bodyTemplate(context) : undefined,
     });
 
-    Logger.log(
-      `(Job ${context.job.id}) Request for ${url} returned ${response.status}`,
-      "URLAction",
-    );
-    if (!response.ok) {
-      const text = await response.text();
-      Logger.error(`(Job ${context.job.id}) Got response: ${text}`);
-      throw new HttpException(
-        {
-          status: response.status,
-          message: `Got response: ${text}`,
-        },
-        response.status,
+    const text = await response.text();
+    if (response.ok) {
+      Logger.log(
+        `(Job ${context.job.id}) Request for ${url} returned ${response.status}. Response: ${text}`,
+        "URLAction",
       );
+    } else {
+      Logger.error(
+        `(Job ${context.job.id}) Request for ${url} returned ${response.status}. Response: ${text}`,
+        "URLAction",
+      );
+
+      if (!this.ignoreErrors) {
+        throw new HttpException(
+          {
+            status: response.status,
+            message: `A remote URL call failed with response: ${text}`,
+          },
+          response.status,
+        );
+      }
     }
   }
 
@@ -84,6 +92,10 @@ export class URLJobAction<T extends JobDto> implements JobAction<T> {
 
     if (options["body"]) {
       this.bodyTemplate = compileJobTemplate(options["body"]);
+    }
+
+    if (options["ignoreErrors"]) {
+      this.ignoreErrors = options.ignoreErrors;
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Short description of the pull request -->
This improves the 'url' job action. Previously, errors from the remote url would always be passed through to the client calling scicat. This adds an `ignoreErrors` option for cases where a failure of the url isn't critical for handling the job.

All errors are logged. This PR also improves logging by logging the response body, which can help debugging.


## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* allow url actions to ignore errors from remote calls

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
