### PR TITLE
fix: implementing optimistic concurrency control

### DIFF
--- a/migrations/20251120153452-add-updatedby-to-instrument.js
+++ b/migrations/20251120153452-add-updatedby-to-instrument.js
@@ -1,0 +1,14 @@
+module.exports = {
+  async up(db, client) {
+    await db
+      .collection("Instrument")
+      .updateMany(
+        { updatedBy: { $exists: false } },
+        [{ $set: { updatedBy: "$createdBy" } }]
+      );
+  },
+
+  async down(db, client) {
+    // No path backward as it's not easy to find on down where updatedBy was added
+  },
+};

--- a/src/attachments/attachments.v4.controller.spec.ts
+++ b/src/attachments/attachments.v4.controller.spec.ts
@@ -72,7 +72,6 @@ describe("AttachmentsController - findOneAndUpdate", () => {
     const result = await controller.findOneAndUpdate(
       { headers },
       "123",
-      headers,
       dto,
     );
 
@@ -84,7 +83,7 @@ describe("AttachmentsController - findOneAndUpdate", () => {
     const dto = { description: null };
     const headers = { "content-type": "application/merge-patch+json" };
 
-    await controller.findOneAndUpdate({ headers }, "123", headers, dto);
+    await controller.findOneAndUpdate({ headers }, "123", dto);
 
     const expectedPatched = jmp.apply(mockAttachment, dto);
     expect(service.findOneAndUpdate).toHaveBeenCalledWith(
@@ -101,10 +100,10 @@ describe("AttachmentsController - findOneAndUpdate", () => {
     };
 
     await expect(
-      controller.findOneAndUpdate({ headers }, "123", headers, dto),
+      controller.findOneAndUpdate({ headers }, "123", dto),
     ).rejects.toThrow(
       new HttpException(
-        "Update error due to failed if-modified-since condition",
+        "Resource has been modified on server",
         HttpStatus.PRECONDITION_FAILED,
       ),
     );

--- a/src/attachments/attachments.v4.controller.spec.ts
+++ b/src/attachments/attachments.v4.controller.spec.ts
@@ -69,11 +69,7 @@ describe("AttachmentsController - findOneAndUpdate", () => {
     const dto: PartialUpdateAttachmentV4Dto = { description: "Updated" };
     const headers = { "content-type": "application/json" };
 
-    const result = await controller.findOneAndUpdate(
-      { headers },
-      "123",
-      dto,
-    );
+    const result = await controller.findOneAndUpdate({ headers }, "123", dto);
 
     expect(result).toEqual(mockUpdatedAttachment);
     expect(service.findOneAndUpdate).toHaveBeenCalledWith({ _id: "123" }, dto);

--- a/src/attachments/attachments.v4.controller.spec.ts
+++ b/src/attachments/attachments.v4.controller.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AttachmentsV4Controller } from "./attachments.v4.controller";
+import { AttachmentsV4Service } from "./attachments.v4.service";
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { PartialUpdateAttachmentV4Dto } from "./dto/update-attachment.v4.dto";
+import { Attachment } from "./schemas/attachment.schema";
+import * as jmp from "json-merge-patch";
+import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
+import { PoliciesGuard } from "src/casl/guards/policies.guard";
+
+describe("AttachmentsController - findOneAndUpdate", () => {
+  let controller: AttachmentsV4Controller;
+  let service: AttachmentsV4Service;
+
+  const mockAttachment: Attachment = {
+    _id: "123",
+    name: "Test Attachment",
+    description: "Initial",
+    updatedAt: new Date("2025-09-01T10:00:00Z"),
+    // other fields...
+  };
+
+  const mockUpdatedAttachment = {
+    ...mockAttachment,
+    description: "Updated",
+  };
+
+  const mockCaslAbilityFactory = {
+    createForUser: jest.fn().mockReturnValue({
+      can: jest.fn().mockReturnValue(true), // or false depending on test
+    }),
+  };
+
+  const mockAttachmentsV4Service = {
+    findOneAndUpdate: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AttachmentsV4Controller],
+      providers: [
+        {
+          provide: AttachmentsV4Service,
+          useValue: mockAttachmentsV4Service,
+          useValue: {
+            findOneAndUpdate: jest
+              .fn()
+              .mockResolvedValue(mockUpdatedAttachment),
+          },
+        },
+        {
+          provide: CaslAbilityFactory,
+          useValue: mockCaslAbilityFactory,
+        },
+        PoliciesGuard,
+      ],
+    }).compile();
+
+    controller = module.get<AttachmentsV4Controller>(AttachmentsV4Controller);
+    service = module.get<AttachmentsV4Service>(AttachmentsV4Service);
+
+    // Mock permission check
+    jest
+      .spyOn(controller, "checkPermissionsForAttachment")
+      .mockResolvedValue(mockAttachment);
+  });
+
+  it("should update attachment with application/json", async () => {
+    const dto: PartialUpdateAttachmentV4Dto = { description: "Updated" };
+    const headers = { "content-type": "application/json" };
+
+    const result = await controller.findOneAndUpdate(
+      { headers },
+      "123",
+      headers,
+      dto,
+    );
+
+    expect(result).toEqual(mockUpdatedAttachment);
+    expect(service.findOneAndUpdate).toHaveBeenCalledWith({ _id: "123" }, dto);
+  });
+
+  it("should update attachment with application/merge-patch+json", async () => {
+    const dto = { description: null };
+    const headers = { "content-type": "application/merge-patch+json" };
+
+    await controller.findOneAndUpdate({ headers }, "123", headers, dto);
+
+    const expectedPatched = jmp.apply(mockAttachment, dto);
+    expect(service.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "123" },
+      expectedPatched,
+    );
+  });
+
+  it("should throw PRECONDITION_FAILED if If-Unmodified-Since is older than updatedAt", async () => {
+    const dto = { name: "Should Fail" };
+    const headers = {
+      "content-type": "application/json",
+      "if-unmodified-since": "2000-01-01T00:00:00Z",
+    };
+
+    await expect(
+      controller.findOneAndUpdate({ headers }, "123", headers, dto),
+    ).rejects.toThrow(
+      new HttpException(
+        "Update error due to failed if-modified-since condition",
+        HttpStatus.PRECONDITION_FAILED,
+      ),
+    );
+  });
+});

--- a/src/attachments/attachments.v4.controller.ts
+++ b/src/attachments/attachments.v4.controller.ts
@@ -373,7 +373,6 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
     @Param("aid") aid: string,
     @Body() updateAttachmentDto: PartialUpdateAttachmentV4Dto,
   ): Promise<OutputAttachmentV4Dto | null> {
-
     const foundAttachment = await this.checkPermissionsForAttachment(
       request,
       aid,
@@ -385,7 +384,10 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
         : updateAttachmentDto;
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(foundAttachment.updatedAt, request.headers['if-unmodified-since']);
+    checkUnmodifiedSince(
+      foundAttachment.updatedAt,
+      request.headers["if-unmodified-since"],
+    );
 
     return this.attachmentsService.findOneAndUpdate(
       { _id: aid },

--- a/src/common/utils/check-unmodified-since.ts
+++ b/src/common/utils/check-unmodified-since.ts
@@ -1,0 +1,30 @@
+import { PreconditionFailedException } from "@nestjs/common";
+
+/**
+* Checks whether a resource has been modified on the server since the time
+* specified in the `If-Unmodified-Since` header.
+*
+* Throws a 412 Precondition Failed exception if the resource has been modified.
+*
+* This is useful for preventing lost updates in PATCH/PUT endpoints when multiple clients
+* may be updating the same resource concurrently.
+*
+* @param resourceDate - The `updatedAt` date of the resource on the server.
+* @param headerDateString - The value of the `If-Unmodified-Since` header from the request.
+*/
+export function checkUnmodifiedSince(
+    resourceDate?: Date | null,
+    headerDateString?: string | null,
+) {
+
+    if (!resourceDate || !headerDateString) return;
+
+    const headerDate = new Date(headerDateString);
+    if (isNaN(headerDate.getTime())) return;
+
+    if (headerDate <= resourceDate) {
+        throw new PreconditionFailedException(
+            'Resource has been modified on server'
+        );
+    }
+}

--- a/src/common/utils/check-unmodified-since.ts
+++ b/src/common/utils/check-unmodified-since.ts
@@ -1,30 +1,29 @@
 import { PreconditionFailedException } from "@nestjs/common";
 
 /**
-* Checks whether a resource has been modified on the server since the time
-* specified in the `If-Unmodified-Since` header.
-*
-* Throws a 412 Precondition Failed exception if the resource has been modified.
-*
-* This is useful for preventing lost updates in PATCH/PUT endpoints when multiple clients
-* may be updating the same resource concurrently.
-*
-* @param resourceDate - The `updatedAt` date of the resource on the server.
-* @param headerDateString - The value of the `If-Unmodified-Since` header from the request.
-*/
+ * Checks whether a resource has been modified on the server since the time
+ * specified in the `If-Unmodified-Since` header.
+ *
+ * Throws a 412 Precondition Failed exception if the resource has been modified.
+ *
+ * This is useful for preventing lost updates in PATCH/PUT endpoints when multiple clients
+ * may be updating the same resource concurrently.
+ *
+ * @param resourceDate - The `updatedAt` date of the resource on the server.
+ * @param headerDateString - The value of the `If-Unmodified-Since` header from the request.
+ */
 export function checkUnmodifiedSince(
-    resourceDate?: Date | null,
-    headerDateString?: string | null,
+  resourceDate?: Date | null,
+  headerDateString?: string | null,
 ) {
+  if (!resourceDate || !headerDateString) return;
 
-    if (!resourceDate || !headerDateString) return;
+  const headerDate = new Date(headerDateString);
+  if (isNaN(headerDate.getTime())) return;
 
-    const headerDate = new Date(headerDateString);
-    if (isNaN(headerDate.getTime())) return;
-
-    if (headerDate <= resourceDate) {
-        throw new PreconditionFailedException(
-            'Resource has been modified on server'
-        );
-    }
+  if (headerDate <= resourceDate) {
+    throw new PreconditionFailedException(
+      "Resource has been modified on server",
+    );
+  }
 }

--- a/src/datasets/datasets.controller.spec.ts
+++ b/src/datasets/datasets.controller.spec.ts
@@ -9,23 +9,37 @@ import { LogbooksService } from "src/logbooks/logbooks.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { ConfigModule } from "@nestjs/config";
 import { HttpModule } from "@nestjs/axios";
+import {
+  ForbiddenException,
+  HttpException,
+  NotFoundException,
+} from "@nestjs/common";
+import { DatasetType } from "./types/dataset-type.enum";
+import { Request } from "express";
 
 class AttachmentsServiceMock {}
 
 class DatablocksServiceMock {}
 
-class DatasetsServiceMock {}
-
 class OrigDatablocksServiceMock {}
 
 class LogbooksServiceMock {}
 
-class CaslAbilityFactoryMock {}
+class DatasetsServiceMock {
+  findOne = jest.fn();
+  findByIdAndUpdate = jest.fn();
+}
+
+class CaslAbilityFactoryMock {
+  datasetInstanceAccess = jest.fn();
+}
 
 class HistoryServiceMock {}
 
 describe("DatasetsController", () => {
   let controller: DatasetsController;
+  let datasetsService: DatasetsServiceMock;
+  let caslAbilityFactory: CaslAbilityFactoryMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -43,9 +57,137 @@ describe("DatasetsController", () => {
     }).compile();
 
     controller = module.get<DatasetsController>(DatasetsController);
+    datasetsService = module.get(DatasetsService);
+    caslAbilityFactory = module.get(CaslAbilityFactory);
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("findByIdAndUpdate", () => {
+    it("should throw NotFoundException if dataset not found", async () => {
+      datasetsService.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.findByIdAndUpdate(
+          { user: {} } as Request,
+          "some-pid",
+          { "if-unmodified-since": "2023-01-01T00:00:00Z" },
+          {},
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw PreconditionFailed if header date <= updatedAt", async () => {
+      const mockDataset = {
+        pid: "some-pid",
+        updatedAt: new Date("2023-01-02T00:00:00Z"),
+        type: DatasetType.Raw,
+      };
+      datasetsService.findOne.mockResolvedValue(mockDataset);
+
+      await expect(
+        controller.findByIdAndUpdate(
+          { user: {} } as Request,
+          "some-pid",
+          { "if-unmodified-since": "2023-01-01T00:00:00Z" },
+          {},
+        ),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it("should throw ForbiddenException if user cannot update", async () => {
+      const mockDataset = {
+        pid: "some-pid",
+        updatedAt: new Date("2023-01-01T00:00:00Z"),
+        type: DatasetType.Raw,
+      };
+      datasetsService.findOne.mockResolvedValue(mockDataset);
+      jest.spyOn(controller, "validateDatasetObsolete").mockResolvedValue({});
+      jest
+        .spyOn(controller, "generateDatasetInstanceForPermissions")
+        .mockResolvedValue({});
+      caslAbilityFactory.datasetInstanceAccess.mockReturnValue({
+        can: () => false,
+      });
+
+      await expect(
+        controller.findByIdAndUpdate(
+          { user: {} } as Request,
+          "some-pid",
+          { "if-unmodified-since": "2023-01-02T00:00:00Z" },
+          {},
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it("should return updated dataset if all conditions pass", async () => {
+      const mockDataset = {
+        pid: "some-pid",
+        updatedAt: new Date("2023-01-01T00:00:00Z"),
+        type: DatasetType.Raw,
+      };
+      const updatedDataset = { pid: "some-pid", name: "Updated" };
+
+      datasetsService.findOne.mockResolvedValue(mockDataset);
+      jest.spyOn(controller, "validateDatasetObsolete").mockResolvedValue({});
+      jest
+        .spyOn(controller, "generateDatasetInstanceForPermissions")
+        .mockResolvedValue({});
+      caslAbilityFactory.datasetInstanceAccess.mockReturnValue({
+        can: () => true,
+      });
+      jest
+        .spyOn(controller, "convertObsoleteToCurrentSchema")
+        .mockReturnValue({});
+      datasetsService.findByIdAndUpdate.mockResolvedValue(updatedDataset);
+      jest
+        .spyOn(controller, "convertCurrentToObsoleteSchema")
+        .mockReturnValue(updatedDataset);
+
+      const result = await controller.findByIdAndUpdate(
+        { user: {} } as Request,
+        "some-pid",
+        { "if-unmodified-since": "2023-01-02T00:00:00Z" },
+        {},
+      );
+
+      expect(result).toEqual(updatedDataset);
+    });
+
+    it("should proceed with update if if-unmodified-since header is missing or invalid", async () => {
+      const mockDataset = {
+        pid: "some-pid",
+        updatedAt: new Date("2023-01-01T00:00:00Z"),
+        type: DatasetType.Raw,
+      };
+      const updatedDataset = { pid: "some-pid", name: "Updated" };
+
+      datasetsService.findOne.mockResolvedValue(mockDataset);
+      jest.spyOn(controller, "validateDatasetObsolete").mockResolvedValue({});
+      jest
+        .spyOn(controller, "generateDatasetInstanceForPermissions")
+        .mockResolvedValue({});
+      caslAbilityFactory.datasetInstanceAccess.mockReturnValue({
+        can: () => true,
+      });
+      jest
+        .spyOn(controller, "convertObsoleteToCurrentSchema")
+        .mockReturnValue({});
+      datasetsService.findByIdAndUpdate.mockResolvedValue(updatedDataset);
+      jest
+        .spyOn(controller, "convertCurrentToObsoleteSchema")
+        .mockReturnValue(updatedDataset);
+
+      const result = await controller.findByIdAndUpdate(
+        { user: {} } as Request,
+        "some-pid",
+        { "if-unmodified-since": "not-a-valid-date" }, // invalid header
+        {},
+      );
+
+      expect(result).toEqual(updatedDataset);
+    });
   });
 });

--- a/src/datasets/datasets.controller.spec.ts
+++ b/src/datasets/datasets.controller.spec.ts
@@ -69,11 +69,18 @@ describe("DatasetsController", () => {
     it("should throw NotFoundException if dataset not found", async () => {
       datasetsService.findOne.mockResolvedValue(null);
 
+      const mockRequest = {
+      user: {},
+      headers: {
+        "if-unmodified-since": "2023-01-01T00:00:00Z",
+        "content-type": "application/json",
+      },
+    } as unknown as Request;
+
       await expect(
         controller.findByIdAndUpdate(
-          { user: {} } as Request,
+          mockRequest,
           "some-pid",
-          { "if-unmodified-since": "2023-01-01T00:00:00Z" },
           {},
         ),
       ).rejects.toThrow(NotFoundException);
@@ -87,11 +94,18 @@ describe("DatasetsController", () => {
       };
       datasetsService.findOne.mockResolvedValue(mockDataset);
 
+      const mockRequest = {
+        user: {},
+        headers: {
+          "if-unmodified-since": "2023-01-01T00:00:00Z",
+          "content-type": "application/json",
+        },
+      } as unknown as Request;
+
       await expect(
         controller.findByIdAndUpdate(
-          { user: {} } as Request,
+          mockRequest,
           "some-pid",
-          { "if-unmodified-since": "2023-01-01T00:00:00Z" },
           {},
         ),
       ).rejects.toThrow(HttpException);
@@ -112,11 +126,18 @@ describe("DatasetsController", () => {
         can: () => false,
       });
 
+      const mockRequest = {
+        user: {},
+        headers: {
+          "if-unmodified-since": "2023-01-02T00:00:00Z",
+          "content-type": "application/json",
+        },
+      } as unknown as Request;
+
       await expect(
         controller.findByIdAndUpdate(
-          { user: {} } as Request,
+          mockRequest,
           "some-pid",
-          { "if-unmodified-since": "2023-01-02T00:00:00Z" },
           {},
         ),
       ).rejects.toThrow(ForbiddenException);
@@ -146,10 +167,17 @@ describe("DatasetsController", () => {
         .spyOn(controller, "convertCurrentToObsoleteSchema")
         .mockReturnValue(updatedDataset);
 
+      const mockRequest = {
+        user: {},
+        headers: {
+          "if-unmodified-since": "2023-01-02T00:00:00Z",
+          "content-type": "application/json",
+        },
+      } as unknown as Request;
+
       const result = await controller.findByIdAndUpdate(
-        { user: {} } as Request,
+        mockRequest,
         "some-pid",
-        { "if-unmodified-since": "2023-01-02T00:00:00Z" },
         {},
       );
 
@@ -179,11 +207,18 @@ describe("DatasetsController", () => {
       jest
         .spyOn(controller, "convertCurrentToObsoleteSchema")
         .mockReturnValue(updatedDataset);
+      
+      const mockRequest = {
+        user: {},
+        headers: {
+          "if-unmodified-since": "not-a-valid-date",// invalid header
+          "content-type": "application/json",
+        },
+      } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(
-        { user: {} } as Request,
+        mockRequest,
         "some-pid",
-        { "if-unmodified-since": "not-a-valid-date" }, // invalid header
         {},
       );
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1338,11 +1338,19 @@ export class DatasetsController {
     @Req() request: Request,
     @Param("pid") pid: string,
     @Body()
+    @Headers()
+    headers: Record<string, string>,
     updateDatasetObsoleteDto:
       | PartialUpdateRawDatasetObsoleteDto
       | PartialUpdateDerivedDatasetObsoleteDto
       | PartialUpdateDatasetDto,
   ): Promise<OutputDatasetObsoleteDto | null> {
+    const headerDateString = headers["if-unmodified-since"];
+    const headerDate =
+      headerDateString && !isNaN(new Date(headerDateString).getTime())
+        ? new Date(headerDateString)
+        : null;
+
     const foundDataset = await this.datasetsService.findOne({
       where: { pid },
     });
@@ -1351,53 +1359,60 @@ export class DatasetsController {
       throw new NotFoundException();
     }
 
-    // NOTE: Default validation pipe does not validate union types. So we need custom validation.
-    let dtoType;
-    switch (foundDataset.type) {
-      case DatasetType.Raw:
-        dtoType = PartialUpdateRawDatasetObsoleteDto;
-        break;
-      case DatasetType.Derived:
-        dtoType = PartialUpdateDerivedDatasetObsoleteDto;
-        break;
-      default:
-        dtoType = PartialUpdateDatasetDto;
-        break;
-    }
-
+    if (headerDate && headerDate <= foundDataset.updatedAt) {
+      throw new HttpException(
+        "Update error due to failed if-modified-since condition",
+        HttpStatus.PRECONDITION_FAILED,
+      );
+    } else {
+      // NOTE: Default validation pipe does not validate union types. So we need custom validation.
+      let dtoType;
+      switch (foundDataset.type) {
+        case DatasetType.Raw:
+          dtoType = PartialUpdateRawDatasetObsoleteDto;
+          break;
+        case DatasetType.Derived:
+          dtoType = PartialUpdateDerivedDatasetObsoleteDto;
+          break;
+        default:
+          dtoType = PartialUpdateDatasetDto;
+          break;
+      }
+  
     const validatedUpdateDatasetObsoleteDto =
-      (await this.validateDatasetObsolete(
-        updateDatasetObsoleteDto,
-        dtoType,
-      )) as
-        | PartialUpdateRawDatasetObsoleteDto
-        | PartialUpdateDerivedDatasetObsoleteDto
-        | PartialUpdateDatasetDto;
+        (await this.validateDatasetObsolete(
+          updateDatasetObsoleteDto,
+          dtoType,
+        )) as
+          | PartialUpdateRawDatasetObsoleteDto
+          | PartialUpdateDerivedDatasetObsoleteDto
+          | PartialUpdateDatasetDto;
 
-    // NOTE: We need DatasetClass instance because casl module can not recognize the type from dataset mongo database model. If other fields are needed can be added later.
-    const datasetInstance =
-      await this.generateDatasetInstanceForPermissions(foundDataset);
+      // NOTE: We need DatasetClass instance because casl module can not recognize the type from dataset mongo database model. If other fields are needed can be added later.
+      const datasetInstance =
+        await this.generateDatasetInstanceForPermissions(foundDataset);
 
-    // instantiate the casl matrix for the user
-    const user: JWTUser = request.user as JWTUser;
-    const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
-    // check if he/she can create this dataset
-    const canUpdate =
-      ability.can(Action.DatasetUpdateAny, DatasetClass) ||
-      ability.can(Action.DatasetUpdateOwner, datasetInstance);
+      // instantiate the casl matrix for the user
+      const user: JWTUser = request.user as JWTUser;
+      const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
+      // check if he/she can create this dataset
+      const canUpdate =
+        ability.can(Action.DatasetUpdateAny, DatasetClass) ||
+        ability.can(Action.DatasetUpdateOwner, datasetInstance);
 
-    if (!canUpdate) {
-      throw new ForbiddenException("Unauthorized to update this dataset");
+      if (!canUpdate) {
+        throw new ForbiddenException("Unauthorized to update this dataset");
+      }
+
+      const updateDatasetDto = this.convertObsoleteToCurrentSchema(
+        validatedUpdateDatasetObsoleteDto,
+      ) as UpdateDatasetDto;
+
+      const res = this.convertCurrentToObsoleteSchema(
+        await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto),
+      );
+      return res;
     }
-
-    const updateDatasetDto = this.convertObsoleteToCurrentSchema(
-      validatedUpdateDatasetObsoleteDto,
-    ) as UpdateDatasetDto;
-
-    const res = await this.convertCurrentToObsoleteSchema(
-      await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto),
-    );
-    return res;
   }
 
   // PUT /datasets/:id

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1353,7 +1353,10 @@ export class DatasetsController {
     }
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(foundDataset.updatedAt, request.headers["if-unmodified-since"])
+    checkUnmodifiedSince(
+      foundDataset.updatedAt,
+      request.headers["if-unmodified-since"],
+    );
 
     // NOTE: Default validation pipe does not validate union types. So we need custom validation.
     let dtoType;

--- a/src/datasets/datasets.v4.controller.spec.ts
+++ b/src/datasets/datasets.v4.controller.spec.ts
@@ -5,6 +5,8 @@ import { ConfigModule } from "@nestjs/config";
 import { DatasetsV4Controller } from "./datasets.v4.controller";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { HttpModule } from "@nestjs/axios";
+import { PartialUpdateDatasetDto } from "./dto/update-dataset.dto";
+import { Request } from "express";
 
 class DatasetsServiceMock {}
 
@@ -31,5 +33,145 @@ describe("DatasetsController", () => {
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+});
+
+describe("DatasetsController (manual instantiate)", () => {
+  let controller: DatasetsV4Controller;
+
+  // ---- Mocks ----
+
+  const mockUser = { id: "u-1", roles: ["admin"] };
+
+  const datasetsService = {
+    findOne: jest.fn().mockResolvedValue({
+      pid: "test-dataset-id",
+      updatedAt: new Date("2025-01-01T00:00:00Z"),
+      scientificMetadata: {
+        temperature: { value: 295, unit: "K" },
+      },
+    }),
+    findByIdAndUpdate: jest
+      .fn()
+      .mockImplementation((pid: string, updateDto) => ({
+        pid,
+        ...updateDto,
+      })),
+  } as unknown as jest.Mocked<DatasetsService>;
+
+  // CASL factory mock (kept for completeness; permission check is stubbed anyway)
+  const caslAbilityFactory = {
+    createForUser: jest.fn().mockReturnValue({
+      can: () => true,
+      cannot: () => false,
+    }),
+    datasetInstanceAccess: jest.fn().mockReturnValue(true),
+  } as unknown as jest.Mocked<CaslAbilityFactory>;
+
+  class LogbooksServiceMock {}
+
+  let checkSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    controller = new DatasetsV4Controller(
+      datasetsService,
+      new LogbooksServiceMock(),
+      caslAbilityFactory,
+    );
+
+    // Force the permission check to always pass in these unit tests
+    checkSpy = jest
+      .spyOn(controller, "checkPermissionsForDatasetExtended")
+      .mockResolvedValue(undefined);
+  });
+
+  it("should update dataset and return updated result (happy path with fresh header)", async () => {
+    const pid = "test-dataset-id";
+    const updateDto: PartialUpdateDatasetDto = {
+      scientificMetadata: { temperature: { value: 300, unit: "K" } },
+    };
+
+    const req = {
+      headers: { "content-type": "application/json" },
+      user: mockUser,
+    } as unknown as Request;
+
+    // Header is *after* updatedAt -> allowed
+    const headers = { "if-unmodified-since": "2026-01-01T00:00:00Z" };
+
+    const result = await controller.findByIdAndUpdate(
+      req,
+      pid,
+      headers,
+      updateDto,
+    );
+
+    expect(result).toBeDefined();
+    expect(result.pid).toBe(pid);
+    expect(result.scientificMetadata.temperature.value).toBe(300);
+
+    expect(datasetsService.findOne).toHaveBeenCalledWith({ where: { pid } });
+    expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    expect(checkSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { title: "missing header", header: {} as Record<string, string> },
+    {
+      title: "invalid header",
+      header: { "if-unmodified-since": "not-a-date" } as Record<string, string>,
+    },
+  ])("should update when if-unmodified-since is $title", async ({ header }) => {
+    const pid = "test-dataset-id";
+    const updateDto: PartialUpdateDatasetDto = {
+      scientificMetadata: { temperature: { value: 305, unit: "K" } },
+    };
+
+    const req = {
+      headers: { "content-type": "application/json" },
+      user: mockUser,
+    } as unknown as Request;
+
+    const result = await controller.findByIdAndUpdate(
+      req,
+      pid,
+      header,
+      updateDto,
+    );
+
+    expect(result).toBeDefined();
+    expect(result.pid).toBe(pid);
+    expect(result.scientificMetadata.temperature.value).toBe(305);
+
+    expect(datasetsService.findOne).toHaveBeenCalledWith({ where: { pid } });
+    expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    expect(checkSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should NOT update and throw 412 when if-unmodified-since is older than updatedAt", async () => {
+    const pid = "test-dataset-id";
+    const updateDto: PartialUpdateDatasetDto = {
+      scientificMetadata: { temperature: { value: 310, unit: "K" } },
+    };
+
+    const req = {
+      headers: { "content-type": "application/json" },
+      user: mockUser,
+    } as unknown as Request;
+
+    // Header is *before* updatedAt -> should fail with PRECONDITION_FAILED (412)
+    const headers = { "if-unmodified-since": "2024-12-31T12:00:00Z" };
+
+    const promise = controller.findByIdAndUpdate(req, pid, headers, updateDto);
+
+    await expect(promise).rejects.toThrow(
+      "Update error due to failed if-modified-since condition",
+    );
+
+    expect(datasetsService.findOne).toHaveBeenCalledWith({ where: { pid } });
+    expect(datasetsService.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(checkSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/datasets/datasets.v4.controller.spec.ts
+++ b/src/datasets/datasets.v4.controller.spec.ts
@@ -7,7 +7,6 @@ import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { HttpModule } from "@nestjs/axios";
 import { PartialUpdateDatasetDto } from "./dto/update-dataset.dto";
 import { Request } from "express";
-import { IsRecord, IsValueUnitObject } from "../common/utils";
 
 class DatasetsServiceMock {}
 
@@ -95,17 +94,14 @@ describe("DatasetsController (manual instantiate)", () => {
     };
 
     const req = {
-      headers: { "content-type": "application/json",
-        "if-unmodified-since": "2026-01-01T00:00:00Z" // Header is *after* updatedAt -> allowed
-       },
+      headers: {
+        "content-type": "application/json",
+        "if-unmodified-since": "2026-01-01T00:00:00Z", // Header is *after* updatedAt -> allowed
+      },
       user: mockUser,
     } as unknown as Request;
 
-    const result = await controller.findByIdAndUpdate(
-      req,
-      pid,
-      updateDto,
-    );
+    const result = await controller.findByIdAndUpdate(req, pid, updateDto);
 
     expect(result).toBeDefined();
     expect(result.pid).toBe(pid);
@@ -122,24 +118,21 @@ describe("DatasetsController (manual instantiate)", () => {
       title: "invalid header",
       header: { "if-unmodified-since": "not-a-date" } as Record<string, string>,
     },
-  ])("should update when if-unmodified-since is $title", async ({ header }) => {
+  ])("should update when if-unmodified-since is $title", async ({}) => {
     const pid = "test-dataset-id";
     const updateDto: PartialUpdateDatasetDto = {
       scientificMetadata: { temperature: { value: 305, unit: "K" } },
     };
 
     const req = {
-      headers: { "content-type": "application/json",
-        "if-unmodified-since": "not-a-date"
-       },
+      headers: {
+        "content-type": "application/json",
+        "if-unmodified-since": "not-a-date",
+      },
       user: mockUser,
     } as unknown as Request;
 
-    const result = await controller.findByIdAndUpdate(
-      req,
-      pid,
-      updateDto,
-    );
+    const result = await controller.findByIdAndUpdate(req, pid, updateDto);
 
     expect(result).toBeDefined();
     expect(result.pid).toBe(pid);
@@ -157,9 +150,10 @@ describe("DatasetsController (manual instantiate)", () => {
     };
 
     const req = {
-      headers: { "content-type": "application/json",
-        "if-unmodified-since": "2024-12-31T12:00:00Z" // Header is *before* updatedAt -> should fail with PRECONDITION_FAILED (412)
-       },
+      headers: {
+        "content-type": "application/json",
+        "if-unmodified-since": "2024-12-31T12:00:00Z", // Header is *before* updatedAt -> should fail with PRECONDITION_FAILED (412)
+      },
       user: mockUser,
     } as unknown as Request;
 

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -1,24 +1,26 @@
 import {
-  BadRequestException,
   Body,
-  ConflictException,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
-  HttpCode,
-  HttpStatus,
-  InternalServerErrorException,
-  NotFoundException,
   Param,
   Patch,
   Post,
   Put,
   Query,
-  Req,
   UseGuards,
   UseInterceptors,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Req,
+  BadRequestException,
+  ForbiddenException,
+  InternalServerErrorException,
+  ConflictException,
   UsePipes,
+  Headers,
+  HttpException,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -784,9 +786,31 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
   async findByIdAndUpdate(
     @Req() request: Request,
     @Param("pid") pid: string,
+    @Headers() headers: Record<string, string>,
     @Body()
     updateDatasetDto: PartialUpdateDatasetDto,
   ): Promise<OutputDatasetDto | null> {
+    return this.findByIdAndUpdateInternal(
+      request,
+      pid,
+      headers,
+      updateDatasetDto,
+    );
+  }
+
+  async findByIdAndUpdateInternal(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+    @Headers() headers: Record<string, string>,
+    @Body()
+    updateDatasetDto: PartialUpdateDatasetDto,
+  ): Promise<OutputDatasetDto | null> {
+    const headerDateString = headers["if-unmodified-since"];
+    const headerDate =
+      headerDateString && !isNaN(new Date(headerDateString).getTime())
+        ? new Date(headerDateString)
+        : null;
+
     const foundDataset = await this.datasetsService.findOne({
       where: { pid },
     });
@@ -813,15 +837,22 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
       );
     }
 
-    const updateDatasetDtoForService =
-      request.headers["content-type"] === "application/merge-patch+json"
-        ? jmp.apply(foundDataset, updateDatasetDto)
-        : updateDatasetDto;
-    const updatedDataset = await this.datasetsService.findByIdAndUpdate(
-      pid,
-      updateDatasetDtoForService,
-    );
-    return updatedDataset;
+    if (headerDate && headerDate <= foundDataset.updatedAt) {
+      throw new HttpException(
+        "Update error due to failed if-modified-since condition",
+        HttpStatus.PRECONDITION_FAILED,
+      );
+    } else {
+      const updateDatasetDtoForService =
+        request.headers["content-type"] === "application/merge-patch+json"
+          ? jmp.apply(foundDataset, updateDatasetDto)
+          : updateDatasetDto;
+      const updatedDataset = await this.datasetsService.findByIdAndUpdate(
+        pid,
+        updateDatasetDtoForService,
+      );
+      return updatedDataset;
+    }
   }
 
   // GET /datasets/:id/datasetlifecycle

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -1,23 +1,23 @@
 import {
+  BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
+  HttpCode,
+  HttpStatus,
+  InternalServerErrorException,
+  NotFoundException,
   Param,
   Patch,
   Post,
   Put,
   Query,
+  Req,
   UseGuards,
   UseInterceptors,
-  HttpCode,
-  HttpStatus,
-  NotFoundException,
-  Req,
-  BadRequestException,
-  ForbiddenException,
-  InternalServerErrorException,
-  ConflictException,
   UsePipes,
 } from "@nestjs/common";
 import {
@@ -801,7 +801,10 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
     );
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(foundDataset.updatedAt, request.headers["if-unmodified-since"]);
+    checkUnmodifiedSince(
+      foundDataset.updatedAt,
+      request.headers["if-unmodified-since"],
+    );
 
     if (foundDataset && IsRecord(updateDatasetDto) && IsRecord(foundDataset)) {
       const mismatchedPaths = this.findInvalidValueUnitUpdates(
@@ -828,7 +831,6 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
     );
     return updatedDataset;
   }
-
 
   // GET /datasets/:id/datasetlifecycle
   @UseGuards(PoliciesGuard)

--- a/src/instruments/instruments.controller.spec.ts
+++ b/src/instruments/instruments.controller.spec.ts
@@ -3,13 +3,30 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { InstrumentsController } from "./instruments.controller";
 import { InstrumentsService } from "./instruments.service";
+import {
+  NotFoundException,
+  HttpException,
+  ConflictException,
+} from "@nestjs/common";
+import { MongoError } from "mongodb";
 
-class InstrumentsServiceMock {}
+class InstrumentsServiceMock {
+  findOne = jest.fn();
+  update = jest.fn();
+}
 
 class CaslAbilityFactoryMock {}
 
 describe("InstrumentsController", () => {
   let controller: InstrumentsController;
+  let service: InstrumentsServiceMock;
+
+  const mockInstrument = {
+    _id: "123",
+    updatedAt: new Date("2025-09-01T10:00:00Z"),
+  };
+
+  const mockUpdateDto = { name: "Updated Instrument" };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,9 +39,59 @@ describe("InstrumentsController", () => {
     }).compile();
 
     controller = module.get<InstrumentsController>(InstrumentsController);
+    service = module.get<InstrumentsService>(InstrumentsService);
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  it("should throw NotFoundException if instrument not found", async () => {
+    service.findOne.mockResolvedValue(null);
+
+    await expect(controller.update("123", mockUpdateDto, {})).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it("should update if header is missing", async () => {
+    service.findOne.mockResolvedValue(mockInstrument);
+    service.update.mockResolvedValue({ ...mockInstrument, ...mockUpdateDto });
+
+    const result = await controller.update("123", mockUpdateDto, {});
+    expect(result).toEqual({ ...mockInstrument, ...mockUpdateDto });
+  });
+
+  it("should throw PRECONDITION_FAILED if header date <= updatedAt", async () => {
+    service.findOne.mockResolvedValue(mockInstrument);
+
+    const headers = {
+      "if-unmodified-since": "2025-09-01T09:00:00Z",
+    };
+
+    await expect(
+      controller.update("123", mockUpdateDto, headers),
+    ).rejects.toThrow(HttpException);
+  });
+
+  it("should update if header date > updatedAt", async () => {
+    service.findOne.mockResolvedValue(mockInstrument);
+    service.update.mockResolvedValue({ ...mockInstrument, ...mockUpdateDto });
+
+    const headers = {
+      "if-unmodified-since": "2025-09-02T10:00:00Z",
+    };
+
+    const result = await controller.update("123", mockUpdateDto, headers);
+    expect(result).toEqual({ ...mockInstrument, ...mockUpdateDto });
+  });
+
+  it("should throw ConflictException on duplicate key error", async () => {
+    service.findOne.mockResolvedValue(mockInstrument);
+    service.update.mockRejectedValue({ code: 11000 } as MongoError);
+
+    await expect(controller.update("123", mockUpdateDto, {})).rejects.toThrow(
+      ConflictException,
+    );
   });
 });

--- a/src/instruments/instruments.controller.ts
+++ b/src/instruments/instruments.controller.ts
@@ -1,20 +1,18 @@
 import {
-  Body,
-  ConflictException,
   Controller,
-  Delete,
   Get,
-  Headers,
-  HttpException,
-  HttpStatus,
-  InternalServerErrorException,
-  NotFoundException,
-  Param,
-  Patch,
   Post,
-  Query,
+  Body,
+  Patch,
+  Param,
+  Delete,
   UseGuards,
+  Query,
   UseInterceptors,
+  InternalServerErrorException,
+  ConflictException,
+  Headers,
+  NotFoundException,
 } from "@nestjs/common";
 import { MongoError } from "mongodb";
 import { InstrumentsService } from "./instruments.service";
@@ -164,13 +162,14 @@ export class InstrumentsController {
     @Body() updateInstrumentDto: PartialUpdateInstrumentDto,
     @Headers() headers: Record<string, string>,
   ): Promise<Instrument | null> {
-
-    const instrument = await this.instrumentsService.findOne({ where: { _id: id } });
+    const instrument = await this.instrumentsService.findOne({
+      where: { _id: id },
+    });
     if (!instrument) throw new NotFoundException("Instrument not found");
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(instrument.updatedAt, headers["if-unmodified-since"])
-    
+    checkUnmodifiedSince(instrument.updatedAt, headers["if-unmodified-since"]);
+
     try {
       const updatedInstrument = await this.instrumentsService.update(
         { _id: id },

--- a/src/instruments/instruments.service.spec.ts
+++ b/src/instruments/instruments.service.spec.ts
@@ -10,6 +10,10 @@ const mockInstrument: Instrument = {
   uniqueName: "Test",
   name: "Test",
   customMetadata: {},
+  createdAt: new Date(),
+  createdBy: "testUser",
+  updatedAt: new Date(),
+  updatedBy: "testUser",
 };
 
 describe("InstrumentsService", () => {
@@ -34,7 +38,7 @@ describe("InstrumentsService", () => {
       ],
     }).compile();
 
-    service = module.get<InstrumentsService>(InstrumentsService);
+    service = await module.resolve<InstrumentsService>(InstrumentsService);
     model = module.get<Model<Instrument>>(getModelToken("Instrument"));
   });
 

--- a/src/instruments/schemas/instrument.schema.ts
+++ b/src/instruments/schemas/instrument.schema.ts
@@ -2,6 +2,7 @@ import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 import { ApiProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 import { v4 as uuidv4 } from "uuid";
+import { QueryableClass } from "../../common/schemas/queryable.schema";
 
 export type InstrumentDocument = Instrument & Document;
 
@@ -13,7 +14,7 @@ export type InstrumentDocument = Instrument & Document;
     getters: true,
   },
 })
-export class Instrument {
+export class Instrument extends QueryableClass {
   @ApiProperty({
     type: String,
     default: function genUUID(): string {

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -37,7 +37,6 @@ describe("OrigDatablocksController", () => {
     );
 
     // Mock internal methods
-    controller["checkPermissionsForOrigDatablock"] = jest.fn();
     controller["updateDatasetSizeAndFiles"] = jest.fn();
   });
 
@@ -46,10 +45,7 @@ describe("OrigDatablocksController", () => {
   });
 
   describe("update", () => {
-    const mockRequest = {} as Request;
-    const mockHeaders = {
-      "if-unmodified-since": new Date().toUTCString(),
-    };
+    const mockRequest = { headers: { "if-unmodified-since": new Date().toUTCString()}} as Request;
     const mockDto = { name: "Updated Name" };
     const mockDatablock = {
       _id: "123",
@@ -60,8 +56,9 @@ describe("OrigDatablocksController", () => {
     it("should throw NotFoundException if datablock not found before update", async () => {
       origDatablocksService.findOne.mockResolvedValue(null);
 
+
       await expect(
-        controller.update(mockRequest, "123", mockHeaders, mockDto),
+        controller.update(mockRequest, "123", mockDto),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -71,8 +68,11 @@ describe("OrigDatablocksController", () => {
         updatedAt: new Date(),
       });
 
+      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
+      .mockResolvedValue(mockDatablock);
+
       await expect(
-        controller.update(mockRequest, "123", mockHeaders, mockDto),
+        controller.update(mockRequest, "123", mockDto),
       ).rejects.toThrow(HttpException);
     });
 
@@ -80,8 +80,11 @@ describe("OrigDatablocksController", () => {
       origDatablocksService.findOne.mockResolvedValue(mockDatablock);
       origDatablocksService.findByIdAndUpdate.mockResolvedValue(null);
 
+      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
+      .mockResolvedValue(mockDatablock);
+
       await expect(
-        controller.update(mockRequest, "123", mockHeaders, mockDto),
+        controller.update(mockRequest, "123", mockDto),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -93,10 +96,12 @@ describe("OrigDatablocksController", () => {
         updatedDatablock,
       );
 
+      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
+      .mockResolvedValue(updatedDatablock);
+
       const result = await controller.update(
         mockRequest,
         "123",
-        mockHeaders,
         mockDto,
       );
 
@@ -107,7 +112,7 @@ describe("OrigDatablocksController", () => {
     });
 
     describe("update", () => {
-      const mockRequest = {} as Request;
+      
       const mockDto = { name: "Updated Name" };
       const mockDatablock = {
         _id: "123",
@@ -124,12 +129,14 @@ describe("OrigDatablocksController", () => {
       });
 
       it("should proceed with update if 'if-unmodified-since' header is missing", async () => {
-        const headers = {}; // No header
+        const mockRequest = {headers :{}} as Request;// No header
+
+        jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
+      .mockResolvedValue(mockDatablock);
 
         const result = await controller.update(
           mockRequest,
           "123",
-          headers,
           mockDto,
         );
 
@@ -140,12 +147,14 @@ describe("OrigDatablocksController", () => {
       });
 
       it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
-        const headers = { "if-unmodified-since": "not-a-date" }; // Invalid date format
+        const mockRequest = {headers :{"if-unmodified-since": "not-a-date"}} as Request;// Invalid date format
+
+        jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
+      .mockResolvedValue(mockDatablock);
 
         const result = await controller.update(
           mockRequest,
           "123",
-          headers,
           mockDto,
         );
 

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -45,7 +45,9 @@ describe("OrigDatablocksController", () => {
   });
 
   describe("update", () => {
-    const mockRequest = { headers: { "if-unmodified-since": new Date().toUTCString()}} as Request;
+    const mockRequest = {
+      headers: { "if-unmodified-since": new Date().toUTCString() },
+    } as Request;
     const mockDto = { name: "Updated Name" };
     const mockDatablock = {
       _id: "123",
@@ -55,7 +57,6 @@ describe("OrigDatablocksController", () => {
 
     it("should throw NotFoundException if datablock not found before update", async () => {
       origDatablocksService.findOne.mockResolvedValue(null);
-
 
       await expect(
         controller.update(mockRequest, "123", mockDto),
@@ -68,8 +69,9 @@ describe("OrigDatablocksController", () => {
         updatedAt: new Date(),
       });
 
-      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
-      .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablock")
+        .mockResolvedValue(mockDatablock);
 
       await expect(
         controller.update(mockRequest, "123", mockDto),
@@ -80,8 +82,9 @@ describe("OrigDatablocksController", () => {
       origDatablocksService.findOne.mockResolvedValue(mockDatablock);
       origDatablocksService.findByIdAndUpdate.mockResolvedValue(null);
 
-      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
-      .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablock")
+        .mockResolvedValue(mockDatablock);
 
       await expect(
         controller.update(mockRequest, "123", mockDto),
@@ -96,14 +99,11 @@ describe("OrigDatablocksController", () => {
         updatedDatablock,
       );
 
-      jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
-      .mockResolvedValue(updatedDatablock);
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablock")
+        .mockResolvedValue(updatedDatablock);
 
-      const result = await controller.update(
-        mockRequest,
-        "123",
-        mockDto,
-      );
+      const result = await controller.update(mockRequest, "123", mockDto);
 
       expect(result).toEqual(updatedDatablock);
       expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
@@ -112,7 +112,6 @@ describe("OrigDatablocksController", () => {
     });
 
     describe("update", () => {
-      
       const mockDto = { name: "Updated Name" };
       const mockDatablock = {
         _id: "123",
@@ -129,16 +128,13 @@ describe("OrigDatablocksController", () => {
       });
 
       it("should proceed with update if 'if-unmodified-since' header is missing", async () => {
-        const mockRequest = {headers :{}} as Request;// No header
+        const mockRequest = { headers: {} } as Request; // No header
 
-        jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
-      .mockResolvedValue(mockDatablock);
+        jest
+          .spyOn(controller, "checkPermissionsForOrigDatablock")
+          .mockResolvedValue(mockDatablock);
 
-        const result = await controller.update(
-          mockRequest,
-          "123",
-          mockDto,
-        );
+        const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
         expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
@@ -147,16 +143,15 @@ describe("OrigDatablocksController", () => {
       });
 
       it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
-        const mockRequest = {headers :{"if-unmodified-since": "not-a-date"}} as Request;// Invalid date format
+        const mockRequest = {
+          headers: { "if-unmodified-since": "not-a-date" },
+        } as Request; // Invalid date format
 
-        jest.spyOn(controller as any, "checkPermissionsForOrigDatablock")
-      .mockResolvedValue(mockDatablock);
+        jest
+          .spyOn(controller, "checkPermissionsForOrigDatablock")
+          .mockResolvedValue(mockDatablock);
 
-        const result = await controller.update(
-          mockRequest,
-          "123",
-          mockDto,
-        );
+        const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
         expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -4,8 +4,13 @@ import { OrigDatablocksService } from "src/origdatablocks/origdatablocks.service
 import { DatasetsService } from "src/datasets/datasets.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { ConfigModule } from "@nestjs/config";
+import { NotFoundException, HttpException } from "@nestjs/common";
+import { Request } from "express";
 
-class OrigDatablocksServiceMock {}
+class OrigDatablocksServiceMock {
+  findOne = jest.fn();
+  findByIdAndUpdate = jest.fn();
+}
 
 class DatasetsServiceMock {}
 
@@ -13,6 +18,7 @@ class CaslAbilityFactoryMock {}
 
 describe("OrigDatablocksController", () => {
   let controller: OrigDatablocksController;
+  let origDatablocksService: OrigDatablocksServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -26,9 +32,128 @@ describe("OrigDatablocksController", () => {
     }).compile();
 
     controller = module.get<OrigDatablocksController>(OrigDatablocksController);
+    origDatablocksService = module.get<OrigDatablocksService>(
+      OrigDatablocksService,
+    );
+
+    // Mock internal methods
+    controller["checkPermissionsForOrigDatablock"] = jest.fn();
+    controller["updateDatasetSizeAndFiles"] = jest.fn();
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("update", () => {
+    const mockRequest = {} as Request;
+    const mockHeaders = {
+      "if-unmodified-since": new Date().toUTCString(),
+    };
+    const mockDto = { name: "Updated Name" };
+    const mockDatablock = {
+      _id: "123",
+      updatedAt: new Date(Date.now() - 1000),
+      datasetId: "ds1",
+    };
+
+    it("should throw NotFoundException if datablock not found before update", async () => {
+      origDatablocksService.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.update(mockRequest, "123", mockHeaders, mockDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw PreconditionFailed if header date <= updatedAt", async () => {
+      origDatablocksService.findOne.mockResolvedValue({
+        ...mockDatablock,
+        updatedAt: new Date(),
+      });
+
+      await expect(
+        controller.update(mockRequest, "123", mockHeaders, mockDto),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it("should throw NotFoundException if datablock not found after update", async () => {
+      origDatablocksService.findOne.mockResolvedValue(mockDatablock);
+      origDatablocksService.findByIdAndUpdate.mockResolvedValue(null);
+
+      await expect(
+        controller.update(mockRequest, "123", mockHeaders, mockDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should return updated datablock on success", async () => {
+      const updatedDatablock = { ...mockDatablock, name: "Updated Name" };
+
+      origDatablocksService.findOne.mockResolvedValue(mockDatablock);
+      origDatablocksService.findByIdAndUpdate.mockResolvedValue(
+        updatedDatablock,
+      );
+
+      const result = await controller.update(
+        mockRequest,
+        "123",
+        mockHeaders,
+        mockDto,
+      );
+
+      expect(result).toEqual(updatedDatablock);
+      expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
+        "ds1",
+      );
+    });
+
+    describe("update", () => {
+      const mockRequest = {} as Request;
+      const mockDto = { name: "Updated Name" };
+      const mockDatablock = {
+        _id: "123",
+        updatedAt: new Date(),
+        datasetId: "ds1",
+      };
+      const updatedDatablock = { ...mockDatablock, name: "Updated Name" };
+
+      beforeEach(() => {
+        origDatablocksService.findOne.mockResolvedValue(mockDatablock);
+        origDatablocksService.findByIdAndUpdate.mockResolvedValue(
+          updatedDatablock,
+        );
+      });
+
+      it("should proceed with update if 'if-unmodified-since' header is missing", async () => {
+        const headers = {}; // No header
+
+        const result = await controller.update(
+          mockRequest,
+          "123",
+          headers,
+          mockDto,
+        );
+
+        expect(result).toEqual(updatedDatablock);
+        expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
+          "ds1",
+        );
+      });
+
+      it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
+        const headers = { "if-unmodified-since": "not-a-date" }; // Invalid date format
+
+        const result = await controller.update(
+          mockRequest,
+          "123",
+          headers,
+          mockDto,
+        );
+
+        expect(result).toEqual(updatedDatablock);
+        expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
+          "ds1",
+        );
+      });
+    });
   });
 });

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -1,3 +1,4 @@
+import { checkUnmodifiedSince } from 'src/common/utils/check-unmodified-since';
 import {
   Controller,
   Get,
@@ -13,8 +14,6 @@ import {
   Req,
   ForbiddenException,
   NotFoundException,
-  Headers,
-  HttpException,
 } from "@nestjs/common";
 import { Request } from "express";
 import { OrigDatablocksService } from "./origdatablocks.service";
@@ -645,44 +644,26 @@ export class OrigDatablocksController {
   async update(
     @Req() request: Request,
     @Param("id") id: string,
-    @Headers() headers: Record<string, string>,
     @Body() updateOrigDatablockDto: PartialUpdateOrigDatablockDto,
   ): Promise<OrigDatablock | null> {
-    await this.checkPermissionsForOrigDatablock(
+    const datablock = await this.checkPermissionsForOrigDatablock(
       request,
       id,
       Action.OrigdatablockUpdate,
     );
 
-    const headerDateString = headers["if-unmodified-since"];
-    const headerDate =
-      headerDateString && !isNaN(new Date(headerDateString).getTime())
-        ? new Date(headerDateString)
-        : null;
+    //checks if the resource is unmodified since clients timestamp
+    checkUnmodifiedSince(datablock.updatedAt, request.headers["if-unmodified-since"])
 
-    const datablock = await this.origDatablocksService.findOne({
-      where: { _id: id },
-    });
-    if (!datablock) {
+    const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
+      id,
+      updateOrigDatablockDto,
+    );
+    if (!origdatablock) {
       throw new NotFoundException("Datablock not found");
     }
-
-    if (headerDate && headerDate <= datablock.updatedAt) {
-      throw new HttpException(
-        "Update error due to failed if-modified-since condition",
-        HttpStatus.PRECONDITION_FAILED,
-      );
-    } else {
-      const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
-        id,
-        updateOrigDatablockDto,
-      );
-      if (!origdatablock) {
-        throw new NotFoundException("Datablock not found");
-      }
-      await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
-      return origdatablock;
-    }
+    await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
+    return origdatablock;
   }
 
   // DELETE /origdatablocks/:id

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -1,4 +1,4 @@
-import { checkUnmodifiedSince } from 'src/common/utils/check-unmodified-since';
+import { checkUnmodifiedSince } from "src/common/utils/check-unmodified-since";
 import {
   Controller,
   Get,
@@ -653,7 +653,10 @@ export class OrigDatablocksController {
     );
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(datablock.updatedAt, request.headers["if-unmodified-since"])
+    checkUnmodifiedSince(
+      datablock.updatedAt,
+      request.headers["if-unmodified-since"],
+    );
 
     const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
       id,

--- a/src/origdatablocks/origdatablocks.v4.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.spec.ts
@@ -4,15 +4,24 @@ import { OrigDatablocksService } from "src/origdatablocks/origdatablocks.service
 import { DatasetsService } from "src/datasets/datasets.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { ConfigModule } from "@nestjs/config";
+import { NotFoundException, HttpException } from "@nestjs/common";
+import { Request } from "express";
 
-class OrigDatablocksServiceMock {}
+class OrigDatablocksServiceMock {
+  findOne = jest.fn();
+  findByIdAndUpdate = jest.fn();
+  findOneComplete = jest.fn();
+}
 
-class DatasetsServiceMock {}
+class DatasetsServiceMock {
+  findOneComplete = jest.fn();
+}
 
 class CaslAbilityFactoryMock {}
 
 describe("OrigDatablocksV4Controller", () => {
   let controller: OrigDatablocksV4Controller;
+  let origDatablocksService: OrigDatablocksServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,9 +37,144 @@ describe("OrigDatablocksV4Controller", () => {
     controller = module.get<OrigDatablocksV4Controller>(
       OrigDatablocksV4Controller,
     );
+    origDatablocksService = module.get(OrigDatablocksService);
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("findByIdAndUpdate", () => {
+    const mockRequest = {
+      user: { id: "user123" },
+    } as unknown as Request;
+
+    const mockHeaders = {
+      "if-unmodified-since": new Date().toISOString(),
+    };
+
+    const mockUpdateDto = {
+      name: "Updated Name",
+    };
+
+    const mockDatablock = {
+      _id: "db123",
+      updatedAt: new Date(Date.now() - 1000),
+      datasetId: "ds123",
+    };
+
+    const updatedDatablock = {
+      ...mockDatablock,
+      name: "Updated Name",
+    };
+
+    beforeEach(() => {
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(controller, "updateDatasetSizeAndFiles")
+        .mockResolvedValue(undefined);
+    });
+
+    it("should throw NotFoundException if datablock not found", async () => {
+      jest.spyOn(origDatablocksService, "findOne").mockResolvedValue(null);
+
+      await expect(
+        controller.findByIdAndUpdate(
+          mockRequest,
+          "db123",
+          mockHeaders,
+          mockUpdateDto,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw HttpException if header date is older than updatedAt", async () => {
+      jest.spyOn(origDatablocksService, "findOne").mockResolvedValue({
+        ...mockDatablock,
+        updatedAt: new Date(),
+      });
+
+      const oldDate = new Date(Date.now() - 10000).toISOString();
+      const headers = { "if-unmodified-since": oldDate };
+
+      await expect(
+        controller.findByIdAndUpdate(
+          mockRequest,
+          "db123",
+          headers,
+          mockUpdateDto,
+        ),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it("should throw NotFoundException if update returns null", async () => {
+      jest
+        .spyOn(origDatablocksService, "findOne")
+        .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(origDatablocksService, "findByIdAndUpdate")
+        .mockResolvedValue(null);
+
+      await expect(
+        controller.findByIdAndUpdate(mockRequest, "db123", {}, mockUpdateDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should return updated datablock on success", async () => {
+      jest
+        .spyOn(origDatablocksService, "findOne")
+        .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(origDatablocksService, "findByIdAndUpdate")
+        .mockResolvedValue(updatedDatablock);
+
+      const result = await controller.findByIdAndUpdate(
+        mockRequest,
+        "db123",
+        {},
+        mockUpdateDto,
+      );
+      expect(result).toEqual(updatedDatablock);
+    });
+
+    it("should succeed if 'if-unmodified-since' header is missing", async () => {
+      jest
+        .spyOn(origDatablocksService, "findOne")
+        .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(origDatablocksService, "findByIdAndUpdate")
+        .mockResolvedValue(updatedDatablock);
+
+      const result = await controller.findByIdAndUpdate(
+        mockRequest,
+        "db123",
+        {},
+        mockUpdateDto,
+      );
+      expect(result).toEqual(updatedDatablock);
+    });
+
+    it("should succeed if 'if-unmodified-since' header is malformed", async () => {
+      const malformedHeaders = {
+        "if-unmodified-since": "not-a-date",
+      };
+
+      jest
+        .spyOn(origDatablocksService, "findOne")
+        .mockResolvedValue(mockDatablock);
+      jest
+        .spyOn(origDatablocksService, "findByIdAndUpdate")
+        .mockResolvedValue(updatedDatablock);
+
+      const result = await controller.findByIdAndUpdate(
+        mockRequest,
+        "db123",
+        malformedHeaders,
+        mockUpdateDto,
+      );
+      expect(result).toEqual(updatedDatablock);
+    });
   });
 });

--- a/src/origdatablocks/origdatablocks.v4.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.spec.ts
@@ -45,7 +45,6 @@ describe("OrigDatablocksV4Controller", () => {
   });
 
   describe("findByIdAndUpdate", () => {
-
     const mockUpdateDto = {
       name: "Updated Name",
     };
@@ -72,17 +71,13 @@ describe("OrigDatablocksV4Controller", () => {
 
       const mockRequest = {
         user: { id: "user123" },
-        headers : {
-        "if-unmodified-since": new Date().toISOString(),
-      }}as unknown as Request;
-
+        headers: {
+          "if-unmodified-since": new Date().toISOString(),
+        },
+      } as unknown as Request;
 
       await expect(
-        controller.findByIdAndUpdate(
-          mockRequest,
-          "db123",
-          mockUpdateDto,
-        ),
+        controller.findByIdAndUpdate(mockRequest, "db123", mockUpdateDto),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -94,18 +89,17 @@ describe("OrigDatablocksV4Controller", () => {
 
       const mockRequest = {
         user: { id: "user123" },
-        headers : {
-        "if-unmodified-since": new Date(Date.now() - 10000).toISOString()
-      }} as unknown as Request;
+        headers: {
+          "if-unmodified-since": new Date(Date.now() - 10000).toISOString(),
+        },
+      } as unknown as Request;
 
-      jest.spyOn(controller as any, "checkPermissionsForOrigDatablockWrite").mockResolvedValue(updatedDatablock)
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock);
 
       await expect(
-        controller.findByIdAndUpdate(
-          mockRequest,
-          "db123",
-          mockUpdateDto,
-        ),
+        controller.findByIdAndUpdate(mockRequest, "db123", mockUpdateDto),
       ).rejects.toThrow(HttpException);
     });
 
@@ -117,11 +111,12 @@ describe("OrigDatablocksV4Controller", () => {
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(null);
 
-        const mockRequest = {
+      const mockRequest = {
         user: { id: "user123" },
-        headers : {
-        "if-unmodified-since": new Date(Date.now() - 10000).toISOString()
-      }} as unknown as Request;
+        headers: {
+          "if-unmodified-since": new Date(Date.now() - 10000).toISOString(),
+        },
+      } as unknown as Request;
 
       await expect(
         controller.findByIdAndUpdate(mockRequest, "db123", {}, mockUpdateDto),
@@ -136,11 +131,14 @@ describe("OrigDatablocksV4Controller", () => {
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
 
-      jest.spyOn(controller as any, "checkPermissionsForOrigDatablockWrite").mockResolvedValue(updatedDatablock)
+      jest
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock);
 
       const mockRequest = {
         user: { id: "user123" },
-        headers : {}} as unknown as Request;
+        headers: {},
+      } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(
         mockRequest,
@@ -157,15 +155,14 @@ describe("OrigDatablocksV4Controller", () => {
       jest
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
-      
+
       jest
-        .spyOn(controller as any, "checkPermissionsForOrigDatablockWrite")
-        .mockResolvedValue(updatedDatablock)
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock);
 
       const mockRequest = {
-        user: { id: "user123",
-        },
-        headers: {}
+        user: { id: "user123" },
+        headers: {},
       } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(
@@ -177,22 +174,20 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should succeed if 'if-unmodified-since' header is malformed", async () => {
-
       jest
         .spyOn(origDatablocksService, "findOne")
         .mockResolvedValue(mockDatablock);
       jest
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
-      
+
       jest
-        .spyOn(controller as any, "checkPermissionsForOrigDatablockWrite")
-        .mockResolvedValue(updatedDatablock)
-      
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock);
+
       const mockRequest = {
-        user: { id: "user123",
-        },
-        headers: { "if-unmodified-since": "not-a-date"}
+        user: { id: "user123" },
+        headers: { "if-unmodified-since": "not-a-date" },
       } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(

--- a/src/origdatablocks/origdatablocks.v4.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.spec.ts
@@ -45,13 +45,6 @@ describe("OrigDatablocksV4Controller", () => {
   });
 
   describe("findByIdAndUpdate", () => {
-    const mockRequest = {
-      user: { id: "user123" },
-    } as unknown as Request;
-
-    const mockHeaders = {
-      "if-unmodified-since": new Date().toISOString(),
-    };
 
     const mockUpdateDto = {
       name: "Updated Name",
@@ -70,9 +63,6 @@ describe("OrigDatablocksV4Controller", () => {
 
     beforeEach(() => {
       jest
-        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
-        .mockResolvedValue(mockDatablock);
-      jest
         .spyOn(controller, "updateDatasetSizeAndFiles")
         .mockResolvedValue(undefined);
     });
@@ -80,11 +70,17 @@ describe("OrigDatablocksV4Controller", () => {
     it("should throw NotFoundException if datablock not found", async () => {
       jest.spyOn(origDatablocksService, "findOne").mockResolvedValue(null);
 
+      const mockRequest = {
+        user: { id: "user123" },
+        headers : {
+        "if-unmodified-since": new Date().toISOString(),
+      }}as unknown as Request;
+
+
       await expect(
         controller.findByIdAndUpdate(
           mockRequest,
           "db123",
-          mockHeaders,
           mockUpdateDto,
         ),
       ).rejects.toThrow(NotFoundException);
@@ -96,14 +92,18 @@ describe("OrigDatablocksV4Controller", () => {
         updatedAt: new Date(),
       });
 
-      const oldDate = new Date(Date.now() - 10000).toISOString();
-      const headers = { "if-unmodified-since": oldDate };
+      const mockRequest = {
+        user: { id: "user123" },
+        headers : {
+        "if-unmodified-since": new Date(Date.now() - 10000).toISOString()
+      }} as unknown as Request;
+
+      jest.spyOn(controller as any, "checkPermissionsForOrigDatablockWrite").mockResolvedValue(updatedDatablock)
 
       await expect(
         controller.findByIdAndUpdate(
           mockRequest,
           "db123",
-          headers,
           mockUpdateDto,
         ),
       ).rejects.toThrow(HttpException);
@@ -116,6 +116,12 @@ describe("OrigDatablocksV4Controller", () => {
       jest
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(null);
+
+        const mockRequest = {
+        user: { id: "user123" },
+        headers : {
+        "if-unmodified-since": new Date(Date.now() - 10000).toISOString()
+      }} as unknown as Request;
 
       await expect(
         controller.findByIdAndUpdate(mockRequest, "db123", {}, mockUpdateDto),
@@ -130,10 +136,15 @@ describe("OrigDatablocksV4Controller", () => {
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
 
+      jest.spyOn(controller as any, "checkPermissionsForOrigDatablockWrite").mockResolvedValue(updatedDatablock)
+
+      const mockRequest = {
+        user: { id: "user123" },
+        headers : {}} as unknown as Request;
+
       const result = await controller.findByIdAndUpdate(
         mockRequest,
         "db123",
-        {},
         mockUpdateDto,
       );
       expect(result).toEqual(updatedDatablock);
@@ -146,20 +157,26 @@ describe("OrigDatablocksV4Controller", () => {
       jest
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
+      
+      jest
+        .spyOn(controller as any, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock)
+
+      const mockRequest = {
+        user: { id: "user123",
+        },
+        headers: {}
+      } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(
         mockRequest,
         "db123",
-        {},
         mockUpdateDto,
       );
       expect(result).toEqual(updatedDatablock);
     });
 
     it("should succeed if 'if-unmodified-since' header is malformed", async () => {
-      const malformedHeaders = {
-        "if-unmodified-since": "not-a-date",
-      };
 
       jest
         .spyOn(origDatablocksService, "findOne")
@@ -167,11 +184,20 @@ describe("OrigDatablocksV4Controller", () => {
       jest
         .spyOn(origDatablocksService, "findByIdAndUpdate")
         .mockResolvedValue(updatedDatablock);
+      
+      jest
+        .spyOn(controller as any, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock)
+      
+      const mockRequest = {
+        user: { id: "user123",
+        },
+        headers: { "if-unmodified-since": "not-a-date"}
+      } as unknown as Request;
 
       const result = await controller.findByIdAndUpdate(
         mockRequest,
         "db123",
-        malformedHeaders,
         mockUpdateDto,
       );
       expect(result).toEqual(updatedDatablock);

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -795,10 +795,10 @@ export class OrigDatablocksV4Controller {
       updateOrigDatablockDto,
     );
 
-    if (!origdatablock) {
-      throw new NotFoundException("Datablock not found");
+    if (origdatablock) {
+      await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
     }
-    await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
+
     return origdatablock;
   }
 

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -773,16 +773,11 @@ export class OrigDatablocksV4Controller {
     @Param("id") id: string,
     @Body() updateOrigDatablockDto: PartialUpdateOrigDatablockDto,
   ): Promise<OrigDatablock | null> {
-    await this.checkPermissionsForOrigDatablockWrite(
+    const datablock = (await this.checkPermissionsForOrigDatablockWrite(
       request,
       id,
       Action.OrigdatablockUpdate,
-    );
-
-    const datablock = await this.origDatablocksService.findOne({
-      where: { _id: id },
-    });
-    if (!datablock) throw new NotFoundException("Datablock not found");
+    )) as OrigDatablock;
 
     //checks if the resource is unmodified since clients timestamp
     checkUnmodifiedSince(

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -785,7 +785,10 @@ export class OrigDatablocksV4Controller {
     if (!datablock) throw new NotFoundException("Datablock not found");
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(datablock.updatedAt, request.headers["if-unmodified-since"])
+    checkUnmodifiedSince(
+      datablock.updatedAt,
+      request.headers["if-unmodified-since"],
+    );
 
     const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
       id,

--- a/src/proposals/proposals.controller.spec.ts
+++ b/src/proposals/proposals.controller.spec.ts
@@ -37,8 +37,6 @@ describe("ProposalsController", () => {
     controller = module.get<ProposalsController>(ProposalsController);
     proposalsService = module.get(ProposalsService);
 
-    // Mock permission check
-    controller["checkPermissionsForProposal"] = jest.fn();
   });
 
   it("should be defined", () => {
@@ -63,6 +61,9 @@ describe("ProposalsController", () => {
       const proposal = { updatedAt: new Date("2023-01-01") } as ProposalClass;
       proposalsService.findOne.mockResolvedValue(proposal);
 
+      jest.spyOn(controller as any, "checkPermissionsForProposal")
+      .mockResolvedValue(proposal);
+
       const headers = {
         "if-unmodified-since": "2022-12-31",
       };
@@ -86,6 +87,9 @@ describe("ProposalsController", () => {
 
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
+
+      jest.spyOn(controller as any, "checkPermissionsForProposal")
+      .mockResolvedValue(proposal);
 
       const headers = {
         "if-unmodified-since": "2023-01-01",
@@ -112,6 +116,9 @@ describe("ProposalsController", () => {
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
 
+      jest.spyOn(controller as any, "checkPermissionsForProposal")
+      .mockResolvedValue(proposal);
+
       const headers = {}; // No 'if-unmodified-since'
 
       const result = await controller.update({}, "proposal-id", headers, {
@@ -130,6 +137,9 @@ describe("ProposalsController", () => {
 
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
+
+      jest.spyOn(controller as any, "checkPermissionsForProposal")
+      .mockResolvedValue(proposal);
 
       const headers = {
         "if-unmodified-since": "not-a-valid-date",

--- a/src/proposals/proposals.controller.spec.ts
+++ b/src/proposals/proposals.controller.spec.ts
@@ -36,7 +36,6 @@ describe("ProposalsController", () => {
 
     controller = module.get<ProposalsController>(ProposalsController);
     proposalsService = module.get(ProposalsService);
-
   });
 
   it("should be defined", () => {
@@ -61,8 +60,9 @@ describe("ProposalsController", () => {
       const proposal = { updatedAt: new Date("2023-01-01") } as ProposalClass;
       proposalsService.findOne.mockResolvedValue(proposal);
 
-      jest.spyOn(controller as any, "checkPermissionsForProposal")
-      .mockResolvedValue(proposal);
+      jest
+        .spyOn(controller, "checkPermissionsForProposal")
+        .mockResolvedValue(proposal);
 
       const headers = {
         "if-unmodified-since": "2022-12-31",
@@ -88,8 +88,9 @@ describe("ProposalsController", () => {
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
 
-      jest.spyOn(controller as any, "checkPermissionsForProposal")
-      .mockResolvedValue(proposal);
+      jest
+        .spyOn(controller, "checkPermissionsForProposal")
+        .mockResolvedValue(proposal);
 
       const headers = {
         "if-unmodified-since": "2023-01-01",
@@ -116,8 +117,9 @@ describe("ProposalsController", () => {
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
 
-      jest.spyOn(controller as any, "checkPermissionsForProposal")
-      .mockResolvedValue(proposal);
+      jest
+        .spyOn(controller, "checkPermissionsForProposal")
+        .mockResolvedValue(proposal);
 
       const headers = {}; // No 'if-unmodified-since'
 
@@ -138,8 +140,9 @@ describe("ProposalsController", () => {
       proposalsService.findOne.mockResolvedValue(proposal);
       proposalsService.update.mockResolvedValue(updatedProposal);
 
-      jest.spyOn(controller as any, "checkPermissionsForProposal")
-      .mockResolvedValue(proposal);
+      jest
+        .spyOn(controller, "checkPermissionsForProposal")
+        .mockResolvedValue(proposal);
 
       const headers = {
         "if-unmodified-since": "not-a-valid-date",

--- a/src/proposals/proposals.controller.spec.ts
+++ b/src/proposals/proposals.controller.spec.ts
@@ -4,17 +4,24 @@ import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { ProposalsController } from "./proposals.controller";
 import { ProposalsService } from "./proposals.service";
+import { NotFoundException, HttpException } from "@nestjs/common";
+import { PartialUpdateProposalDto } from "./dto/update-proposal.dto";
+import { ProposalClass } from "./schemas/proposal.schema";
 
 class AttachmentsServiceMock {}
 
 class DatasetsServiceMock {}
 
-class ProposalsServiceMock {}
+class ProposalsServiceMock {
+  findOne = jest.fn();
+  update = jest.fn();
+}
 
 class CaslAbilityFactoryMock {}
 
 describe("ProposalsController", () => {
   let controller: ProposalsController;
+  let proposalsService: ProposalsServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,9 +35,111 @@ describe("ProposalsController", () => {
     }).compile();
 
     controller = module.get<ProposalsController>(ProposalsController);
+    proposalsService = module.get(ProposalsService);
+
+    // Mock permission check
+    controller["checkPermissionsForProposal"] = jest.fn();
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("update", () => {
+    it("should throw NotFoundException if proposal not found", async () => {
+      proposalsService.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.update(
+          {},
+          "proposal-id",
+          {},
+          {} as PartialUpdateProposalDto,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw HttpException if headerDate <= proposal.updatedAt", async () => {
+      const proposal = { updatedAt: new Date("2023-01-01") } as ProposalClass;
+      proposalsService.findOne.mockResolvedValue(proposal);
+
+      const headers = {
+        "if-unmodified-since": "2022-12-31",
+      };
+
+      await expect(
+        controller.update(
+          {},
+          "proposal-id",
+          headers,
+          {} as PartialUpdateProposalDto,
+        ),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it("should call update and return updated proposal", async () => {
+      const proposal = { updatedAt: new Date("2022-12-31") } as ProposalClass;
+      const updatedProposal = {
+        ...proposal,
+        title: "Updated",
+      } as ProposalClass;
+
+      proposalsService.findOne.mockResolvedValue(proposal);
+      proposalsService.update.mockResolvedValue(updatedProposal);
+
+      const headers = {
+        "if-unmodified-since": "2023-01-01",
+      };
+
+      const result = await controller.update({}, "proposal-id", headers, {
+        title: "Updated",
+      });
+
+      expect(result).toEqual(updatedProposal);
+      expect(proposalsService.update).toHaveBeenCalledWith(
+        { proposalId: "proposal-id" },
+        { title: "Updated" },
+      );
+    });
+
+    it("should proceed with update if header is missing", async () => {
+      const proposal = { updatedAt: new Date("2023-01-01") } as ProposalClass;
+      const updatedProposal = {
+        ...proposal,
+        title: "Updated",
+      } as ProposalClass;
+
+      proposalsService.findOne.mockResolvedValue(proposal);
+      proposalsService.update.mockResolvedValue(updatedProposal);
+
+      const headers = {}; // No 'if-unmodified-since'
+
+      const result = await controller.update({}, "proposal-id", headers, {
+        title: "Updated",
+      });
+
+      expect(result).toEqual(updatedProposal);
+    });
+
+    it("should proceed with update if header is invalid date string", async () => {
+      const proposal = { updatedAt: new Date("2023-01-01") } as ProposalClass;
+      const updatedProposal = {
+        ...proposal,
+        title: "Updated",
+      } as ProposalClass;
+
+      proposalsService.findOne.mockResolvedValue(proposal);
+      proposalsService.update.mockResolvedValue(updatedProposal);
+
+      const headers = {
+        "if-unmodified-since": "not-a-valid-date",
+      };
+
+      const result = await controller.update({}, "proposal-id", headers, {
+        title: "Updated",
+      });
+
+      expect(result).toEqual(updatedProposal);
+    });
   });
 });

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -725,7 +725,6 @@ export class ProposalsController {
     @Headers() headers: Record<string, string>,
     @Body() updateProposalDto: PartialUpdateProposalDto,
   ): Promise<ProposalClass | null> {
-
     const proposal = await this.checkPermissionsForProposal(
       request,
       proposalId,
@@ -733,7 +732,7 @@ export class ProposalsController {
     );
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(proposal.updatedAt, headers["if-unmodified-since"])
+    checkUnmodifiedSince(proposal.updatedAt, headers["if-unmodified-since"]);
 
     return this.proposalsService.update(
       { proposalId: proposalId },

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -12,7 +12,6 @@ import {
   HttpStatus,
   NotFoundException,
   Req,
-  Headers,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -406,7 +405,6 @@ export class PublishedDataV4Controller {
   async publish(
     @Req() request: Request,
     @Param("id") id: string,
-    @Headers() headers: Record<string, string>,
   ): Promise<PublishedData | null> {
     const filter = this.getAccessBasedFilters(request, id);
     const publishedData = await this.publishedDataService.findOne(filter);
@@ -428,14 +426,9 @@ export class PublishedDataV4Controller {
     const datasetPids = publishedData.datasetPids;
     await Promise.all(
       datasetPids.map(async (pid) => {
-        await this.datasetsController.findByIdAndUpdateInternal(
-          request,
-          pid,
-          headers,
-          {
-            isPublished: true,
-          },
-        );
+        await this.datasetsController.findByIdAndUpdate(request, pid, {
+          isPublished: true,
+        });
       }),
     );
 
@@ -570,7 +563,6 @@ export class PublishedDataV4Controller {
   async register(
     @Req() request: Request,
     @Param("id") id: string,
-    @Headers() headers: Record<string, string>,
   ): Promise<IRegister | null> {
     const filter = this.getAccessBasedFilters(request, id);
     const publishedData = await this.publishedDataService.findOne(filter);
@@ -593,15 +585,10 @@ export class PublishedDataV4Controller {
 
     await Promise.all(
       publishedData.datasetPids.map(async (pid) => {
-        await this.datasetsController.findByIdAndUpdateInternal(
-          request,
-          pid,
-          headers,
-          {
-            isPublished: true,
-            datasetlifecycle: { publishedOn: data.registeredTime },
-          },
-        );
+        await this.datasetsController.findByIdAndUpdate(request, pid, {
+          isPublished: true,
+          datasetlifecycle: { publishedOn: data.registeredTime },
+        });
       }),
     );
     const registerDoiUri = this.configService.get<string>("registerDoiUri");

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpStatus,
   NotFoundException,
   Req,
+  Headers,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -405,6 +406,7 @@ export class PublishedDataV4Controller {
   async publish(
     @Req() request: Request,
     @Param("id") id: string,
+    @Headers() headers: Record<string, string>,
   ): Promise<PublishedData | null> {
     const filter = this.getAccessBasedFilters(request, id);
     const publishedData = await this.publishedDataService.findOne(filter);
@@ -426,9 +428,14 @@ export class PublishedDataV4Controller {
     const datasetPids = publishedData.datasetPids;
     await Promise.all(
       datasetPids.map(async (pid) => {
-        await this.datasetsController.findByIdAndUpdate(request, pid, {
-          isPublished: true,
-        });
+        await this.datasetsController.findByIdAndUpdateInternal(
+          request,
+          pid,
+          headers,
+          {
+            isPublished: true,
+          },
+        );
       }),
     );
 
@@ -563,6 +570,7 @@ export class PublishedDataV4Controller {
   async register(
     @Req() request: Request,
     @Param("id") id: string,
+    @Headers() headers: Record<string, string>,
   ): Promise<IRegister | null> {
     const filter = this.getAccessBasedFilters(request, id);
     const publishedData = await this.publishedDataService.findOne(filter);
@@ -585,10 +593,15 @@ export class PublishedDataV4Controller {
 
     await Promise.all(
       publishedData.datasetPids.map(async (pid) => {
-        await this.datasetsController.findByIdAndUpdate(request, pid, {
-          isPublished: true,
-          datasetlifecycle: { publishedOn: data.registeredTime },
-        });
+        await this.datasetsController.findByIdAndUpdateInternal(
+          request,
+          pid,
+          headers,
+          {
+            isPublished: true,
+            datasetlifecycle: { publishedOn: data.registeredTime },
+          },
+        );
       }),
     );
     const registerDoiUri = this.configService.get<string>("registerDoiUri");

--- a/src/samples/samples.controller.spec.ts
+++ b/src/samples/samples.controller.spec.ts
@@ -4,17 +4,25 @@ import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { SamplesController } from "./samples.controller";
 import { SamplesService } from "./samples.service";
+import { NotFoundException, HttpException } from "@nestjs/common";
+import { Request } from "express";
+import { SampleClass } from "./schemas/sample.schema";
+import { PartialUpdateSampleDto } from "./dto/update-sample.dto";
 
 class AttachmentsServiceMock {}
 
 class DatasetsServiceMock {}
 
-class SamplesServiceMock {}
-
 class CaslAbilityFactoryMock {}
+
+class SamplesServiceMock {
+  findOne = jest.fn();
+  update = jest.fn();
+}
 
 describe("SamplesController", () => {
   let controller: SamplesController;
+  let samplesService: SamplesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,9 +36,86 @@ describe("SamplesController", () => {
     }).compile();
 
     controller = module.get<SamplesController>(SamplesController);
+    samplesService = module.get<SamplesService>(SamplesService);
+    jest.spyOn(controller, "checkPermissionsForSample").mockResolvedValue(true);
   });
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("update", () => {
+    const sampleId = "sample123";
+    const updateDto: PartialUpdateSampleDto = { name: "Updated Sample" };
+    const mockRequest = {} as Request;
+
+    it("should update sample when header is missing", async () => {
+      const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
+      samplesService.findOne.mockResolvedValue(sample);
+      samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+      const result = await controller.update(
+        mockRequest,
+        sampleId,
+        updateDto,
+        {},
+      );
+      expect(result).toEqual({ ...sample, ...updateDto });
+    });
+
+    it("should throw NotFoundException if sample not found", async () => {
+      samplesService.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.update(mockRequest, sampleId, updateDto, {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it("should throw PreconditionFailed if header date is older than updatedAt", async () => {
+      const sample = {
+        _id: sampleId,
+        updatedAt: new Date("2023-01-01"),
+      } as SampleClass;
+      samplesService.findOne.mockResolvedValue(sample);
+
+      const headers = {
+        "if-unmodified-since": new Date("2022-01-01").toUTCString(),
+      };
+
+      await expect(
+        controller.update(mockRequest, sampleId, updateDto, headers),
+      ).rejects.toThrow(HttpException);
+    });
+    it("should update sample if header date is invalid", async () => {
+      const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
+      samplesService.findOne.mockResolvedValue(sample);
+      samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+      const headers = {
+        "if-unmodified-since": "invalid-date-string",
+      };
+
+      const result = await controller.update(
+        mockRequest,
+        sampleId,
+        updateDto,
+        headers,
+      );
+      expect(result).toEqual({ ...sample, ...updateDto });
+    });
+
+    it("should update sample if header date is not present", async () => {
+      const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
+      samplesService.findOne.mockResolvedValue(sample);
+      samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+      const result = await controller.update(
+        mockRequest,
+        sampleId,
+        updateDto,
+        {},
+      );
+      expect(result).toEqual({ ...sample, ...updateDto });
+    });
   });
 });

--- a/src/samples/samples.controller.spec.ts
+++ b/src/samples/samples.controller.spec.ts
@@ -37,7 +37,6 @@ describe("SamplesController", () => {
 
     controller = module.get<SamplesController>(SamplesController);
     samplesService = module.get<SamplesService>(SamplesService);
-    jest.spyOn(controller, "checkPermissionsForSample").mockResolvedValue(true);
   });
 
   it("should be defined", () => {
@@ -50,9 +49,13 @@ describe("SamplesController", () => {
     const mockRequest = {} as Request;
 
     it("should update sample when header is missing", async () => {
-      const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
+      const sample = { _id: sampleId, updatedAt: new Date("2023-01-01") } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+      jest.spyOn(controller as any, "checkPermissionsForSample")
+      .mockResolvedValue(sample);
+
 
       const result = await controller.update(
         mockRequest,
@@ -78,6 +81,9 @@ describe("SamplesController", () => {
       } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
 
+       jest.spyOn(controller as any, "checkPermissionsForSample")
+      .mockResolvedValue(sample);
+
       const headers = {
         "if-unmodified-since": new Date("2022-01-01").toUTCString(),
       };
@@ -90,6 +96,9 @@ describe("SamplesController", () => {
       const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+       jest.spyOn(controller as any, "checkPermissionsForSample")
+      .mockResolvedValue(sample);
 
       const headers = {
         "if-unmodified-since": "invalid-date-string",
@@ -108,6 +117,9 @@ describe("SamplesController", () => {
       const sample = { _id: sampleId, updatedAt: new Date() } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
+
+       jest.spyOn(controller as any, "checkPermissionsForSample")
+      .mockResolvedValue(sample);
 
       const result = await controller.update(
         mockRequest,

--- a/src/samples/samples.controller.spec.ts
+++ b/src/samples/samples.controller.spec.ts
@@ -49,13 +49,16 @@ describe("SamplesController", () => {
     const mockRequest = {} as Request;
 
     it("should update sample when header is missing", async () => {
-      const sample = { _id: sampleId, updatedAt: new Date("2023-01-01") } as SampleClass;
+      const sample = {
+        _id: sampleId,
+        updatedAt: new Date("2023-01-01"),
+      } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
 
-      jest.spyOn(controller as any, "checkPermissionsForSample")
-      .mockResolvedValue(sample);
-
+      jest
+        .spyOn(controller, "checkPermissionsForSample")
+        .mockResolvedValue(sample);
 
       const result = await controller.update(
         mockRequest,
@@ -81,8 +84,9 @@ describe("SamplesController", () => {
       } as SampleClass;
       samplesService.findOne.mockResolvedValue(sample);
 
-       jest.spyOn(controller as any, "checkPermissionsForSample")
-      .mockResolvedValue(sample);
+      jest
+        .spyOn(controller, "checkPermissionsForSample")
+        .mockResolvedValue(sample);
 
       const headers = {
         "if-unmodified-since": new Date("2022-01-01").toUTCString(),
@@ -97,8 +101,9 @@ describe("SamplesController", () => {
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
 
-       jest.spyOn(controller as any, "checkPermissionsForSample")
-      .mockResolvedValue(sample);
+      jest
+        .spyOn(controller, "checkPermissionsForSample")
+        .mockResolvedValue(sample);
 
       const headers = {
         "if-unmodified-since": "invalid-date-string",
@@ -118,8 +123,9 @@ describe("SamplesController", () => {
       samplesService.findOne.mockResolvedValue(sample);
       samplesService.update.mockResolvedValue({ ...sample, ...updateDto });
 
-       jest.spyOn(controller as any, "checkPermissionsForSample")
-      .mockResolvedValue(sample);
+      jest
+        .spyOn(controller, "checkPermissionsForSample")
+        .mockResolvedValue(sample);
 
       const result = await controller.update(
         mockRequest,

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -701,10 +701,14 @@ export class SamplesController {
     @Body() updateSampleDto: PartialUpdateSampleDto,
     @Headers() headers: Record<string, string>,
   ): Promise<SampleClass | null> {
-    const sample = await this.checkPermissionsForSample(request, id, Action.SampleUpdate);
+    const sample = await this.checkPermissionsForSample(
+      request,
+      id,
+      Action.SampleUpdate,
+    );
 
     //checks if the resource is unmodified since clients timestamp
-    checkUnmodifiedSince(sample.updatedAt, headers["if-unmodified-since"])
+    checkUnmodifiedSince(sample.updatedAt, headers["if-unmodified-since"]);
 
     return this.samplesService.update({ sampleId: id }, updateSampleDto);
   }


### PR DESCRIPTION
<!--
Follow up PR for #2138. Introducing "if-unmodified-since" header field to implement optimistic concurrency control for patch requests.
-->

## Description
This is a direct followup PR for #2138, addressing the change requests. Mainly introducing a helper function to reduce the code duplication in each controller function. The following Endpoints are modified:

- Sample
- Attachments
- Datasets
- datasets.v4
- instruments
- origdatablocks
- origdatablocks.v4
- proposals

The tests were left as they were in PR #2138, except for minor adjustments. 

## Changes compared to original PR:

- introduced helper function to reduce code duplication
- removed the check in pusblished dataset
- uniform header access using request.headers
- removed findByIdAndUpdateInternal in publish datasets