### PR TITLE
fix: exclude history from v3 when not in fields

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -560,6 +560,7 @@ export class DatasetsController {
 
   async convertCurrentToObsoleteSchema(
     inputDataset: DatasetDocument | null,
+    fields?: IDatasetFields,
   ): Promise<OutputDatasetObsoleteDto> {
     const propertiesModifier: Record<string, unknown> = {};
     if (inputDataset) {
@@ -594,13 +595,17 @@ export class DatasetsController {
         }
       }
 
-      propertiesModifier.history = convertGenericHistoriesToObsoleteHistories(
-        await this.historyService.find({
-          documentId: inputDataset._id,
-          subsystem: "Dataset",
-        }),
-        inputDataset,
-      );
+      const excludeHistory =
+        Array.isArray(fields) && !fields.includes("history");
+
+      if (!excludeHistory)
+        propertiesModifier.history = convertGenericHistoriesToObsoleteHistories(
+          await this.historyService.find({
+            documentId: inputDataset._id,
+            subsystem: "Dataset",
+          }),
+          inputDataset,
+        );
     }
 
     const outputDataset: OutputDatasetObsoleteDto = {
@@ -912,7 +917,7 @@ export class DatasetsController {
     );
     return Promise.all(
       (datasets as DatasetDocument[]).map((dataset) =>
-        this.convertCurrentToObsoleteSchema(dataset),
+        this.convertCurrentToObsoleteSchema(dataset, mergedFilters?.fields),
       ),
     );
   }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
History is included in all requests, even when excluded from the fields

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* avoid including history when not in fields

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
