### PR TITLE
feat: add datasets delete all attachments

### DIFF
--- a/src/attachments/attachments.service.ts
+++ b/src/attachments/attachments.service.ts
@@ -145,6 +145,13 @@ export class AttachmentsService {
     return this.attachmentModel.findOneAndDelete(convertedFilter).lean().exec();
   }
 
+  async removeMany(filter: FilterQuery<AttachmentDocument>): Promise<unknown> {
+    const convertedFilter = this.convertObsoleteWhereFilterToCurrentSchema(
+      filter.where,
+    );
+    return this.attachmentModel.deleteMany(convertedFilter).exec();
+  }
+
   convertObsoleteWhereFilterToCurrentSchema(
     filter: FilterQuery<AttachmentDocument>,
   ): FilterQuery<AttachmentDocument> {

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2023,6 +2023,44 @@ export class DatasetsController {
     });
   }
 
+  // DELETE /datasets/:pid/attachments
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("datasets", (ability: AppAbility) =>
+    ability.can(Action.DatasetAttachmentDelete, DatasetClass),
+  )
+  @Delete("/:pid/attachments")
+  @ApiOperation({
+    summary: "It deletes all attachments from the dataset.",
+    description:
+      "It deletes the attachment from the dataset.<br>This endpoint is obsolete and will be dropped in future versions.<br>Deleting attachments will be allowed only from the attachments endpoint.",
+  })
+  @ApiParam({
+    name: "pid",
+    description:
+      "Persistent identifier of the dataset for which we would like to delete all attachments",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "No value is returned.",
+  })
+  async findAttachmentsAndRemove(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+  ) {
+    await this.checkPermissionsForDatasetExtended(
+      request,
+      pid,
+      Action.DatasetAttachmentDelete,
+    );
+
+    return this.attachmentsService.removeMany({
+      where: {
+        datasetId: pid,
+      },
+    });
+  }
+
   // POST /datasets/:id/origdatablocks
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) => {

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -658,7 +658,7 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       });
   });
 
-  it("0395: counts dataset 1 attachments as User 3", async () => {
+  it("0393: counts dataset 1 attachments as User 3", async () => {
     return request(appUrl)
       .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments/count")
       .set("Accept", "application/json")
@@ -667,6 +667,40 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
         res.body.count.should.be.equal(1);
+      });
+  });
+
+  it("0396: delete all attachments as User 3 returns forbidden", async () => {
+    return request(appUrl)
+      .delete("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(TestData.DeleteForbiddenStatusCode)
+  });
+
+  it("0399: delete all attachments as admin returns 200", async () => {
+    await request(appUrl)
+      .post(`/api/v3/datasets/${encodedDatasetPid1}/attachments`)
+      .send(TestData.AttachmentCorrect)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+    await request(appUrl)
+      .delete("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect("Content-Type", /json/)
+      .expect(TestData.SuccessfulDeleteStatusCode)
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/attachments/count")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect("Content-Type", /json/)
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.count.should.be.equal(0);
       });
   });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following the [old be specs](https://dacat.psi.ch/explorer/#!/Dataset/Dataset_prototype_delete_attachments), readding the datasets/{id}/attachments/count endpoint. This is added in v3 only for backward compatibility

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
