### PR TITLE
fix: readd fields as obj for v3 for backward compatibility

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -122,6 +122,7 @@ import { convertGenericHistoriesToObsoleteHistories } from "src/datasets/utils/h
 import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe";
 import { DATASET_LOOKUP_FIELDS } from "./types/dataset-lookup";
 import { getSwaggerDatasetFilterContentV3 } from "./types/dataset-filter-content.v3";
+import { isObject } from "lodash";
 
 @ApiBearerAuth()
 @ApiExtraModels(
@@ -928,6 +929,14 @@ export class DatasetsController {
         this.getFilters(headers, queryFilter),
       ) as Record<string, unknown>,
     ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
+    if (
+      isObject(mergedFilters?.fields) &&
+      !Array.isArray(mergedFilters.fields)
+    ) {
+      mergedFilters.fields = Object.keys(mergedFilters.fields).filter(
+        (key) => mergedFilters.fields![key],
+      ) as unknown as IDatasetFields;
+    }
     if (queryFilter.filter)
       new IncludeValidationPipe(DATASET_LOOKUP_FIELDS).transform(
         queryFilter.filter,

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -393,6 +393,37 @@ describe("1900: RawDataset: Raw Datasets", () => {
       });
   });
 
+  it("0133 should fetch datasets with include and scope and fields as obj", async () => {
+    const filter = {
+      where: { pid: decodeURIComponent(pid) },
+      fields: { pid: 1, datasetName: true, description: 0 },
+      include: [
+        { relation: "instruments" },
+        { relation: "proposals", scope: { fields: ["abstract"] } }
+      ],
+    };
+
+    return request(appUrl)
+      .get(`/api/v3/datasets`)
+      .query({ filter: JSON.stringify(filter) })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.a("array");
+        const [firstDataset] = res.body;
+
+        firstDataset.should.have.property("pid");
+        firstDataset.should.have.property("instruments");
+        firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.should.not.have.property("description");
+        firstDataset.proposals[0].should.not.have.property("title");
+        firstDataset.proposals[0].should.have.property("abstract")
+          .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);
+        firstDataset.should.not.have.property("datablocks");
+      });
+  });
+
   it("0134 should fetch dataset with findOne include and scope", async () => {
     const filter = {
       where: { pid: decodeURIComponent(pid) },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Before this #2237, the v3 controller accepted fields in the format {field1: 1, field2: 0} and not only [field1, field2]. This PR makes it support both formats. 
 
## Fixes
Add support for both formats. It should have been a Pipe, but given historic code that merges headers and qwargs, the pipe implementation would have required quite some refactoring

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
