### PR TITLE
feat: add datasets delete all origdatablocks

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2199,6 +2199,48 @@ export class DatasetsController {
     return null;
   }
 
+  // DELETE /datasets/:id/origdatablocks
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("datasets", (ability: AppAbility) =>
+    ability.can(Action.DatasetOrigdatablockDelete, DatasetClass),
+  )
+  @Delete("/:pid/origdatablocks")
+  @ApiOperation({
+    summary: "It deletes all origdatablocks from the dataset.",
+    description:
+      "It deletes all origdatablocks from the dataset.<br>This endpoint is obsolete and will be dropped in future versions.<br>Deleting datablocks will be done only from the datablocks endpoint.",
+  })
+  @ApiParam({
+    name: "pid",
+    description:
+      "Persistent identifier of the dataset for which we would like to delete the origdatablocks specified",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "No value is returned.",
+  })
+  async deleteAllOrigDatablocksFromDatasetId(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+  ): Promise<undefined> {
+    const dataset = await this.checkPermissionsForDatasetExtended(
+      request,
+      pid,
+      Action.DatasetDatablockDelete,
+    );
+    if (!dataset) return;
+    // remove datablock
+    await this.origDatablocksService.removeMany({
+      datasetId: pid,
+    });
+    // update dataset size and files number
+    await this.datasetsService.findByIdAndUpdate(dataset.pid, {
+      size: 0,
+      numberOfFiles: 0,
+    });
+  }
+
   // DELETE /datasets/:id/origdatablocks/:fk
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -330,6 +330,12 @@ export class OrigDatablocksService {
     return this.origDatablockModel.findOneAndDelete(filter).exec();
   }
 
+  async removeMany(
+    filter: FilterQuery<OrigDatablockDocument>,
+  ): Promise<unknown> {
+    return this.origDatablockModel.deleteMany(filter).exec();
+  }
+
   async findByIdAndUpdate(
     id: string,
     updateDatasetDto: PartialUpdateOrigDatablockDto,

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -4,6 +4,7 @@ const { TestData } = require("./TestData");
 
 let accessTokenAdminIngestor = null,
   accessTokenArchiveManager = null,
+  accessTokenUser1 = null,
 
   datasetPid = null,
   origDatablockId1 = null,
@@ -22,6 +23,11 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
     accessTokenArchiveManager = await utils.getToken(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
     });
   });
 
@@ -417,6 +423,85 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       .then((res) => {
         res.body.should.be.instanceof(Array).and.to.have.length(0);
       });
+  });
+
+  it("0183: should delete all origdatablocks without auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/origdatablocks`)
+      .set("Accept", "application/json")
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0186: should delete all origdatablocks with wrong auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/origdatablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0189: should delete all origdatablocks attached to dataset", async () => {
+    const dataset2 = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(TestData.DerivedCorrect)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+    const datasetPid2 = encodeURIComponent(dataset2.body["pid"]);
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/origdatablocks`)
+      .send({ ...TestData.OrigDataBlockCorrect1 })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/origdatablocks`)
+      .send({ ...TestData.OrigDataBlockCorrect1 })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.be.greaterThan(0);
+        res.body.should.have.property("numberOfFiles").and.be.greaterThan(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid2}/origdatablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.equal(0);
+        res.body.should.have.property("numberOfFiles").and.equal(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode)
+      .expect("Content-Type", /json/);
   });
 
   it("0190: The size and numFiles fields in the dataset should be zero", async () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following the [old be specs](https://dacat.psi.ch/explorer/#!/Dataset/Dataset_prototype_delete_origdatablocks), readding the datasets/{id}/attachments/count endpoint. This is added in v3 only for backward compatibility

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
