### PR TITLE
fix: default datasetName to sourceFolder last 2

### DIFF
--- a/src/datasets/dto/create-derived-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/create-derived-dataset-obsolete.dto.ts
@@ -2,6 +2,7 @@ import { UpdateDerivedDatasetObsoleteDto } from "./update-derived-dataset-obsole
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsOptional, IsString } from "class-validator";
 import { DatasetType } from "../types/dataset-type.enum";
+import { Expose, Transform } from "class-transformer";
 
 export class CreateDerivedDatasetObsoleteDto extends UpdateDerivedDatasetObsoleteDto {
   @ApiProperty({
@@ -32,5 +33,11 @@ export class CreateDerivedDatasetObsoleteDto extends UpdateDerivedDatasetObsolet
       "A name for the dataset, given by the creator to carry some semantic meaning. Useful for display purposes e.g. instead of displaying the pid.",
   })
   @IsString()
+  @Expose()
+  @Transform(
+    ({ value, obj }) =>
+      value ?? obj.sourceFolder?.split("/").filter(Boolean).slice(-2).join("/"),
+    { toClassOnly: true },
+  )
   declare readonly datasetName: string;
 }

--- a/src/datasets/dto/create-raw-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/create-raw-dataset-obsolete.dto.ts
@@ -2,6 +2,7 @@ import { UpdateRawDatasetObsoleteDto } from "./update-raw-dataset-obsolete.dto";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsEnum, IsOptional, IsString } from "class-validator";
 import { DatasetType } from "../types/dataset-type.enum";
+import { Expose, Transform } from "class-transformer";
 
 export class CreateRawDatasetObsoleteDto extends UpdateRawDatasetObsoleteDto {
   @ApiProperty({
@@ -32,5 +33,11 @@ export class CreateRawDatasetObsoleteDto extends UpdateRawDatasetObsoleteDto {
       "A name for the dataset, given by the creator to carry some semantic meaning. Useful for display purposes e.g. instead of displaying the pid.",
   })
   @IsString()
+  @Expose()
+  @Transform(
+    ({ value, obj }) =>
+      value ?? obj.sourceFolder?.split("/").filter(Boolean).slice(-2).join("/"),
+    { toClassOnly: true },
+  )
   declare readonly datasetName: string;
 }

--- a/test/DerivedDataset.js
+++ b/test/DerivedDataset.js
@@ -67,10 +67,23 @@ describe("0700: DerivedDataset: Derived Datasets", () => {
       });
   });
 
+  it("0025: check if valid raw dataset min is valid", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets/isValid")
+      .send(TestData.DerivedCorrectMin)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryValidStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("valid").and.equal(true);
+      });
+  });
+
   it("0110: adds a new minimal derived dataset", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
-      .send(TestData.DerivedCorrectMin)
+      .send({...TestData.DerivedCorrectMin, sourceFolder: "/data/derived/"})
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
@@ -79,6 +92,7 @@ describe("0700: DerivedDataset: Derived Datasets", () => {
         res.body.should.have.property("owner").and.be.string;
         res.body.should.have.property("type").and.equal("derived");
         res.body.should.have.property("pid").and.be.string;
+        res.body.should.have.property("datasetName").and.equal("data/derived");
         minPid = res.body["pid"];
       });
   });

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -64,10 +64,23 @@ describe("1900: RawDataset: Raw Datasets", () => {
       });
   });
 
+  it("0025: check if valid raw dataset min is valid", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets/isValid")
+      .send(TestData.RawCorrectMin)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryValidStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("valid").and.equal(true);
+      });
+  });
+
   it("0030: adds a new minimal raw dataset", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
-      .send(TestData.RawCorrectMin)
+      .send({...TestData.RawCorrectMin, sourceFolder: "/data/derived/"})
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
@@ -76,7 +89,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
         res.body.should.have.property("owner").and.be.string;
         res.body.should.have.property("type").and.equal("raw");
         res.body.should.have.property("pid").and.be.string;
-
+        res.body.should.have.property("datasetName").and.equal("data/derived");
         minPid = encodeURIComponent(res.body["pid"]);
       });
   });

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -205,7 +205,6 @@ const TestData = {
     sourceFolder: faker.system.directoryPath(),
     owner: faker.internet.username(),
     contactEmail: faker.internet.email(),
-    datasetName: `${faker.string.alphanumeric(20)} ${faker.string.sample()}`,
   },
 
   RawCorrectMinV4: {
@@ -740,7 +739,6 @@ const TestData = {
     sourceFolder: faker.system.directoryPath(),
     creationTime: faker.date.past(),
     ownerGroup: faker.string.alphanumeric(6),
-    datasetName: `${faker.string.alphanumeric(20)} ${faker.string.sample()}`,
     type: "derived",
   },
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This is replicating the behaviour of /v3 for datasetName default, as can be seen [here](https://github.com/SciCatProject/backend-v3/blob/master/common/models/dataset.js#L360-L365)

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Compute default of datasetName for raw and derived obsolete

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
