### PR TITLE
fix: remove wrong key in origs patch

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2312,7 +2312,7 @@ export class DatasetsController {
     });
     if (dataset && origDatablockBeforeUpdate) {
       const origDatablock = await this.origDatablocksService.update(
-        { _id: oid, pid },
+        { _id: oid },
         updateOrigdatablockDto,
       );
       if (origDatablock) {

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -109,6 +109,27 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       });
   });
 
+  it("0055: The new dataset should have the size of the first origDatablock", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("size")
+          .and.equal(
+            TestData.OrigDataBlockCorrect1.size
+          );
+        res.body.should.have
+          .property("numberOfFiles")
+          .and.equal(
+            TestData.OrigDataBlockCorrect1.dataFileList.length
+          );
+      });
+  });
+
   it("0060: adds a second origDatablock", async () => {
     return request(appUrl)
       .post(`/api/v3/datasets/${datasetPid}/OrigDatablocks`)
@@ -140,7 +161,7 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       });
   });
 
-  it("0070: Should count all origdatablocks belonging to the new dataset", async () => {
+  it("0075: Should count all origdatablocks belonging to the new dataset", async () => {
     return request(appUrl)
       .get(`/api/v3/Datasets/${datasetPid}/OrigDatablocks/count`)
       .set("Accept", "application/json")
@@ -160,10 +181,18 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body["size"].should.be.equal(
-          TestData.OrigDataBlockCorrect1.size +
-          TestData.OrigDataBlockCorrect2.size,
-        );
+        res.body.should.have
+          .property("size")
+          .and.equal(
+            TestData.OrigDataBlockCorrect1.size +
+            TestData.OrigDataBlockCorrect2.size,
+          );
+        res.body.should.have
+          .property("numberOfFiles")
+          .and.equal(
+            TestData.OrigDataBlockCorrect1.dataFileList.length +
+            TestData.OrigDataBlockCorrect2.dataFileList.length,
+          );
       });
   });
 
@@ -382,7 +411,19 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       });
   });
 
-  it("0150: The size and numFiles fields in the dataset should be correctly updated", async () => {
+  it("150: Should patch second origdatablock", async () => {
+    await request(appUrl)
+      .patch(`/api/v3/Datasets/${datasetPid}/origdatablocks/${origDatablockId2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .send({ size: 123, dataFileList: [TestData.OrigDataBlockCorrect2.dataFileList[0]] })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) =>
+        res.body.should.have
+          .property("size")
+          .and.equal(123)
+      );
     return request(appUrl)
       .get("/api/v3/Datasets/" + datasetPid)
       .set("Accept", "application/json")
@@ -392,33 +433,42 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
       .then((res) => {
         res.body.should.have
           .property("size")
-          .and.equal(
-            TestData.OrigDataBlockCorrect1.size +
-            TestData.OrigDataBlockCorrect2.size,
-          );
+          .and.equal(TestData.OrigDataBlockCorrect1.size + 123);
         res.body.should.have
           .property("numberOfFiles")
-          .and.equal(
-            TestData.OrigDataBlockCorrect1.dataFileList.length +
-            TestData.OrigDataBlockCorrect2.dataFileList.length,
-          );
+          .and.equal(TestData.OrigDataBlockCorrect1.dataFileList.length + 1);
       });
   });
 
-  it("0160: should delete first OrigDatablock", async () => {
-    return request(appUrl)
+  it("0160: should delete second OrigDatablock", async () => {
+    await request(appUrl)
       .delete(
-        `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId1}`,
+        `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId2}`,
       )
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(TestData.SuccessfulDeleteStatusCode);
+
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + datasetPid)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("size")
+          .and.equal(TestData.OrigDataBlockCorrect1.size);
+        res.body.should.have
+          .property("numberOfFiles")
+          .and.equal(TestData.OrigDataBlockCorrect1.dataFileList.length);
+      });
   });
 
-  it("0170: should delete second OrigDatablock", async () => {
+  it("0170: should delete first OrigDatablock", async () => {
     return request(appUrl)
       .delete(
-        `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId2}`,
+        `/api/v3/datasets/${datasetPid}/OrigDatablocks/${origDatablockId1}`,
       )
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Patching origs had no effect because the wrong field was used to filter. This PR fixes is, together with adding tests for all datasets/{id}/origdatablocks, where missing

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
