### PR TITLE
fix: accept v3 fields in filters when using v3 jobs

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1040,6 +1040,9 @@ export const datasetsFullQueryDescriptionFields =
 export const jobsFullQueryExampleFields =
   '{"ownerGroup": "group1", "statusCode": "jobCreated"}';
 
+export const jobsFullQueryExampleFieldsV3 =
+  '{"emailJobInitiator": "group1@email.com", "jobStatusMessage": "jobCreated"}';
+
 export const jobsFullQueryDescriptionFields =
   '<pre>\n  \
 {\n \
@@ -1055,6 +1058,20 @@ export const jobsFullQueryDescriptionFields =
   "id": string, <optional>\n \
   "statusCode": string, <optional>\n \
   "statusMessage": string, <optional>\n \
+  ... <optional>\n \
+}\n \
+  </pre>';
+
+export const jobsFullQueryDescriptionFieldsV3 =
+  '<pre>\n  \
+{\n \
+  "creationTime": { <optional>\n \
+    "begin": string,\n \
+    "end": string,\n \
+  },\n \
+  "type": string, <optional>\n \
+  "id": string, <optional>\n \
+  "jobStatusMessage": string, <optional>\n \
   ... <optional>\n \
 }\n \
   </pre>';

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -41,8 +41,8 @@ import { FullFacetResponse } from "src/common/types";
 import {
   fullQueryDescriptionLimits,
   fullQueryExampleLimits,
-  jobsFullQueryExampleFields,
-  jobsFullQueryDescriptionFields,
+  jobsFullQueryDescriptionFieldsV3,
+  jobsFullQueryExampleFieldsV3,
 } from "src/common/utils";
 import { CreateJobV3MappingInterceptor } from "./interceptors/create-job-v3-mapping.interceptor";
 import { UpdateJobV3MappingInterceptor } from "./interceptors/update-job-v3-mapping.interceptor";
@@ -161,10 +161,10 @@ export class JobsController {
     name: "fields",
     description:
       "Filters to apply when retrieving jobs.\n" +
-      jobsFullQueryDescriptionFields,
+      jobsFullQueryDescriptionFieldsV3,
     required: false,
     type: String,
-    example: jobsFullQueryExampleFields,
+    example: jobsFullQueryExampleFieldsV3,
   })
   @ApiQuery({
     name: "limits",
@@ -210,10 +210,10 @@ export class JobsController {
     name: "fields",
     description:
       "Define the filter conditions by specifying the values of fields requested.\n" +
-      jobsFullQueryDescriptionFields,
+      jobsFullQueryDescriptionFieldsV3,
     required: false,
     type: String,
-    example: jobsFullQueryExampleFields,
+    example: jobsFullQueryExampleFieldsV3,
   })
   @ApiQuery({
     name: "facets",
@@ -221,7 +221,7 @@ export class JobsController {
       "Define a list of field names, for which facet counts should be calculated.",
     required: false,
     type: String,
-    example: '["type","ownerGroup","statusCode"]',
+    example: '["type","ownerGroup","jobStatusMessage"]',
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -1,0 +1,182 @@
+import { PipeTransform, Injectable, ArgumentMetadata } from "@nestjs/common";
+import { jobV3toV4FieldMap } from "../types/jobs-filter-content";
+import _ from "lodash";
+
+type KeyMap = Record<string, string>;
+
+type Func = (value: unknown) => unknown;
+
+type FuncMap = Record<string, Func>;
+
+interface TransformDeepOptions {
+  keyMap?: KeyMap;
+  funcMap?: FuncMap;
+  arrayFn?: Func;
+  valueFn?: Func;
+}
+
+const transformDeep = (
+  obj: unknown,
+  opts: TransformDeepOptions = {},
+): unknown => {
+  const { keyMap = {}, funcMap = {}, arrayFn, valueFn } = opts;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) =>
+      arrayFn ? arrayFn(transformDeep(item, opts)) : transformDeep(item, opts),
+    );
+  }
+
+  if (obj && typeof obj === "object") {
+    const newObj: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const mappedKey = keyMap[key] ?? key;
+      let transformed: unknown;
+      if (funcMap[key]) {
+        transformed = funcMap[key](value);
+      } else {
+        transformed = transformDeep(value, opts);
+      }
+      newObj[mappedKey] = valueFn ? valueFn(transformed) : transformed;
+    }
+    return newObj;
+  }
+
+  return obj;
+};
+
+class ParseJsonPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    if (!value || typeof value !== "string") return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+}
+
+class ParseDeepJsonPipe implements PipeTransform<string, unknown> {
+  private jsonPipe = new ParseJsonPipe();
+
+  transform(value: string): unknown {
+    const parsed = this.jsonPipe.transform(value);
+    return transformDeep(parsed, {
+      valueFn: (value) => this.jsonPipe.transform(value as string),
+    });
+  }
+}
+
+class ReplaceObjKeysPipe implements PipeTransform<unknown, unknown> {
+  constructor(private keyMap: KeyMap) {}
+
+  transform(value: unknown): unknown {
+    return transformDeep(value, { keyMap: this.keyMap });
+  }
+}
+
+class TransformObjValuesPipe implements PipeTransform<unknown, unknown> {
+  constructor(private funcMap: FuncMap) {}
+
+  transform(value: unknown): unknown {
+    return transformDeep(value, { funcMap: this.funcMap });
+  }
+}
+
+class TransformArrayValuesPipe implements PipeTransform<unknown, unknown> {
+  constructor(private arrayFn: (item: unknown) => unknown) {}
+
+  transform(value: unknown): unknown {
+    return transformDeep(value, { arrayFn: this.arrayFn });
+  }
+}
+
+class ComposePipe<T = unknown> implements PipeTransform<T, T> {
+  private readonly pipes: PipeTransform[];
+  private readonly jsonToString = new JsonToStringPipe();
+  private readonly parseDeepJson = new ParseDeepJsonPipe();
+
+  constructor(
+    pipes: PipeTransform[],
+    private readonly jsonTransform = true,
+  ) {
+    this.pipes = [...pipes];
+    if (this.jsonTransform) {
+      this.pipes.unshift(this.parseDeepJson);
+      this.pipes.push(this.jsonToString);
+    }
+  }
+
+  transform(value: T, metadata: ArgumentMetadata = {} as ArgumentMetadata): T {
+    return this.pipes.reduce(
+      (val, pipe) => pipe.transform(val, metadata),
+      value,
+    );
+  }
+}
+
+class JsonToStringPipe implements PipeTransform<object, string | object> {
+  transform(value: object): string | object {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return value;
+    }
+  }
+}
+
+@Injectable()
+export class V3LimitsToV4Pipe extends ComposePipe<object> {
+  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
+    const sortToOrderPipe = new TransformObjValuesPipe({
+      order: (value: unknown) => {
+        const isArray = _.isArray(value);
+        const order = (isArray ? value : [value]).reduce((acc, orderValue) => {
+          const [field, direction] = (orderValue as string).split(":");
+          return acc.concat(`${keyMappings[field]}:${direction}`);
+        }, [] as string[]);
+        return isArray ? order : order[0];
+      },
+    });
+    super(
+      [sortToOrderPipe, new V3ConditionToV4Pipe(keyMappings, false)],
+      jsonTransform,
+    );
+  }
+}
+
+@Injectable()
+export class V3ConditionToV4Pipe extends ComposePipe<object> {
+  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
+    super([new ReplaceObjKeysPipe(keyMappings)], jsonTransform);
+  }
+}
+
+@Injectable()
+export class V3FieldsToV4Pipe extends ComposePipe<object> {
+  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
+    super(
+      [
+        new TransformArrayValuesPipe((item) => {
+          if (_.isString(item) && keyMappings[item]) return keyMappings[item];
+          return item;
+        }),
+      ],
+      jsonTransform,
+    );
+  }
+}
+
+@Injectable()
+export class V3FilterToV4Pipe extends ComposePipe<string> {
+  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
+    super(
+      [
+        new V3LimitsToV4Pipe(keyMappings, false),
+        new V3ConditionToV4Pipe(keyMappings, false),
+        new V3FieldsToV4Pipe(keyMappings, false),
+      ],
+      jsonTransform,
+    );
+  }
+}

--- a/src/jobs/types/jobs-filter-content.ts
+++ b/src/jobs/types/jobs-filter-content.ts
@@ -23,7 +23,7 @@ const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
     items: {
       type: "string",
     },
-    example: ["ownerUser", "datasets.keywords"],
+    example: ["type", "datasets.keywords"],
   },
   limits: {
     type: "object",
@@ -39,7 +39,7 @@ const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
       sort: {
         type: "object",
         properties: {
-          ownerUser: {
+          type: {
             type: "string",
             example: "asc | desc",
           },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This bug can be tried in the JOB view in the frontend, where the sorting has no effect. The cause is that the FE sends the fields of V3 to sort, but these have been renamed in the DB so the sorting has no effect. This PR introduces some pipelines that have the effect of mapping the v3 fields input by the client to the DB ones, at all levels, in fields, whereConditions and limits. IMO this logic should take place in all v3 endpoints. If so, it can be implemented in later PRs

It's opened agains #2320 as it reuses the jobv3v4 mapping. I will open against master once merged

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
