### PR TITLE
fix: update archived fields only on datablock CRUDs

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2484,8 +2484,6 @@ export class DatasetsController {
         packedSize: (dataset.packedSize ?? 0) + datablock.packedSize,
         numberOfFilesArchived:
           dataset.numberOfFilesArchived + datablock.dataFileList.length,
-        size: dataset.size + datablock.size,
-        numberOfFiles: dataset.numberOfFiles + datablock.dataFileList.length,
       });
       return datablock;
     }
@@ -2593,7 +2591,7 @@ export class DatasetsController {
   @ApiParam({
     name: "pid",
     description:
-      "PErsistent identifier of the dataset for which we would like to update the datablocks specified",
+      "Persistent identifier of the dataset for which we would like to update the datablocks specified",
     type: String,
   })
   @ApiParam({
@@ -2626,7 +2624,7 @@ export class DatasetsController {
     });
     if (dataset && datablockBeforeUpdate) {
       const datablock = await this.datablocksService.update(
-        { _id: did, pid },
+        { _id: did },
         updateDatablockDto,
       );
       if (datablock) {
@@ -2762,8 +2760,6 @@ export class DatasetsController {
     await this.datasetsService.findByIdAndUpdate(dataset.pid, {
       packedSize: 0,
       numberOfFilesArchived: 0,
-      size: 0,
-      numberOfFiles: 0,
     });
     return res;
   }

--- a/test/DerivedDatasetDatablock.js
+++ b/test/DerivedDatasetDatablock.js
@@ -72,8 +72,8 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size);
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize);
         res.body.should.have.property("id").and.be.string;
         datablockId1 = res.body["id"];
       });
@@ -143,7 +143,7 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body["size"].should.be.equal(TestData.DataBlockCorrect.size * 2);
+        res.body["packedSize"].should.be.equal(TestData.DataBlockCorrect.packedSize * 2);
       });
   });
 
@@ -245,10 +245,10 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size * 2);
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize * 2);
         res.body.should.have
-          .property("numberOfFiles")
+          .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
       });
   });
@@ -323,9 +323,7 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.be.greaterThan(0);
         res.body.should.have.property("packedSize").and.be.greaterThan(0);
-        res.body.should.have.property("numberOfFiles").and.be.greaterThan(0);
         res.body.should.have.property("numberOfFilesArchived").and.be.greaterThan(0);
       });
 
@@ -343,9 +341,7 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.equal(0);
         res.body.should.have.property("packedSize").and.equal(0);
-        res.body.should.have.property("numberOfFiles").and.equal(0);
         res.body.should.have.property("numberOfFilesArchived").and.equal(0);
       });
 
@@ -357,17 +353,61 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect("Content-Type", /json/);
   });
 
-  it("0190: should delete first datablock", async () => {
-    return request(appUrl)
-      .delete(`/api/v3/datasets/${datasetPid}/datablocks/${datablockId1}`)
+  it("190: Should patch second datablock", async () => {
+    await request(appUrl)
+      .patch(`/api/v3/Datasets/${datasetPid}/datablocks/${datablockId2}`)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
-      .expect(TestData.SuccessfulDeleteStatusCode);
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .send({ packedSize: 123, dataFileList: [TestData.DataBlockCorrect.dataFileList[0]] })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) =>
+        res.body.should.have
+          .property("packedSize")
+          .and.equal(123)
+      );
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + datasetPid)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize + 123);
+        res.body.should.have
+          .property("numberOfFilesArchived")
+          .and.equal(TestData.DataBlockCorrect.dataFileList.length + 1);
+      });
   });
 
-  it("0200: should delete second datablock", async () => {
+  it("195: Should delete second datablock", async () => {
+    await request(appUrl)
+      .delete(`/api/v3/Datasets/${datasetPid}/datablocks/${datablockId2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+
     return request(appUrl)
-      .delete(`/api/v3/datasets/${datasetPid}/datablocks/${datablockId2}`)
+      .get("/api/v3/Datasets/" + datasetPid)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize);
+        res.body.should.have
+          .property("numberOfFilesArchived")
+          .and.equal(TestData.DataBlockCorrect.dataFileList.length);
+      });
+  });
+
+  it("0200: should delete first datablock", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/datablocks/${datablockId1}`)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(TestData.SuccessfulDeleteStatusCode);
@@ -393,8 +433,8 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.equal(0);
-        res.body.should.have.property("numberOfFiles").and.equal(0);
+        res.body.should.have.property("packedSize").and.equal(0);
+        res.body.should.have.property("numberOfFilesArchived").and.equal(0);
       });
   });
 

--- a/test/RawDatasetDatablock.js
+++ b/test/RawDatasetDatablock.js
@@ -55,8 +55,8 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size);
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize);
         res.body.should.have.property("id").and.be.string;
         datablockId = res.body["id"];
       });
@@ -75,10 +75,10 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
           .property("instrumentId")
           .and.be.equal(TestData.PatchInstrument1["instrumentId"]);
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size);
+          .property("packedSize")
+          .and.equal(TestData.DataBlockCorrect.packedSize);
         res.body.should.have
-          .property("numberOfFiles")
+          .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length);
       });
   });
@@ -237,14 +237,8 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size * 2);
-        res.body.should.have
           .property("packedSize")
           .and.equal(TestData.DataBlockCorrect.packedSize * 2);
-        res.body.should.have
-          .property("numberOfFiles")
-          .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
         res.body.should.have
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
@@ -321,9 +315,7 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.be.greaterThan(0);
         res.body.should.have.property("packedSize").and.be.greaterThan(0);
-        res.body.should.have.property("numberOfFiles").and.be.greaterThan(0);
         res.body.should.have.property("numberOfFilesArchived").and.be.greaterThan(0);
       });
 
@@ -341,9 +333,7 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.equal(0);
         res.body.should.have.property("packedSize").and.equal(0);
-        res.body.should.have.property("numberOfFiles").and.equal(0);
         res.body.should.have.property("numberOfFilesArchived").and.equal(0);
       });
 
@@ -373,14 +363,8 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have
-          .property("size")
-          .and.equal(TestData.DataBlockCorrect.size);
-        res.body.should.have
           .property("packedSize")
           .and.equal(TestData.DataBlockCorrect.packedSize);
-        res.body.should.have
-          .property("numberOfFiles")
-          .and.equal(TestData.DataBlockCorrect.dataFileList.length);
         res.body.should.have
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length);
@@ -404,9 +388,7 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.equal(0);
         res.body.should.have.property("packedSize").and.equal(0);
-        res.body.should.have.property("numberOfFiles").and.equal(0);
         res.body.should.have.property("numberOfFilesArchived").and.equal(0);
       });
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following the [old backend](https://github.com/SciCatProject/backend-v3/blob/master/common/models/datablock.js#L40) (and the current POST logic), datablocks should only modify archived values, i.e. `numberOfFilesArchived` and `packedSize`. See here

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
