### PR TITLE
fix: enhance replaceLikeOperatorRecursive to support 'ilike' operator

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1173,9 +1173,10 @@ const replaceLikeOperatorRecursive = (
 ): Record<string, unknown> => {
   const output = {} as Record<string, unknown>;
   for (const k in input) {
-    if (k == "like" && typeof input[k] !== "object") {
+    if ((k === "like" || k === "ilike") && typeof input[k] !== "object") {
       // we have encountered a loopback operator like
       output["$regex"] = input[k];
+      if (k === "ilike") output["$options"] = "i";
     } else if (
       Array.isArray(input[k]) &&
       (k == "$or" || k == "$and" || k == "$in")

--- a/test/InstrumentsFilter.js
+++ b/test/InstrumentsFilter.js
@@ -8,7 +8,6 @@ let accessTokenAdminIngestor = null,
   accessTokenUser2 = null,
   accessTokenUser3 = null,
   accessTokenArchiveManager = null,
-
   instrumentPid1 = null,
   encodedInstrumentPid1 = null,
   instrumentPid2 = null,
@@ -159,6 +158,20 @@ describe("1000: InstrumentFilter: Test retrieving instruments using filtering ca
 
   it('0060: retrieve instruments with "ESS instrument" in name using loopback style "like" operator', async () => {
     const query = { where: { name: { like: "ESS instrument" } } };
+    return request(appUrl)
+      .get("/api/v3/Instruments")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .query("filter=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(2);
+      });
+  });
+
+  it('0065: retrieve instruments with "ESS instrument" in name using loopback style "ilike" operator', async () => {
+    const query = { where: { name: { ilike: "ess instrument" } } };
     return request(appUrl)
       .get("/api/v3/Instruments")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })


### PR DESCRIPTION

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR added ilike support for replaceLikeOperatorRecursive utility function
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
