### PR TITLE
fix: add jobParams.username to v3 output as per migration

### DIFF
--- a/src/jobs/types/jobs-filter-content.ts
+++ b/src/jobs/types/jobs-filter-content.ts
@@ -94,5 +94,6 @@ export const jobV3toV4FieldMap: Record<string, string> = {
   creationTime: "createdAt",
   jobStatusMessage: "statusCode",
   executionTime: "jobParams.executionTime",
+  "jobParams.username": "ownerUser",
   datasetList: "jobParams.datasetList",
 };

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -229,7 +229,9 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("datasetList")
           .that.deep.equals(jobCreateDtoByAdmin.datasetList);
-        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have.property("jobParams").that.deep.equals(
+          {username: TestData.Accounts["admin"]["username"]}
+        );
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(TestData.Accounts["admin"]["email"]);
@@ -318,7 +320,9 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("datasetList")
           .that.deep.equals(jobCreateDtoForUser51.datasetList);
-        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have.property("jobParams").that.deep.equals(
+          {username: TestData.Accounts["admin"]["username"]}
+        );
         encodedJobOwnedByGroup5 = encodeURIComponent(res.body["id"]);
       });
   });
@@ -362,7 +366,9 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("datasetList")
           .that.deep.equals(jobCreateDtoForUser51.datasetList);
-        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have.property("jobParams").that.deep.equals(
+          {username: TestData.Accounts["admin"]["username"]}
+        );
         encodedJobOwnedByGroup5 = encodeURIComponent(res.body["id"]);
       });
   });
@@ -1174,6 +1180,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       ...jobDatasetAccess,
       jobParams: {
         param: "ok",
+        username: TestData.Accounts["user5.1"]["username"]
       },
       datasetList: [{ pid: datasetPid1, files: [] }],
     };
@@ -1254,7 +1261,9 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("datasetList")
           .that.deep.equals(jobCreateDtoByAdmin.datasetList);
-        res.body.should.have.property("jobParams").that.deep.equals({});
+        res.body.should.have.property("jobParams").that.deep.equals(
+          {username: TestData.Accounts["adminIngestor"]["username"]}
+        );
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(TestData.Accounts["adminIngestor"]["email"]);


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Fixes username not being added to the V3 model by v3 transformers. It's opened against #2316, will move to main once merged

This is justified by the migration script

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
