### PR TITLE
fix: convert publicationYear field from number to string

### DIFF
--- a/migrations/20251126180700-change-publicationYear-type.js
+++ b/migrations/20251126180700-change-publicationYear-type.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async up(db, client) {
+    await db
+      .collection("PublishedData")
+      .find({})
+      .forEach(async (publishedData) => {
+        await db
+          .collection("PublishedData")
+          .updateOne(
+            { _id: publishedData._id },
+            { $set: { publicationYear: publishedData.publicationYear.toString() } }
+          );
+      });
+  },
+
+  async down(db, client) {
+    await db
+      .collection("PublishedData")
+      .find({})
+      .forEach(async (publishedData) => {
+        await db
+          .collection("PublishedData")
+          .updateOne(
+            { _id: publishedData._id },
+            { $set: { publicationYear: Number(publishedData.publicationYear) } }
+          );
+      });
+  },
+};

--- a/publishedDataConfig.example.json
+++ b/publishedDataConfig.example.json
@@ -120,7 +120,7 @@
         "$dataciteRequired": true
       },
       "publicationYear": {
-        "type": "integer",
+        "type": "string",
         "title": "Publication Year",
         "$dataciteRequired": true
       },

--- a/src/published-data/dto/published-data.obsolete.dto.ts
+++ b/src/published-data/dto/published-data.obsolete.dto.ts
@@ -48,7 +48,7 @@ export class PublishedDataObsoleteDto {
   publisher: string;
 
   @ApiProperty({
-    type: Number,
+    type: String,
     required: true,
     description:
       "Year of publication.  This field has the semantics of Dublin Core" +
@@ -56,7 +56,7 @@ export class PublishedDataObsoleteDto {
       " and [DataCite publicationYear](https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/publicationyear/).",
   })
   @IsNumber()
-  publicationYear: number;
+  publicationYear: string;
 
   @ApiProperty({
     type: String,

--- a/src/published-data/dto/update-published-data.dto.ts
+++ b/src/published-data/dto/update-published-data.dto.ts
@@ -18,8 +18,8 @@ export class UpdatePublishedDataDto {
   @IsString()
   readonly publisher: string;
 
-  @IsNumber()
-  readonly publicationYear: number;
+  @IsString()
+  readonly publicationYear: string;
 
   @IsString()
   readonly title: string;

--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -252,7 +252,7 @@ export class PublishedDataController {
       sizeOfArchive: inputPublishedData.sizeOfArchive,
       affiliation: inputPublishedData.metadata?.affiliation as string,
       publisher: inputPublishedData.metadata?.publisher as string,
-      publicationYear: inputPublishedData.metadata?.publicationYear as number,
+      publicationYear: inputPublishedData.metadata?.publicationYear as string,
       creator: (inputPublishedData.metadata?.creators as object[])?.map(
         (creator: any) => creator.name,
       ),

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -69,7 +69,7 @@ export class PublishedDataService {
     );
 
     if (createdPublished.metadata) {
-      createdPublished.metadata.publicationYear = new Date().getFullYear();
+      createdPublished.metadata.publicationYear = new Date().getFullYear().toString();
     }
 
     return createdPublished.save();

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -69,7 +69,9 @@ export class PublishedDataService {
     );
 
     if (createdPublished.metadata) {
-      createdPublished.metadata.publicationYear = new Date().getFullYear().toString();
+      createdPublished.metadata.publicationYear = new Date()
+        .getFullYear()
+        .toString();
     }
 
     return createdPublished.save();

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -1333,7 +1333,7 @@ const TestData = {
   PublishedData: {
     creator: ["ESS"],
     publisher: "ESS",
-    publicationYear: 2020,
+    publicationYear: "2020",
     title: "dd",
     url: "",
     abstract: "dd",
@@ -1351,7 +1351,7 @@ const TestData = {
     metadata: {
       creators: [{ name: "ESS" }],
       publisher: { name: "ESS", publisherIdentifierScheme: "testScheme" },
-      publicationYear: 2020,
+      publicationYear: "2020",
       resourceType: "raw",
       landingPage: "doi.ess.eu/detail/",
     },


### PR DESCRIPTION
## Description
Tiny fix for publication wirkflow to convert publicationYear from number to string as is expected by the DataCite API

## Motivation
Registration atempts fail with a 422 error due to wron publicationYear type

## Fixes

* Change type of publicationYear (mangaed by system, configuration ignored by FE) to string
* Add migration script to fix the type for existing publishedData instances

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated