### PR TITLE
fix: change hardcoded admin to ADMIN_GROUPS

### DIFF
--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -569,8 +569,7 @@ export class JobsControllerUtils {
     );
     // check if the user can create this job
     const canCreate =
-      (ability.can(Action.JobCreateAny, JobClass) &&
-        user.currentGroups.includes("admin")) ||
+      ability.can(Action.JobCreateAny, JobClass) ||
       (ability.can(Action.JobCreateAny, JobClass) && datasetsNoAccess == 0) ||
       ability.can(Action.JobCreateOwner, jobInstance) ||
       (ability.can(Action.JobCreateConfiguration, jobInstance) &&

--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -569,7 +569,8 @@ export class JobsControllerUtils {
     );
     // check if the user can create this job
     const canCreate =
-      ability.can(Action.JobCreateAny, JobClass) ||
+      (ability.can(Action.JobCreateAny, JobClass) &&
+        user.currentGroups.some((g) => this.accessGroups?.admin.includes(g))) ||
       (ability.can(Action.JobCreateAny, JobClass) && datasetsNoAccess == 0) ||
       ability.can(Action.JobCreateOwner, jobInstance) ||
       (ability.can(Action.JobCreateConfiguration, jobInstance) &&

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -266,7 +266,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("jobParams").that.deep.equals({});
         res.body.should.have
           .property("emailJobInitiator")
-          .to.be.equal(TestData.Accounts["admin"]["email"]);
+          .to.be.equal(TestData.Accounts["adminIngestor"]["email"]);
         res.body.should.not.have.property("ownerUser");
         res.body.should.not.have.property("executionTime");
         encodedJobOwnedByAdmin = encodeURIComponent(res.body["id"]);
@@ -970,7 +970,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(7);
+        res.body.should.be.an("array").to.have.lengthOf(8);
       });
   });
 
@@ -1037,7 +1037,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(6);
+        res.body.should.be.an("array").to.have.lengthOf(7);
       });
   });
 

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -239,40 +239,6 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       });
   });
 
-  it("0055: Add via /api/v3 an anonymous job with custom jobStatusMessage, as a user from ADMIN_GROUPS: adminingestor", async () => {
-    jobCreateDtoByAdmin = {
-      ...jobDatasetPublic,
-      datasetList: [{ pid: datasetPid1, files: [] }],
-      jobStatusMessage: "custom_message"
-    };
-
-    return request(appUrl)
-      .post("/api/v3/Jobs")
-      .send(jobCreateDtoByAdmin)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        res.body.should.have.property("id");
-        res.body.should.have.property("creationTime");
-        res.body.should.have.property("type").and.be.string;
-        res.body.should.have
-          .property("jobStatusMessage")
-          .to.be.equal("custom_message");
-        res.body.should.have
-          .property("datasetList")
-          .that.deep.equals(jobCreateDtoByAdmin.datasetList);
-        res.body.should.have.property("jobParams").that.deep.equals({});
-        res.body.should.have
-          .property("emailJobInitiator")
-          .to.be.equal(TestData.Accounts["adminIngestor"]["email"]);
-        res.body.should.not.have.property("ownerUser");
-        res.body.should.not.have.property("executionTime");
-        encodedJobOwnedByAdmin = encodeURIComponent(res.body["id"]);
-      });
-  });
-
   it("0060: Get via /api/v4 the anonymous job as a user from ADMIN_GROUPS, which now belongs to that logged in admin user", async () => {
     return request(appUrl)
       .get(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
@@ -970,7 +936,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(8);
+        res.body.should.be.an("array").to.have.lengthOf(7);
       });
   });
 
@@ -1037,7 +1003,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(7);
+        res.body.should.be.an("array").to.have.lengthOf(6);
       });
   });
 
@@ -1263,6 +1229,41 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("ownerGroup").to.be.equal("group5");
       });
   });
+
+  it("0440: Add via /api/v3 an anonymous job with custom jobStatusMessage, as a user from ADMIN_GROUPS: adminingestor", async () => {
+    jobCreateDtoByAdmin = {
+      ...jobDatasetPublic,
+      datasetList: [{ pid: datasetPid1, files: [] }],
+      jobStatusMessage: "custom_message"
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(jobCreateDtoByAdmin)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("id");
+        res.body.should.have.property("creationTime");
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have
+          .property("jobStatusMessage")
+          .to.be.equal("custom_message");
+        res.body.should.have
+          .property("datasetList")
+          .that.deep.equals(jobCreateDtoByAdmin.datasetList);
+        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have
+          .property("emailJobInitiator")
+          .to.be.equal(TestData.Accounts["adminIngestor"]["email"]);
+        res.body.should.not.have.property("ownerUser");
+        res.body.should.not.have.property("executionTime");
+        encodedJobOwnedByAdmin = encodeURIComponent(res.body["id"]);
+      });
+  });
+
   describe("1192: Jobs: Test datasetDetails backwards Compatibility", () => {
     before(async () => {
       const newJob = {

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -239,6 +239,40 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       });
   });
 
+  it("0055: Add via /api/v3 an anonymous job with custom jobStatusMessage, as a user from ADMIN_GROUPS: adminingestor", async () => {
+    jobCreateDtoByAdmin = {
+      ...jobDatasetPublic,
+      datasetList: [{ pid: datasetPid1, files: [] }],
+      jobStatusMessage: "custom_message"
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(jobCreateDtoByAdmin)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("id");
+        res.body.should.have.property("creationTime");
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have
+          .property("jobStatusMessage")
+          .to.be.equal("custom_message");
+        res.body.should.have
+          .property("datasetList")
+          .that.deep.equals(jobCreateDtoByAdmin.datasetList);
+        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have
+          .property("emailJobInitiator")
+          .to.be.equal(TestData.Accounts["admin"]["email"]);
+        res.body.should.not.have.property("ownerUser");
+        res.body.should.not.have.property("executionTime");
+        encodedJobOwnedByAdmin = encodeURIComponent(res.body["id"]);
+      });
+  });
+
   it("0060: Get via /api/v4 the anonymous job as a user from ADMIN_GROUPS, which now belongs to that logged in admin user", async () => {
     return request(appUrl)
       .get(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The permissions check checked against hardcoded "admin" is now replaced with ADMIN_GROUPS. This made all non "admin" users but are in the ADMIN_GROUPS env var receive 403 on job creation

## Fixes

* replace "admin" with ADMIN_GROUPS

## Tests included

- [x] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
