### PR TITLE
feat: add datasets origdatablocks count endpoint

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2128,6 +2128,43 @@ export class DatasetsController {
     return this.origDatablocksService.findAll({ where: { datasetId: pid } });
   }
 
+  // GET /datasets/:id/origdatablocks/count
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("datasets", (ability: AppAbility) => {
+    return ability.can(Action.DatasetOrigdatablockRead, DatasetClass);
+  })
+  @Get("/:pid/origdatablocks/count")
+  @ApiOperation({
+    summary:
+      "It returns the count of all the origDatablock for the dataset specified.",
+    description:
+      "It returns the count of all the original datablocks for the dataset specified by the pid passed.",
+  })
+  @ApiParam({
+    name: "pid",
+    description:
+      "Persistent identifier of the dataset for which we would like to retrieve all the original datablocks",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: CountApiResponse,
+    isArray: true,
+    description:
+      "Return the number of origdatablocks for the pid in the following format: { count: integer }",
+  })
+  async countOrigDatablocks(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+  ): Promise<CountApiResponse> {
+    await this.checkPermissionsForDatasetExtended(
+      request,
+      pid,
+      Action.DatasetOrigdatablockRead,
+    );
+    return this.origDatablocksService.count({ where: { datasetId: pid } });
+  }
+
   // PATCH /datasets/:id/origdatablocks/:fk
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) => {

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -43,6 +43,7 @@ import {
   ORIGDATABLOCK_LOOKUP_FIELDS,
 } from "./types/origdatablock-lookup";
 import { isEmpty } from "lodash";
+import { CountApiResponse } from "src/common/types";
 
 @Injectable({ scope: Scope.REQUEST })
 export class OrigDatablocksService {
@@ -358,5 +359,15 @@ export class OrigDatablocksService {
 
   async findByIdAndDelete(id: string): Promise<OutputOrigDatablockDto | null> {
     return await this.origDatablockModel.findOneAndDelete({ _id: id });
+  }
+
+  async count(
+    filter: IFilters<OrigDatablockDocument>,
+  ): Promise<CountApiResponse> {
+    const whereFilter = filter.where ?? {};
+    const count = await this.origDatablockModel
+      .countDocuments(whereFilter)
+      .exec();
+    return { count };
   }
 }

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -134,6 +134,18 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       });
   });
 
+  it("0070: Should count all origdatablocks belonging to the new dataset", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid}/OrigDatablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) =>
+        res.body.count.should.be.equal(2)
+      );
+  });
+
   it("0080: The new dataset should be the sum of the size of the origDatablocks", async () => {
     return request(appUrl)
       .get(`/api/v3/Datasets/${datasetPid}`)

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -136,7 +136,7 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
 
   it("0070: Should count all origdatablocks belonging to the new dataset", async () => {
     return request(appUrl)
-      .get(`/api/v3/Datasets/${datasetPid}/OrigDatablocks`)
+      .get(`/api/v3/Datasets/${datasetPid}/OrigDatablocks/count`)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.SuccessfulGetStatusCode)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following the [old be specs](https://dacat.psi.ch/explorer/#!/Dataset/Dataset_prototype_count_origdatablocks), readding the datasets/{id}/attachments/count endpoint. This is added in v3 only for backward compatibility

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
