### PR TITLE
refactor: simplify origs crud

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2103,8 +2103,6 @@ export class DatasetsController {
       Action.DatasetOrigdatablockCreate,
     );
 
-    if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
-
     const createOrigDatablock: CreateOrigDatablockDto = {
       ...createDatasetOrigDatablockDto,
       datasetId: pid,
@@ -2293,8 +2291,6 @@ export class DatasetsController {
       pid,
       Action.DatasetOrigdatablockUpdate,
     );
-    if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
-
     const origDatablockBeforeUpdate = await this.origDatablocksService.findOne({
       _id: oid,
     });
@@ -2398,8 +2394,6 @@ export class DatasetsController {
       pid,
       Action.DatasetOrigdatablockDelete,
     );
-    if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
-
     const odb = (await this.origDatablocksService.remove({
       _id: oid,
       datasetId: pid,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Simplify origdatablock cruds code by exiting when empty and avoiding reduce logic. It's open against #2382 

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
