### PR TITLE
fix: return history _id as string

### DIFF
--- a/src/datasets/utils/history.util.ts
+++ b/src/datasets/utils/history.util.ts
@@ -5,6 +5,7 @@ import {
   DatasetDocument,
 } from "src/datasets/schemas/dataset.schema";
 import { computeDeltaWithOriginals } from "src/common/utils/delta.util";
+import { cloneDeep } from "lodash";
 
 const IGNORE_FIELDS = ["updatedAt", "updatedBy", "_id"];
 
@@ -94,7 +95,7 @@ export function convertGenericHistoriesToObsoleteHistories(
 ): HistoryClass[] {
   let currentDatasetCopy;
   if ("$clone" in currentDataset) currentDatasetCopy = currentDataset.$clone();
-  else currentDatasetCopy = structuredClone(currentDataset);
+  else currentDatasetCopy = cloneDeep(currentDataset);
   const result: HistoryClass[] = [];
   for (const history of histories) {
     const obsoleteHistory = convertGenericHistoryToObsoleteHistory(

--- a/test/jest-e2e-tests/datasetHistory.e2e-spec.ts
+++ b/test/jest-e2e-tests/datasetHistory.e2e-spec.ts
@@ -1,0 +1,74 @@
+import request from "supertest";
+import { INestApplication } from "@nestjs/common";
+import { getConnectionToken } from "@nestjs/mongoose";
+import { Connection } from "mongoose";
+import { createTestingApp, createTestingModuleFactory } from "./utlis";
+import { getToken } from "../LoginUtils";
+import { TestData } from "../TestData";
+
+describe("Test v3 history in datasetLifecycle", () => {
+  let app: INestApplication;
+  let mongoConnection: Connection;
+  let token: string;
+  process.env.TRACKABLES = "Dataset";
+  process.env.TRACKABLE_STRATEGY = "delta";
+  process.env.HISTORY_ACCESS_DATASET_GROUPS = "";
+
+  let dsId: string;
+
+  beforeAll(async () => {
+    const moduleFixture = await createTestingModuleFactory().compile();
+    app = await createTestingApp(moduleFixture);
+    mongoConnection = await app.get<Promise<Connection>>(getConnectionToken());
+  });
+
+  beforeAll(async () => {
+    token = await getToken(app.getHttpServer(), {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+  });
+
+  beforeAll(async () => {
+    const dataset = {
+      ...TestData.RawCorrectMin,
+      ownerGroup: "group1",
+      accessGroups: ["access1@group.site", "access2@group.site"],
+    };
+
+    const ds = await request(app.getHttpServer())
+      .post("/api/v3/datasets")
+      .send(dataset)
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(TestData.EntryCreatedStatusCode);
+    dsId = ds.body._id;
+  });
+
+  afterAll(async () => {
+    if (mongoConnection.db) await mongoConnection.db.dropDatabase();
+    await app.close();
+  });
+
+  it("Should check v3 built history", async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v3/datasets/${encodeURIComponent(dsId)}/datasetlifecycle`)
+      .send({ archivable: false })
+      .auth(token, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode);
+
+    await request(app.getHttpServer())
+      .get(`/api/v3/datasets/${encodeURIComponent(dsId)}`)
+      .auth(token, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        expect(res.body.history.length).toBe(1);
+        const lifecycle = res.body.history[0].datasetlifecycle;
+        expect(lifecycle.previousValue.archivable).toBe(true);
+        expect(lifecycle.currentValue.archivable).toBe(false);
+        expect(lifecycle.previousValue.retrievable).toBeDefined();
+        expect(lifecycle.currentValue.retrievable).not.toBeDefined();
+        expect(typeof lifecycle.previousValue._id).toBe("string");
+      });
+  });
+});


### PR DESCRIPTION
Avoid structuredClone since returns arrayBuffer

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
`structuredClone` creates a clone that keeps converts mongo bson buffers to unit8Arryas, making _ids in history be returned as an array with a list of integers. `cloneDeep` keeps the mongo bson buffers, thus _ids as strings

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* cloneDeep replaces structured clone

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
