### PR TITLE
fix: updated error message on duplicated pid on post to contain the pid

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -719,7 +719,7 @@ export class DatasetsController {
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
-          `A dataset with pid ${obsoleteDatasetDto.pid?.trim() ? obsoleteDatasetDto.pid : 'unknown'} already exists!`,
+          `A dataset with pid ${obsoleteDatasetDto.pid?.trim() ? obsoleteDatasetDto.pid : "unknown"} already exists!`,
         );
       } else {
         throw new InternalServerErrorException(error);

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -719,7 +719,7 @@ export class DatasetsController {
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
-          "A dataset with this this unique key already exists!",
+          `A dataset with pid ${obsoleteDatasetDto.pid?.trim() ? obsoleteDatasetDto.pid : 'unknown'} already exists!`,
         );
       } else {
         throw new InternalServerErrorException(error);

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -348,7 +348,7 @@ export class DatasetsV4Controller {
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
-          `A dataset with pid ${datasetDto.pid?.trim() ? datasetDto.pid : 'unknown'} already exists!`,
+          `A dataset with pid ${datasetDto.pid?.trim() ? datasetDto.pid : "unknown"} already exists!`,
         );
       } else {
         throw new InternalServerErrorException(

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -348,7 +348,7 @@ export class DatasetsV4Controller {
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
-          "A dataset with this unique key already exists!",
+          `A dataset with pid ${datasetDto.pid?.trim() ? datasetDto.pid : 'unknown'} already exists!`,
         );
       } else {
         throw new InternalServerErrorException(


### PR DESCRIPTION
## Description
This PR updates the message provided when users try to create a new dataset with a pid that already exists to include the also the pid.

## Motivation
This PR is motivated by providing better logging and make it easier to troubleshoot this type of incidents

## Changes:
* src/datasets/datasets.controller.ts
* src/datasets/datasets.v4.controller.ts

## Tests included
- [ ] Included for each change/fix? Not needed
- [ ] Passing? 

## Documentation
- [ ] swagger documentation updated (required for API changes) Not needed
- [ ] official documentation updated

