### PR TITLE
fix: use custom email list validation rule for contactEmail

### DIFF
--- a/src/datasets/dto/update-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-dataset-obsolete.dto.ts
@@ -16,6 +16,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  Validate,
   ValidateNested,
 } from "class-validator";
 import { TechniqueClass } from "../schemas/technique.schema";
@@ -24,6 +25,7 @@ import { CreateTechniqueDto } from "./create-technique.dto";
 import { RelationshipClass } from "../schemas/relationship.schema";
 import { CreateRelationshipDto } from "./create-relationship.dto";
 import { LifecycleClass } from "../schemas/lifecycle.schema";
+import { CustomEmailList } from "../utils/email-list-validator.util";
 
 @ApiTags("datasets")
 export class UpdateDatasetObsoleteDto extends OwnableDto {
@@ -62,7 +64,7 @@ export class UpdateDatasetObsoleteDto extends OwnableDto {
     description:
       "Email of the contact person for this dataset. The string may contain a list of emails, which should then be separated by semicolons.",
   })
-  @IsEmail()
+  @Validate(CustomEmailList)
   readonly contactEmail: string;
 
   @ApiProperty({

--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -16,6 +16,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  Validate,
   ValidateNested,
 } from "class-validator";
 import { TechniqueClass } from "../schemas/technique.schema";
@@ -25,6 +26,7 @@ import { RelationshipClass } from "../schemas/relationship.schema";
 import { CreateRelationshipDto } from "./create-relationship.dto";
 import { LifecycleClass } from "../schemas/lifecycle.schema";
 import { HistoryClass } from "../schemas/history.schema";
+import { CustomEmailList } from "../utils/email-list-validator.util";
 
 @ApiTags("datasets")
 export class UpdateDatasetDto extends OwnableDto {
@@ -64,7 +66,7 @@ export class UpdateDatasetDto extends OwnableDto {
     description:
       "Email of the contact person for this dataset. The string may contain a list of emails, which should then be separated by semicolons.",
   })
-  @IsEmail()
+  @Validate(CustomEmailList)
   readonly contactEmail: string;
 
   @ApiProperty({

--- a/src/datasets/utils/email-list-validator.util.spec.ts
+++ b/src/datasets/utils/email-list-validator.util.spec.ts
@@ -1,0 +1,38 @@
+import { CustomEmailList } from "./email-list-validator.util";
+import { ValidationArguments } from "class-validator";
+
+describe("CustomEmailList", () => {
+  const validator = new CustomEmailList();
+  const dummyArgs = {} as ValidationArguments;
+
+  it("accepts a single valid email", () => {
+    expect(validator.validate("user@example.com", dummyArgs)).toBe(true);
+  });
+
+  it("accepts multiple valid emails separated by semicolons", () => {
+    expect(validator.validate("a@x.com; b@y.org; c@z.net", dummyArgs)).toBe(
+      true,
+    );
+  });
+
+  it("rejects if any email is invalid", () => {
+    expect(validator.validate("a@x.com; notanemail; c@z.net", dummyArgs)).toBe(
+      false,
+    );
+  });
+
+  it("rejects empty string", () => {
+    expect(validator.validate("", dummyArgs)).toBe(false);
+  });
+
+  it("rejects string with extra semicolons", () => {
+    expect(validator.validate("a@x.com;;b@y.org", dummyArgs)).toBe(false);
+  });
+
+  it("returns descriptive defaultMessage", () => {
+    const msg = validator.defaultMessage({
+      value: "foo",
+    } as ValidationArguments);
+    expect(msg).toContain("foo");
+  });
+});

--- a/src/datasets/utils/email-list-validator.util.spec.ts
+++ b/src/datasets/utils/email-list-validator.util.spec.ts
@@ -3,36 +3,29 @@ import { ValidationArguments } from "class-validator";
 
 describe("CustomEmailList", () => {
   const validator = new CustomEmailList();
-  const dummyArgs = {} as ValidationArguments;
 
   it("accepts a single valid email", () => {
-    expect(validator.validate("user@example.com", dummyArgs)).toBe(true);
+    expect(validator.validate("user@example.com")).toBe(true);
   });
 
   it("accepts multiple valid emails separated by semicolons", () => {
-    expect(validator.validate("a@x.com; b@y.org; c@z.net", dummyArgs)).toBe(
-      true,
-    );
+    expect(validator.validate("a@x.com; b@y.org; c@z.net")).toBe(true);
   });
 
   it("rejects if any email is invalid", () => {
-    expect(validator.validate("a@x.com; notanemail; c@z.net", dummyArgs)).toBe(
-      false,
-    );
+    expect(validator.validate("a@x.com; notanemail; c@z.net")).toBe(false);
   });
 
   it("rejects empty string", () => {
-    expect(validator.validate("", dummyArgs)).toBe(false);
+    expect(validator.validate("")).toBe(false);
   });
 
   it("rejects undefined", () => {
-    expect(validator.validate(undefined as unknown as string, dummyArgs)).toBe(
-      false,
-    );
+    expect(validator.validate(undefined as unknown as string)).toBe(false);
   });
 
   it("rejects string with extra semicolons", () => {
-    expect(validator.validate("a@x.com;;b@y.org", dummyArgs)).toBe(false);
+    expect(validator.validate("a@x.com;;b@y.org")).toBe(false);
   });
 
   it("returns descriptive defaultMessage", () => {

--- a/src/datasets/utils/email-list-validator.util.spec.ts
+++ b/src/datasets/utils/email-list-validator.util.spec.ts
@@ -25,6 +25,12 @@ describe("CustomEmailList", () => {
     expect(validator.validate("", dummyArgs)).toBe(false);
   });
 
+  it("rejects undefined", () => {
+    expect(validator.validate(undefined as unknown as string, dummyArgs)).toBe(
+      false,
+    );
+  });
+
   it("rejects string with extra semicolons", () => {
     expect(validator.validate("a@x.com;;b@y.org", dummyArgs)).toBe(false);
   });

--- a/src/datasets/utils/email-list-validator.util.ts
+++ b/src/datasets/utils/email-list-validator.util.ts
@@ -1,3 +1,4 @@
+import { Injectable } from "@nestjs/common";
 import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
@@ -5,15 +6,22 @@ import {
   isEmail,
 } from "class-validator";
 
+@Injectable()
 @ValidatorConstraint({ name: "customEmailList", async: false })
 export class CustomEmailList implements ValidatorConstraintInterface {
-  extractEmails(text: string): string[] {
-    return text.split(";").map((e) => e.trim());
+  static readonly SEPARATOR = ";";
+
+  splitEmails(text: string): string[] {
+    return text.split(CustomEmailList.SEPARATOR).map((e) => e.trim());
   }
 
-  validate(text: string, _: ValidationArguments) {
+  joinEmails(emails: string[]): string {
+    return emails.join(`${CustomEmailList.SEPARATOR} `);
+  }
+
+  validate(text: string) {
     if (!text) return false;
-    const emails = this.extractEmails(text);
+    const emails = this.splitEmails(text);
     return emails.every((e) => isEmail(e));
   }
 

--- a/src/datasets/utils/email-list-validator.util.ts
+++ b/src/datasets/utils/email-list-validator.util.ts
@@ -7,9 +7,13 @@ import {
 
 @ValidatorConstraint({ name: "customEmailList", async: false })
 export class CustomEmailList implements ValidatorConstraintInterface {
+  extractEmails(text: string): string[] {
+    return text.split(";").map((e) => e.trim());
+  }
+
   validate(text: string, _: ValidationArguments) {
     if (!text) return false;
-    const emails = text.split(";").map((e) => e.trim());
+    const emails = this.extractEmails(text);
     return emails.every((e) => isEmail(e));
   }
 

--- a/src/datasets/utils/email-list-validator.util.ts
+++ b/src/datasets/utils/email-list-validator.util.ts
@@ -8,6 +8,7 @@ import {
 @ValidatorConstraint({ name: "customEmailList", async: false })
 export class CustomEmailList implements ValidatorConstraintInterface {
   validate(text: string, _: ValidationArguments) {
+    if (!text) return false;
     const emails = text.split(";").map((e) => e.trim());
     return emails.every((e) => isEmail(e));
   }

--- a/src/datasets/utils/email-list-validator.util.ts
+++ b/src/datasets/utils/email-list-validator.util.ts
@@ -1,0 +1,19 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  isEmail,
+} from "class-validator";
+
+@ValidatorConstraint({ name: "customEmailList", async: false })
+export class CustomEmailList implements ValidatorConstraintInterface {
+  validate(text: string, _: ValidationArguments) {
+    const emails = text.split(";").map((e) => e.trim());
+    return emails.every((e) => isEmail(e));
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    // here you can provide default error message if validation failed
+    return `Expected an email or a list of semicolon separated emails, got ${args.value}`;
+  }
+}

--- a/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
+++ b/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
@@ -45,7 +45,7 @@ describe("HidePersonalInfo test", () => {
     const dataset = {
       ...TestData.RawCorrectMin,
       isPublished: true,
-      contactEmail: user2email,
+      contactEmail: `${user1email}; ${user2email}`,
       ownerGroup: "group1",
       ownerEmail: user1email,
       sampleId: "sample123",
@@ -63,7 +63,7 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.EntryCreatedStatusCode)
       .then(
         (result) => (
-          expect(result.body.contactEmail).toEqual("*****"),
+          expect(result.body.contactEmail).toEqual(`${user1email}; *****`),
           expect(result.body.ownerEmail).toEqual(user1email),
           expect(result.body.accessGroups).toEqual(["*****"])
         ),
@@ -75,7 +75,7 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual("*****"),
+          expect(result.body[0].contactEmail).toEqual(`${user1email}; *****`),
           expect(result.body[0].ownerEmail).toEqual(user1email),
           expect(result.body[0].accessGroups).toEqual(["*****"]),
           expect(result.body[0].datasetlifecycle._id).toEqual(
@@ -106,7 +106,7 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual("*****"),
+          expect(result.body[0].contactEmail).toEqual(`${user1email}; *****`),
           expect(result.body[0].ownerEmail).toEqual(user1email),
           expect(result.body[0].accessGroups).toEqual(["*****"])
         ),
@@ -134,7 +134,7 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual("*****"),
+          expect(result.body[0].contactEmail).toEqual("*****; *****"),
           expect(result.body[0].ownerEmail).toEqual("*****"),
           expect(result.body[0].accessGroups).toEqual(["*****"])
         ),
@@ -153,7 +153,9 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual(user2email),
+          expect(result.body[0].contactEmail).toEqual(
+            `${user1email}; ${user2email}`,
+          ),
           expect(result.body[0].ownerEmail).toEqual(user1email),
           expect(result.body[0].accessGroups).toEqual([
             "access1@group.site",
@@ -182,7 +184,9 @@ describe("HidePersonalInfo test", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then(
         (result) => (
-          expect(result.body[0].contactEmail).toEqual(user2email),
+          expect(result.body[0].contactEmail).toEqual(
+            `${user1email}; ${user2email}`,
+          ),
           expect(result.body[0].ownerEmail).toEqual(user1email),
           expect(result.body[0].accessGroups).toEqual([
             "access1@group.site",


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Fixes https://github.com/SciCatProject/scicat-backend-next/issues/2317

## Motivation
<!-- Background on use case, changes needed -->
Users at PSI used to be able to ingest datasets with multiple contactEmails as per the spec of the field, but weren't anymore due to this bug.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->
https://github.com/SciCatProject/scicat-backend-next/issues/2317

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* Added a custom email list class-validator ([reference](https://github.com/typestack/class-validator?tab=readme-ov-file#custom-validation-classes))
* Using it on the `contactEmail` field in updateDataset[obsolete]dto's which are the base classes for dataset creation dto's. 
## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

Tested locally using scicatlive that the payload mentioned in the issue now returns `{valid: true}`

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
