### PR TITLE
feat: extend fa role to be a list

### DIFF
--- a/functionalAccounts.json.minimal.example
+++ b/functionalAccounts.json.minimal.example
@@ -24,7 +24,7 @@
     "username": "proposalIngestor",
     "email": "scicatproposalingestor@your.site",
     "password": "aman",
-    "role": "proposalingestor",
+    "role": ["proposalingestor"],
     "global": true
   }
 ]

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -64,6 +64,7 @@ export class UsersService implements OnModuleInit {
         createAccount.authStrategy = "local";
         const user = await this.findOrCreate(createAccount);
         const roles: Record<string, Array<string>> = {};
+        const rolesList = typeof role === "string" ? [role] : role;
 
         if (user) {
           const userPayload: UserPayload = {
@@ -75,13 +76,15 @@ export class UsersService implements OnModuleInit {
             await this.accessGroupService.getAccessGroups(userPayload);
           const accessGroups = [...accessGroupsOrig];
 
-          if (role) {
-            // add role as access group
-            accessGroups.push(role);
-            if (!(role in roles)) {
-              roles[role] = [];
-            }
-            roles[role].push(user._id.toString());
+          if (rolesList) {
+            rolesList.forEach((r) => {
+              // add role as access group
+              accessGroups.push(r);
+              if (!(r in roles)) {
+                roles[r] = [];
+              }
+              roles[r].push(user._id.toString());
+            });
           }
           if (global) {
             accessGroups.push("globalaccess");
@@ -102,7 +105,9 @@ export class UsersService implements OnModuleInit {
               username: account.username as string,
               thumbnailPhoto: "error: no photo found",
               emails: [{ value: account.email as string }],
-              accessGroups: [...new Set([role as string, ...accessGroups])],
+              accessGroups: [
+                ...new Set([...(rolesList ?? []), ...accessGroups]),
+              ],
               id: user.id as string,
             },
             provider: "local",

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -1661,4 +1661,34 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
         res.body.should.not.have.property("pid");
       });
   });
+
+  it("0870: add a dataset with role and access by username", async () => {
+    const user = "user6";
+    const ds = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send({ ...TestData.RawCorrectMin, accessGroups: [TestData.Accounts[user].username] })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+    const accessTokenUser6 = await await utils.getToken(appUrl, {
+      username: user,
+      password: TestData.Accounts[user]["password"],
+    });
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${encodeURIComponent(ds.body.pid)}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+    return request(appUrl)
+      .get(`/api/v3/Datasets/${encodeURIComponent(ds.body.pid)}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser6}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) =>
+        res.body.should.have.property("pid").and.equal(ds.body.pid)
+      );
+  });
 });

--- a/test/config/functionalAccounts.json
+++ b/test/config/functionalAccounts.json
@@ -82,5 +82,12 @@
       "password": "f3ebd2e4def95db59ef95ee32ef45242",
       "role": "group5",
       "global": false
+    },
+    {
+      "username": "user6",
+      "email": "user6@your.site",
+      "password": "a1b2c3d4e5f67890123456789abcdef0",
+      "role": ["group6", "user6"],
+      "global": false
     }
 ]


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Following from #2408 this extends role in fa to be a list. This covers #2408 by adding the username in the role adds it to the allowed accessGroups. 

The field is kept `role`, even thought it should be `roles` to keep backward compatibility.

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
