### PR TITLE
fix: avoid datablocks updates on origs

### DIFF
--- a/test/Datablock.js
+++ b/test/Datablock.js
@@ -137,13 +137,13 @@ describe("Datablocks", () => {
       .then((res) => {
         res.body.should.have
           .property("size")
-          .and.equal(TestData.DataBlockCorrect.size * 2);
+          .and.equal(0);
         res.body.should.have
           .property("packedSize")
           .and.equal(TestData.DataBlockCorrect.packedSize * 2);
         res.body.should.have
           .property("numberOfFiles")
-          .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
+          .and.equal(0);
         res.body.should.have
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
@@ -169,13 +169,13 @@ describe("Datablocks", () => {
       .then((res) => {
         res.body.should.have
           .property("size")
-          .and.equal(TestData.DataBlockCorrect.size);
+          .and.equal(0);
         res.body.should.have
           .property("packedSize")
           .and.equal(TestData.DataBlockCorrect.packedSize);
         res.body.should.have
           .property("numberOfFiles")
-          .and.equal(TestData.DataBlockCorrect.dataFileList.length);
+          .and.equal(0);
         res.body.should.have
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length);
@@ -199,9 +199,7 @@ describe("Datablocks", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("size").and.equal(0);
         res.body.should.have.property("packedSize").and.equal(0);
-        res.body.should.have.property("numberOfFiles").and.equal(0);
         res.body.should.have.property("numberOfFilesArchived").and.equal(0);
       });
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Datablocks should not update size and files count, as they belong to origs. This PR fixes it

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
