### PR TITLE
refactor: use custom filter decorator to simplify controller

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -891,7 +891,7 @@ export class DatasetsController {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
-        JSON.parse(queryFilter.filter || "{}"),
+        JSON.parse(queryFilter.filter ?? "{}"),
       ) as Record<string, unknown>,
     ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
     if (
@@ -1230,7 +1230,7 @@ export class DatasetsController {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
-        JSON.parse(queryFilter.filter || "{}"),
+        JSON.parse(queryFilter.filter ?? "{}"),
       ) as Record<string, unknown>,
     ) as IFilters<DatasetDocument, IDatasetFields>;
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -6,7 +6,6 @@ import {
   Delete,
   ForbiddenException,
   Get,
-  Headers,
   HttpCode,
   HttpException,
   HttpStatus,
@@ -123,6 +122,7 @@ import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe"
 import { DATASET_LOOKUP_FIELDS } from "./types/dataset-lookup";
 import { getSwaggerDatasetFilterContentV3 } from "./types/dataset-filter-content.v3";
 import { isObject } from "lodash";
+import { Filter } from "./decorators/filter.decorator";
 
 @ApiBearerAuth()
 @ApiExtraModels(
@@ -160,40 +160,6 @@ export class DatasetsController {
   private datasetCreationValidationEnabled;
   private datasetCreationValidationRegex;
   private datasetTypes;
-
-  getFilters(
-    headers: Record<string, string>,
-    queryFilter: { filter?: string },
-  ) {
-    let filters: IFilters<DatasetDocument, IDatasetFields> = {};
-    // NOTE: If both headers and query filters are present return error because we don't want to support this scenario.
-    if (queryFilter?.filter && (headers?.filter || headers?.where)) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message:
-            "Using two different types(query and headers) of filters is not supported and can result with inconsistencies",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    } else {
-      try {
-        if (queryFilter?.filter) {
-          filters = JSON.parse(queryFilter.filter);
-        } else if (headers?.filter) {
-          filters = JSON.parse(headers.filter);
-        } else if (headers?.where) {
-          filters = JSON.parse(headers.where);
-        }
-      } catch (err) {
-        const error = err as Error;
-        throw new BadRequestException(
-          `Invalid JSON in filter: ${error.message}`,
-        );
-      }
-    }
-    return filters;
-  }
 
   updateMergedFiltersForList(
     request: Request,
@@ -920,13 +886,12 @@ export class DatasetsController {
   })
   async findAll(
     @Req() request: Request,
-    @Headers() headers: Record<string, string>,
-    @Query(new FilterPipe()) queryFilter: { filter?: string },
+    @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<OutputDatasetObsoleteDto[]> {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
-        this.getFilters(headers, queryFilter),
+        JSON.parse(queryFilter.filter || "{}"),
       ) as Record<string, unknown>,
     ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
     if (
@@ -1220,12 +1185,13 @@ export class DatasetsController {
   })
   async findOne(
     @Req() request: Request,
-    @Headers() headers: Record<string, string>,
-    @Query(new FilterPipe()) queryFilter: { filter?: string },
+    @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<OutputDatasetObsoleteDto | null> {
-    const filter = JSON.parse(queryFilter.filter ?? headers.filter ?? "{}");
+    const filter = JSON.parse(queryFilter.filter ?? "{}");
     filter.limits = { limit: 1, ...(filter.limits ?? {}) };
-    const dataset = await this.findAll(request, headers, queryFilter);
+    const dataset = await this.findAll(request, {
+      filter: JSON.stringify(filter),
+    });
     return dataset[0] as OutputDatasetObsoleteDto;
   }
 
@@ -1259,13 +1225,12 @@ export class DatasetsController {
   })
   async count(
     @Req() request: Request,
-    @Headers() headers: Record<string, string>,
-    @Query(new FilterPipe()) queryFilter: { filter?: string },
+    @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ) {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
-        this.getFilters(headers, queryFilter),
+        JSON.parse(queryFilter.filter || "{}"),
       ) as Record<string, unknown>,
     ) as IFilters<DatasetDocument, IDatasetFields>;
 
@@ -1309,14 +1274,13 @@ export class DatasetsController {
   async findById(
     @Req() request: Request,
     @Param("pid") id: string,
-    @Headers() headers: Record<string, string>,
-    @Query(new FilterPipe()) queryFilter: { filter?: string },
+    @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ) {
     await this.findOrThrow(id);
-    const filterObj = JSON.parse(queryFilter.filter ?? headers.filter ?? "{}");
+    const filterObj = JSON.parse(queryFilter.filter ?? "{}");
     filterObj.where = filterObj.where ?? {};
     filterObj.where.pid = id;
-    const dataset = await this.findAll(request, headers, {
+    const dataset = await this.findAll(request, {
       filter: JSON.stringify(filterObj),
     });
     if (dataset.length == 0)

--- a/src/datasets/decorators/filter.decorator.ts
+++ b/src/datasets/decorators/filter.decorator.ts
@@ -1,0 +1,31 @@
+import {
+  BadRequestException,
+  createParamDecorator,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+} from "@nestjs/common";
+
+export const Filter = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    if (request?.headers?.filter && request?.query?.filter)
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message:
+            "Using two different types(query and headers) of filters is not supported and can result with inconsistencies",
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    let filter = {};
+    try {
+      if (request?.query?.filter) filter = JSON.parse(request.query.filter);
+      if (request?.headers?.filter) filter = JSON.parse(request.headers.filter);
+    } catch (err) {
+      const error = err as Error;
+      throw new BadRequestException(`Invalid JSON in filter: ${error.message}`);
+    }
+    return { filter: JSON.stringify(filter) };
+  },
+);

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Headers,
   Patch,
   Param,
   Delete,
@@ -11,7 +10,6 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  HttpException,
   Req,
 } from "@nestjs/common";
 import { Request } from "express";
@@ -32,6 +30,7 @@ import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { replaceLikeOperator } from "src/common/utils";
 import { FilterPipe } from "src/common/pipes/filter.pipe";
 import { CountApiResponse } from "src/common/types";
+import { Filter } from "src/datasets/decorators/filter.decorator";
 
 @ApiBearerAuth()
 @ApiTags("policies")
@@ -41,39 +40,6 @@ export class PoliciesController {
     private readonly policiesService: PoliciesService,
     private caslAbilityFactory: CaslAbilityFactory,
   ) {}
-  getFilters(
-    headers: Record<string, string>,
-    queryFilter: { filter?: string },
-  ) {
-    // NOTE: If both headers and query filters are present return error because we don't want to support this scenario.
-    if (queryFilter?.filter && (headers?.filter || headers?.where)) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message:
-            "Using two different types(query and headers) of filters is not supported and can result with inconsistencies",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    } else if (queryFilter?.filter) {
-      const jsonQueryFilters: IFilters<PolicyDocument, IPolicyFilter> =
-        JSON.parse(queryFilter.filter);
-
-      return jsonQueryFilters;
-    } else if (headers?.filter) {
-      const jsonHeadersFilters: IFilters<PolicyDocument, IPolicyFilter> =
-        JSON.parse(headers.filter);
-
-      return jsonHeadersFilters;
-    } else if (headers?.where) {
-      const jsonHeadersWhereFilters: IFilters<PolicyDocument, IPolicyFilter> =
-        JSON.parse(headers.where);
-
-      return jsonHeadersWhereFilters;
-    }
-
-    return {};
-  }
 
   updateMergedFiltersForList(
     request: Request,
@@ -122,13 +88,12 @@ export class PoliciesController {
   })
   async findAll(
     @Req() request: Request,
-    @Headers() headers: Record<string, string>,
-    @Query(new FilterPipe()) queryFilter: { filter?: string },
+    @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<Policy[]> {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
-        this.getFilters(headers, queryFilter),
+        JSON.parse(queryFilter.filter ?? "{}"),
       ) as Record<string, unknown>,
     ) as IFilters<PolicyDocument, IPolicyFilter>;
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Refactor: use nestjs custom decorator to reduce duplication and keep controller simpler. See [here](https://docs.nestjs.com/custom-decorators)

## Fixes
This PR includes a small bug fix in findOne. Happy to split into 2 PRs if better

* findOne bug fix
