### PR TITLE
refactor: change the naming of the config flag to hideEmptyMetadataTable

### DIFF
--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -63,7 +63,7 @@
   "datasetDetailsShowMissingProposalId": false,
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
-  "showEmptyMetadataTable": false,
+  "hideEmptyMetadataTable": false,
   "datafilesActionsEnabled": true,
   "datafilesActions": [
     {


### PR DESCRIPTION
## Description
This PR updates the name of the config flag showEmptyMetadataTable to hideEmptyMetadataTable.

## Motivation
When set to `false`, metadata sections are displayed even when empty (default behavior). Set to `true` to hide empty sections.
## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
