### PR TITLE
fix: convert all object fields from obsolete to generic history

### DIFF
--- a/src/datasets/utils/history.util.spec.ts
+++ b/src/datasets/utils/history.util.spec.ts
@@ -37,6 +37,64 @@ describe("History Utility Functions", () => {
           retrieveIntegrityCheck: false,
         },
       },
+      scientificMetadata: {
+        currentValue: {
+          runNumber: 484,
+          scanAxis0Name: ["phi"],
+          scanName: "run0484_diamond_D2FG",
+          scan_parameters: {
+            expected_total_number_of_steps: 7,
+            name: ["phi2"],
+            scan_name: "run0484_diamond_D2FG",
+          },
+          scan_readbacks: [
+            [73.369784942746],
+            [73.36755732624964],
+            [73.3680595489329],
+            [73.36857790677979],
+            [73.3690102872549],
+            [73.36911958727225],
+            [73.37012839122846],
+          ],
+          scan_readbacks_raw: [[], [], [], [], [], [], []],
+          scan_step_info: [
+            {
+              step_number: 1,
+            },
+            {
+              step_number: 2,
+            },
+          ],
+        },
+        previousValue: {
+          runNumber: 0,
+          scanAxis0Name: ["phi"],
+          scanName: "run0484_diamond_D2FG",
+          scan_parameters: {
+            expected_total_number_of_steps: 7,
+            name: ["phi"],
+            scan_name: "run0484_diamond_D2FG",
+          },
+          scan_readbacks: [
+            [73.369784942746],
+            [73.36755732624964],
+            [73.3680595489329],
+            [73.36857790677979],
+            [73.3690102872549],
+            [73.36911958727225],
+            [73.37012839122846],
+          ],
+          scan_readbacks_raw: [[], [], [], [], [], [], []],
+          scan_step_info: [
+            {
+              step_number: 1,
+            },
+            {
+              step_number: 2,
+            },
+          ],
+        },
+      },
       _id: "",
     };
     const documentId = "pid123";
@@ -44,7 +102,6 @@ describe("History Utility Functions", () => {
       obsoleteHistory,
       documentId,
     );
-
     expect(genericHistory).toEqual({
       subsystem: "Dataset",
       documentId: "pid123",
@@ -53,17 +110,22 @@ describe("History Utility Functions", () => {
       timestamp: new Date("2023-10-01T12:00:00Z"),
       before: {
         isPublished: false,
-        datasetlifecycle: {
-          publishedOn: undefined,
-          archivable: false,
+        datasetlifecycle: { archivable: false, publishedOn: undefined },
+        scientificMetadata: {
+          runNumber: 0,
+          scan_parameters: { name: ["phi"] },
         },
       },
       after: {
-        datasetlifecycle: {
-          publishedOn: new Date("2023-10-01T12:00:00Z"),
-          archivable: true,
-        },
         isPublished: true,
+        datasetlifecycle: {
+          archivable: true,
+          publishedOn: new Date("2023-10-01T12:00:00.000Z"),
+        },
+        scientificMetadata: {
+          runNumber: 484,
+          scan_parameters: { name: ["phi2"] },
+        },
       },
     });
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Fixes an inconsitency with https://github.com/SciCatProject/scicat-backend-next/pull/2286 - migrate all object-typed fields to the GenericHistory delta format, not just datasetlifecyle. Using `computeDeltaWithOriginals` of the history plugin to construct the deltas.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
