### PR TITLE
fix: enable datasetPublic permission to be unauth

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -655,7 +655,9 @@ export class CaslAbilityFactory {
       // job creation
       if (
         Object.values(this.jobConfigService.allJobConfigs).some(
-          (j) => j.create.auth == CreateJobAuth.All,
+          (j) =>
+            j.create.auth == CreateJobAuth.All ||
+            j.create.auth == CreateJobAuth.DatasetPublic,
         )
       ) {
         can(Action.JobCreate, JobClass);

--- a/test/jest-e2e-tests/jobsDatasetPublic.e2e-spec.ts
+++ b/test/jest-e2e-tests/jobsDatasetPublic.e2e-spec.ts
@@ -1,0 +1,71 @@
+import request from "supertest";
+import { INestApplication } from "@nestjs/common";
+import { getConnectionToken } from "@nestjs/mongoose";
+import { Connection } from "mongoose";
+import { createTestingApp, createTestingModuleFactory } from "./utlis";
+import { TestData } from "../TestData";
+import { JobConfigService } from "src/config/job-config/jobconfig.service";
+import { getToken } from "../LoginUtils";
+
+describe("Jobs public groups test", () => {
+  let app: INestApplication;
+  let mongoConnection: Connection;
+  let pid: string;
+
+  class JobsConfigMock extends JobConfigService {
+    get allJobConfigs() {
+      const jobs = super.allJobConfigs;
+      return { public_access: jobs["public_access"] };
+    }
+  }
+
+  beforeAll(async () => {
+    const moduleFixture = await createTestingModuleFactory()
+      .overrideProvider(JobConfigService)
+      .useClass(JobsConfigMock)
+      .compile();
+    app = await createTestingApp(moduleFixture);
+    mongoConnection = await app.get<Promise<Connection>>(getConnectionToken());
+  });
+
+  beforeAll(async () => {
+    const token = await getToken(app.getHttpServer(), {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+
+    const dataset = {
+      ...TestData.RawCorrectMin,
+      isPublished: true,
+    };
+
+    await request(app.getHttpServer())
+      .post("/api/v3/datasets")
+      .send(dataset)
+      .auth(token, { type: "bearer" })
+      .set("Accept", "application/json")
+      .expect(TestData.EntryCreatedStatusCode)
+      .then((res) => {
+        pid = res.body.pid;
+      });
+  });
+
+  afterAll(async () => {
+    if (mongoConnection.db) await mongoConnection.db.dropDatabase();
+    await app.close();
+  });
+
+  it("Check if job can be submitted", async () => {
+    const job = {
+      type: "public_access",
+      emailJobInitiator: "user5.1@your.site",
+      datasetList: [{ pid: pid, files: [] }],
+    };
+
+    return request(app.getHttpServer())
+      .post("/api/v3/jobs")
+      .send(job)
+      .set("Accept", "application/json")
+      .expect(TestData.EntryCreatedStatusCode);
+  });
+});


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This enables jobConfigs without `#all` to submit jobs that check if datasets are public. I have to admit I don't understand the jobs auth very well, so I am happy for feedback

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
