### PR TITLE
feat: allow objs for fields in v3 using FilterPipe

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -4,6 +4,7 @@ import {
   TransformObjValuesPipe,
 } from "src/jobs/pipes/v3-filter.pipe";
 import { IFilters } from "../interfaces/common.interface";
+import _ from "lodash";
 
 /**
  * @class FilterPipe
@@ -37,7 +38,13 @@ export class FilterPipe<T = unknown>
   };
   private readonly replaceOperatorsPipe: TransformObjValuesPipe;
 
-  constructor() {
+  constructor(options = { allowObjectFields: true }) {
+    const fields: { fields?: (value: unknown) => unknown } = {};
+    if (options.allowObjectFields)
+      fields.fields = (val: unknown) =>
+        _.isPlainObject(val)
+          ? _.keys(_.pickBy(val as Record<string, boolean>, Boolean))
+          : val;
     this.replaceOperatorsPipe = new TransformObjValuesPipe({
       where: (value: unknown) => {
         return transformDeep(value, {
@@ -56,6 +63,7 @@ export class FilterPipe<T = unknown>
           keyMap: FilterPipe.replaceOperatorsMap,
         });
       },
+      ...fields,
     });
   }
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -120,7 +120,6 @@ import { convertGenericHistoriesToObsoleteHistories } from "src/datasets/utils/h
 import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe";
 import { DATASET_LOOKUP_FIELDS } from "./types/dataset-lookup";
 import { getSwaggerDatasetFilterContentV3 } from "./types/dataset-filter-content.v3";
-import { isObject } from "lodash";
 import { Filter } from "./decorators/filter.decorator";
 import { checkUnmodifiedSince } from "src/common/utils/check-unmodified-since";
 
@@ -898,14 +897,6 @@ export class DatasetsController {
       request,
       queryFilter.filter ?? {},
     ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
-    if (
-      isObject(mergedFilters?.fields) &&
-      !Array.isArray(mergedFilters.fields)
-    ) {
-      mergedFilters.fields = Object.keys(mergedFilters.fields).filter(
-        (key) => mergedFilters.fields![key],
-      ) as unknown as IDatasetFields;
-    }
     if (queryFilter.filter)
       new IncludeValidationPipe(DATASET_LOOKUP_FIELDS).transform(
         JSON.stringify(queryFilter.filter),

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -117,7 +117,7 @@ export class PublishedDataV4Controller {
   })
   async findAll(
     @Req() request: Request,
-    @Query(new FilterPipe(), RegisteredFilterPipe)
+    @Query(new FilterPipe({ allowObjectFields: false }), RegisteredFilterPipe)
     filter?: {
       filter: IPublishedDataFilters;
       fields: string;
@@ -177,7 +177,7 @@ export class PublishedDataV4Controller {
   })
   async count(
     @Req() request: Request,
-    @Query(new FilterPipe(), RegisteredFilterPipe)
+    @Query(new FilterPipe({ allowObjectFields: false }), RegisteredFilterPipe)
     filter?: {
       filter: IPublishedDataFilters;
       fields: string;

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -79,7 +79,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
   it("0030: adds a new minimal raw dataset", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
-      .send({...TestData.RawCorrectMin, sourceFolder: "/data/derived/"})
+      .send({ ...TestData.RawCorrectMin, sourceFolder: "/data/derived/" })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
@@ -411,7 +411,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
       fields: { pid: 1, datasetName: true, description: 0 },
       include: [
         { relation: "instruments" },
-        { relation: "proposals", scope: { fields: ["abstract"] } }
+        { relation: "proposals", scope: { fields: { abstract: 1 } } }
       ],
     };
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following [v3](https://loopback.io/doc/en/lb3/Querying-data.html#filters), wherever using FilterPipe, the user can pass fields both as an object and as a list

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
