### PR TITLE
fix: avoid recursion error on non primitives

### DIFF
--- a/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
+++ b/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
@@ -53,6 +53,9 @@ describe("HidePersonalInfo test", () => {
       datasetlifecycle: {
         _id: "68b85b9cf830ebdccde06a0e",
       },
+      scientificMetadata: {
+        nestedEmails: [{ email: "another@example.com" }],
+      },
     };
 
     await request(app.getHttpServer())
@@ -65,7 +68,10 @@ describe("HidePersonalInfo test", () => {
         (result) => (
           expect(result.body.contactEmail).toEqual(`${user1email}; *****`),
           expect(result.body.ownerEmail).toEqual(user1email),
-          expect(result.body.accessGroups).toEqual(["*****"])
+          expect(result.body.accessGroups).toEqual(["*****"]),
+          expect(result.body.scientificMetadata.nestedEmails[0].email).toEqual(
+            "*****",
+          )
         ),
       );
 
@@ -80,7 +86,10 @@ describe("HidePersonalInfo test", () => {
           expect(result.body[0].accessGroups).toEqual(["*****"]),
           expect(result.body[0].datasetlifecycle._id).toEqual(
             "68b85b9cf830ebdccde06a0e",
-          )
+          ),
+          expect(
+            result.body[0].scientificMetadata.nestedEmails[0].email,
+          ).toEqual("*****")
         ),
       );
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Fixing two corner cases in recursion logic, one due to not adding arrays to weaksets, the second running set on non primitives.

## Fixes

* not adding arrays to weaksets had the potential problem of going into recursion error if an array contains itself. This can happen with mongo objs
* The second could happen because [new Set ] changes the array reference and even if it was added to weakset it could indefinetely recurse. The reference is changed only if it's not an array of primitives, this is checked by `anyMasked`
* In all cases a try catch was added to avoid returning 500

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
