### PR TITLE
fix: run docs when main changes

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,15 +3,21 @@ name: Deploy docs
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - main
+      - master
     tags:
       - v*
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: SciCatProject/docs-template/.github/actions/mkdocs-pages@main
+      - uses: SciCatProject/docs-template/.github/actions/mkdocs-pages@v0.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          push: true
+          push: ${{ github.event_name == 'push' && 'true' || '' }}
+          # if this file does not need to exist locally, the one in the action is used
+          # https://github.com/SciCatProject/docs-template/blob/v0.1.0/.github/actions/mkdocs-pages/mkdocs-nested.yml
+          docs_config: .github/mkdocs/mkdocs-nested.yml


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This fixes the docs build since we use master
