### PR TITLE
feat: add datasets attachments count endpoint

### DIFF
--- a/src/attachments/attachments.service.ts
+++ b/src/attachments/attachments.service.ts
@@ -19,6 +19,7 @@ import { CreateAttachmentV3Dto } from "./dto-obsolete/create-attachment.v3.dto";
 import { AttachmentRelationTargetType } from "./types/relationship-filter.enum";
 import { OutputAttachmentV3Dto } from "./dto-obsolete/output-attachment.v3.dto";
 import { OutputAttachmentV4Dto } from "./dto/output-attachment.v4.dto";
+import { CountApiResponse } from "src/common/types";
 
 @Injectable({ scope: Scope.REQUEST })
 export class AttachmentsService {
@@ -247,5 +248,20 @@ export class AttachmentsService {
     delete reverted.aid;
     delete reverted.relationships;
     return reverted;
+  }
+
+  async count(
+    filter: FilterQuery<AttachmentDocument>,
+  ): Promise<CountApiResponse> {
+    const convertedWhere = this.convertObsoleteWhereFilterToCurrentSchema(
+      filter.where,
+    );
+
+    const datasets = await this.findAllComplete({
+      where: convertedWhere,
+      fields: ["_id"],
+    });
+
+    return { count: datasets.length };
   }
 }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1867,7 +1867,7 @@ export class DatasetsController {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    type: Attachment,
+    type: CountApiResponse,
     isArray: true,
     description:
       "Return the number of attachments for the pid in the following format: { count: integer }",

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1848,6 +1848,53 @@ export class DatasetsController {
     return null;
   }
 
+  // GET /datasets/:id/attachments/count
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("datasets", (ability: AppAbility) =>
+    ability.can(Action.DatasetAttachmentRead, DatasetClass),
+  )
+  @Get("/:pid/attachments/count")
+  @ApiOperation({
+    summary: "It returns the attachments count for the dataset specified.",
+    description:
+      "It returns the attachments count for the dataset specified by the pid passed.",
+  })
+  @ApiParam({
+    name: "pid",
+    description:
+      "Persisten Identifier of the dataset for which we would like to retrieve the count of all attachments",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: Attachment,
+    isArray: true,
+    description:
+      "Return the number of attachments for the pid in the following format: { count: integer }",
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    type: ForbiddenException,
+    example: {
+      message: "Forbidden resource",
+      error: "Forbidden",
+      statusCode: 403,
+    },
+    description: "Forbidden resource",
+  })
+  async attachmentsCount(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+  ): Promise<CountApiResponse> {
+    await this.checkPermissionsForDatasetExtended(
+      request,
+      pid,
+      Action.DatasetAttachmentRead,
+    );
+
+    return this.attachmentsService.count({ where: { datasetId: pid } });
+  }
+
   // GET /datasets/:id/attachments
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -658,6 +658,18 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       });
   });
 
+  it("0395: counts dataset 1 attachments as User 3", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments/count")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.count.should.be.equal(1);
+      });
+  });
+
   it("0400: access dataset 1 thumbnail as User 3", async () => {
     return request(appUrl)
       .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/thumbnail")


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following the [old be specs](https://dacat.psi.ch/explorer/#!/Dataset/Dataset_prototype_count_attachments), readding the datasets/{id}/attachments/count endpoint. This is added in v3 only for backward compatibility

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
