### PR TITLE
refactor: unify replaceLike and fitler pipe

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -1,5 +1,4 @@
 import { Injectable, PipeTransform } from "@nestjs/common";
-import { isObject } from "lodash";
 import {
   transformDeep,
   TransformObjValuesPipe,
@@ -18,10 +17,7 @@ import {
 @Injectable()
 export class FilterPipe
   implements
-    PipeTransform<
-      { filter?: string; fields?: string } | string,
-      { filter?: string; fields?: string } | string
-    >
+    PipeTransform<{ filter?: string } | string, { filter?: string } | string>
 {
   private static readonly replaceOperatorsMap = {
     inq: "$in",
@@ -39,7 +35,6 @@ export class FilterPipe
         return transformDeep(value, {
           funcMap: {
             ilike: (val: unknown, par: unknown) => {
-              if (!isObject(par)) return par;
               const p = par as Record<string, unknown>;
               p["$options"] = "i";
               return val;
@@ -51,7 +46,7 @@ export class FilterPipe
     });
   }
 
-  transform(inValue: { filter?: string; fields?: string } | string):
+  transform(inValue: { filter?: string } | string):
     | {
         filter?: string;
         fields?: string;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -5,7 +5,6 @@ import { format, unit, Unit, createUnit, MathJSON } from "mathjs";
 import { Expression, FilterQuery, Model, PipelineStage } from "mongoose";
 import {
   IAxiosError,
-  IFilters,
   ILimitsFilter,
   ILimitsFilterV4,
   IScientificFilter,
@@ -1157,45 +1156,6 @@ export const parseBoolean = (v: unknown): boolean => {
     default:
       return false;
   }
-};
-
-export const replaceLikeOperator = <T>(filter: IFilters<T>): IFilters<T> => {
-  if (filter.where) {
-    filter.where = replaceLikeOperatorRecursive(
-      filter.where as Record<string, unknown>,
-    ) as object;
-  }
-  return filter;
-};
-
-const replaceLikeOperatorRecursive = (
-  input: Record<string, unknown>,
-): Record<string, unknown> => {
-  const output = {} as Record<string, unknown>;
-  for (const k in input) {
-    if ((k === "like" || k === "ilike") && typeof input[k] !== "object") {
-      // we have encountered a loopback operator like
-      output["$regex"] = input[k];
-      if (k === "ilike") output["$options"] = "i";
-    } else if (
-      Array.isArray(input[k]) &&
-      (k == "$or" || k == "$and" || k == "$in")
-    ) {
-      output[k] = (input[k] as Array<unknown>).map((v) =>
-        typeof v === "string"
-          ? v
-          : replaceLikeOperatorRecursive(v as Record<string, unknown>),
-      );
-    } else if (typeof input[k] === "object") {
-      output[k] = replaceLikeOperatorRecursive(
-        input[k] as Record<string, unknown>,
-      );
-    } else {
-      output[k] = input[k];
-    }
-  }
-
-  return output;
 };
 
 export const sleep = (ms: number) => {

--- a/src/datablocks/datablocks.controller.ts
+++ b/src/datablocks/datablocks.controller.ts
@@ -33,13 +33,13 @@ import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { IFilters } from "src/common/interfaces/common.interface";
 import { CountApiResponse } from "src/common/types";
-import { replaceLikeOperator } from "src/common/utils";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { PartialUpdateDatasetObsoleteDto } from "src/datasets/dto/update-dataset-obsolete.dto";
 import { DatablocksService } from "./datablocks.service";
 import { CreateDatablockDto } from "./dto/create-datablock.dto";
 import { PartialUpdateDatablockDto } from "./dto/update-datablock.dto";
 import { Datablock, DatablockDocument } from "./schemas/datablock.schema";
+import { FilterPipe } from "src/common/pipes/filter.pipe";
 
 @ApiBearerAuth()
 @ApiTags("datablocks")
@@ -141,12 +141,11 @@ export class DatablocksController {
   @Get()
   async findAll(
     @Req() request: Request,
-    @Query("filter") filter?: string,
+    @Query("filter", new FilterPipe()) filter?: string,
   ): Promise<Datablock[]> {
-    let datablockFilter: IFilters<DatablockDocument> = replaceLikeOperator(
-      JSON.parse(filter ?? "{}"),
+    let datablockFilter: IFilters<DatablockDocument> = JSON.parse(
+      filter ?? "{}",
     );
-
     const user: JWTUser = request.user as JWTUser;
     const abilities = this.caslAbilityFactory.datablockInstanceAccess(user);
 
@@ -203,8 +202,8 @@ export class DatablocksController {
   })
   async count(
     @Req() request: Request,
-    @Query("where") where?: string,
-    @Query("filter") filter?: string,
+    @Query("where", new FilterPipe()) where?: string,
+    @Query("filter", new FilterPipe()) filter?: string,
   ): Promise<CountApiResponse> {
     if (where && !filter) {
       Logger.warn(
@@ -214,8 +213,8 @@ export class DatablocksController {
       filter = where;
     }
 
-    let datablockFilter: IFilters<DatablockDocument> = replaceLikeOperator(
-      JSON.parse(filter ?? "{}"),
+    let datablockFilter: IFilters<DatablockDocument> = JSON.parse(
+      filter ?? "{}",
     );
     const user: JWTUser = request.user as JWTUser;
     const abilities = this.caslAbilityFactory.datablockInstanceAccess(user);

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -66,7 +66,6 @@ import {
   filterDescription,
   fullQueryDescriptionLimits,
   fullQueryExampleLimits,
-  replaceLikeOperator,
 } from "src/common/utils";
 import { AccessGroupsType } from "src/config/configuration";
 import { DatablocksService } from "src/datablocks/datablocks.service";
@@ -893,11 +892,9 @@ export class DatasetsController {
     @Req() request: Request,
     @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<OutputDatasetObsoleteDto[]> {
-    const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        JSON.parse(queryFilter.filter ?? "{}"),
-      ) as Record<string, unknown>,
+    const mergedFilters = this.updateMergedFiltersForList(
+      request,
+      JSON.parse(queryFilter.filter ?? "{}"),
     ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
     if (
       isObject(mergedFilters?.fields) &&
@@ -1232,11 +1229,9 @@ export class DatasetsController {
     @Req() request: Request,
     @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ) {
-    const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        JSON.parse(queryFilter.filter ?? "{}"),
-      ) as Record<string, unknown>,
+    const mergedFilters = this.updateMergedFiltersForList(
+      request,
+      JSON.parse(queryFilter.filter ?? "{}"),
     ) as IFilters<DatasetDocument, IDatasetFields>;
 
     return this.datasetsService.count(mergedFilters);

--- a/src/instruments/instruments.controller.ts
+++ b/src/instruments/instruments.controller.ts
@@ -30,12 +30,9 @@ import { Action } from "src/casl/action.enum";
 import { Instrument, InstrumentDocument } from "./schemas/instrument.schema";
 import { FormatPhysicalQuantitiesInterceptor } from "src/common/interceptors/format-physical-quantities.interceptor";
 import { IFilters } from "src/common/interfaces/common.interface";
-import {
-  filterDescription,
-  filterExample,
-  replaceLikeOperator,
-} from "src/common/utils";
+import { filterDescription, filterExample } from "src/common/utils";
 import { CountApiResponse } from "src/common/types";
+import { FilterPipe } from "src/common/pipes/filter.pipe";
 
 @ApiBearerAuth()
 @ApiTags("instruments")
@@ -82,9 +79,11 @@ export class InstrumentsController {
     description: "Database filters to apply when retrieve all instruments",
     required: false,
   })
-  async findAll(@Query("filter") filter?: string): Promise<Instrument[]> {
-    const instrumentFilter: IFilters<InstrumentDocument> = replaceLikeOperator(
-      JSON.parse(filter ?? "{}"),
+  async findAll(
+    @Query("filter", new FilterPipe()) filter?: string,
+  ): Promise<Instrument[]> {
+    const instrumentFilter: IFilters<InstrumentDocument> = JSON.parse(
+      filter ?? "{}",
     );
     return this.instrumentsService.findAll(instrumentFilter);
   }
@@ -99,9 +98,11 @@ export class InstrumentsController {
     description: "Database filters to apply when retrieve instrument count",
     required: false,
   })
-  async count(@Query("filter") filter?: string): Promise<CountApiResponse> {
-    const instrumentFilter: IFilters<InstrumentDocument> = replaceLikeOperator(
-      JSON.parse(filter ?? "{}"),
+  async count(
+    @Query("filter", new FilterPipe()) filter?: string,
+  ): Promise<CountApiResponse> {
+    const instrumentFilter: IFilters<InstrumentDocument> = JSON.parse(
+      filter ?? "{}",
     );
     return this.instrumentsService.count(instrumentFilter);
   }
@@ -131,8 +132,10 @@ export class InstrumentsController {
     type: Instrument,
     description: "Return the instrument requested",
   })
-  async findOne(@Query("filter") filter?: string): Promise<Instrument | null> {
-    const instrumentFilters = replaceLikeOperator(JSON.parse(filter ?? "{}"));
+  async findOne(
+    @Query("filter", new FilterPipe()) filter?: string,
+  ): Promise<Instrument | null> {
+    const instrumentFilters = JSON.parse(filter ?? "{}");
 
     return this.instrumentsService.findOne(instrumentFilters);
   }

--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -6,7 +6,7 @@ type KeyMap = Record<string, string>;
 
 type Func = (value: unknown) => unknown;
 
-type FuncMap = Record<string, Func>;
+type FuncMap = Record<string, (value: unknown, parent: unknown) => unknown>;
 
 interface TransformDeepOptions {
   keyMap?: KeyMap;
@@ -15,7 +15,7 @@ interface TransformDeepOptions {
   valueFn?: Func;
 }
 
-const transformDeep = (
+export const transformDeep = (
   obj: unknown,
   opts: TransformDeepOptions = {},
 ): unknown => {
@@ -33,7 +33,7 @@ const transformDeep = (
       const mappedKey = keyMap[key] ?? key;
       let transformed: unknown;
       if (funcMap[key]) {
-        transformed = funcMap[key](value);
+        transformed = funcMap[key](value, newObj);
       } else {
         transformed = transformDeep(value, opts);
       }
@@ -67,7 +67,7 @@ class ParseDeepJsonPipe implements PipeTransform<string, string | object> {
   }
 }
 
-class ReplaceObjKeysPipe implements PipeTransform<unknown, unknown> {
+export class ReplaceObjKeysPipe implements PipeTransform<unknown, unknown> {
   constructor(private keyMap: KeyMap) {}
 
   transform(value: unknown): unknown {
@@ -75,7 +75,7 @@ class ReplaceObjKeysPipe implements PipeTransform<unknown, unknown> {
   }
 }
 
-class TransformObjValuesPipe implements PipeTransform<unknown, unknown> {
+export class TransformObjValuesPipe implements PipeTransform<unknown, unknown> {
   constructor(private funcMap: FuncMap) {}
 
   transform(value: unknown): unknown {

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -27,7 +27,6 @@ import { IPolicyFilter } from "./interfaces/policy-filters.interface";
 import { UpdateWherePolicyDto } from "./dto/update-where-policy.dto";
 import { IFilters } from "src/common/interfaces/common.interface";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
-import { replaceLikeOperator } from "src/common/utils";
 import { FilterPipe } from "src/common/pipes/filter.pipe";
 import { CountApiResponse } from "src/common/types";
 import { Filter } from "src/datasets/decorators/filter.decorator";
@@ -90,11 +89,9 @@ export class PoliciesController {
     @Req() request: Request,
     @Filter(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<Policy[]> {
-    const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        JSON.parse(queryFilter.filter ?? "{}"),
-      ) as Record<string, unknown>,
+    const mergedFilters = this.updateMergedFiltersForList(
+      request,
+      JSON.parse(queryFilter.filter ?? "{}"),
     ) as IFilters<PolicyDocument, IPolicyFilter>;
 
     return this.policiesService.findAll(mergedFilters);


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Refactors FilterPipe to avoid regex replace and unifies with replaceLikeOperator. It applies replacements recursively

## Motivation
Single function that does all the mongo syntax replacement

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* all mongo syntax replacements in one Pipe
* avoids regexes
* applies replacements recursively, as long as they are relatives of `where`
* can be applied on both strings and {filter: string}

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
