### PR TITLE
fix: update origin IP retrieval method in AccessTrackingMiddleware

### DIFF
--- a/src/metrics/middlewares/accessTracking.middleware.ts
+++ b/src/metrics/middlewares/accessTracking.middleware.ts
@@ -29,7 +29,7 @@ export class AccessTrackingMiddleware implements NestMiddleware {
 
     const startTime = Date.now();
     const authHeader = req.headers.authorization;
-    const originIp = req.socket.remoteAddress;
+    const originIp = req.headers["x-forwarded-for"] || "-";
     const userId = this.parseToken(authHeader);
 
     const cacheKeyIdentifier = `${userId}-${originIp}-${pathname}`;


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Improve origin IP extraction to correctly capture the full chain of client IPs from X-Forwarded-For.

## Motivation
The existing implementation only returns internal cluster IPs, making it impossible to identify the actual client IP behind HAProxy and Ingress

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
