### PR TITLE
refactor: simplify datablocks CRUD code

### DIFF
--- a/test/RawDatasetDatablock.js
+++ b/test/RawDatasetDatablock.js
@@ -351,7 +351,6 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(TestData.SuccessfulDeleteStatusCode)
-      .expect("Content-Type", /json/);
   });
 
   it("0100: The size and numFiles fields in the dataset should be correctly updated", async () => {
@@ -377,7 +376,6 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(TestData.SuccessfulDeleteStatusCode)
-      .expect("Content-Type", /json/);
   });
 
   it("0120: The size and numFiles fields in the dataset should be correctly updated", async () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Simplify datablock cruds code by exiting when empty and avoiding reduce logic. It's open against #2380 

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
