### PR TITLE
fix(publisheddata): only register to DataCite if an URL is configured

### DIFF
--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -587,7 +587,7 @@ export class PublishedDataV4Controller {
     );
 
     const registerDoiUri = this.configService.get<string>("registerDoiUri");
-    if (registerDoiUri) {
+    if (registerDoiUri && registerDoiUri.trim().length > 0) {
       let doiProviderCredentials = {
         username: "removed",
         password: "removed",

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -12,7 +12,7 @@ import {
   Post,
   Query,
   Req,
-  UseGuards
+  UseGuards,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import {

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -12,7 +12,7 @@ import {
   Post,
   Query,
   Req,
-  UseGuards,
+  UseGuards
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import {

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -577,8 +577,6 @@ export class PublishedDataV4Controller {
 
     await this.validateMetadata(publishedData.metadata);
 
-    const jsonData = this.doiRegistrationJSON(publishedData);
-
     await Promise.all(
       publishedData.datasetPids.map(async (pid) => {
         await this.datasetsController.findByIdAndUpdate(request, pid, {
@@ -587,47 +585,50 @@ export class PublishedDataV4Controller {
         });
       }),
     );
+
     const registerDoiUri = this.configService.get<string>("registerDoiUri");
-
-    let doiProviderCredentials = {
-      username: "removed",
-      password: "removed",
-    };
-
-    const username = this.configService.get<string>("doiUsername");
-    const password = this.configService.get<string>("doiPassword");
-
-    if (username && password) {
-      doiProviderCredentials = {
-        username,
-        password,
+    if (registerDoiUri) {
+      let doiProviderCredentials = {
+        username: "removed",
+        password: "removed",
       };
-    }
 
-    const authorization = `${doiProviderCredentials.username}:${doiProviderCredentials.password}`;
-    const registerDataciteDoiOptions = {
-      method: "POST",
-      url: `${registerDoiUri}`,
-      headers: {
-        accept: "application/vnd.api+json",
-        "content-type": "application/json",
-        authorization: `Basic ${Buffer.from(authorization).toString("base64")}`,
-      },
-      data: jsonData,
-    };
+      const username = this.configService.get<string>("doiUsername");
+      const password = this.configService.get<string>("doiPassword");
 
-    try {
-      await firstValueFrom(
-        this.httpService.request(registerDataciteDoiOptions),
-      );
-    } catch (err) {
-      console.log("Error in registerDataciteDoiOptions", err);
+      if (username && password) {
+        doiProviderCredentials = {
+          username,
+          password,
+        };
+      }
 
-      handleAxiosRequestError(err, "PublishedDataController.register");
-      throw new HttpException(
-        `Error occurred: ${err}`,
-        HttpStatus.FAILED_DEPENDENCY,
-      );
+      const authorization = `${doiProviderCredentials.username}:${doiProviderCredentials.password}`;
+      const jsonData = this.doiRegistrationJSON(publishedData);
+      const registerDataciteDoiOptions = {
+        method: "POST",
+        url: `${registerDoiUri}`,
+        headers: {
+          accept: "application/vnd.api+json",
+          "content-type": "application/json",
+          authorization: `Basic ${Buffer.from(authorization).toString("base64")}`,
+        },
+        data: jsonData,
+      };
+
+      try {
+        await firstValueFrom(
+          this.httpService.request(registerDataciteDoiOptions),
+        );
+      } catch (err) {
+        console.log("Error in registerDataciteDoiOptions", err);
+
+        handleAxiosRequestError(err, "PublishedDataController.register");
+        throw new HttpException(
+          `Error occurred: ${err}`,
+          HttpStatus.FAILED_DEPENDENCY,
+        );
+      }
     }
 
     const res = await this.publishedDataService.update(

--- a/test/jest-e2e-tests/publishedData.e2e-spec.ts
+++ b/test/jest-e2e-tests/publishedData.e2e-spec.ts
@@ -9,111 +9,117 @@ import { getToken } from "../LoginUtils";
 import { TestData } from "../TestData";
 import { createTestingApp, createTestingModuleFactory } from "./utlis";
 
-describe.each([undefined, "", "https://api.test.datacite.org/dois"])("Published data datacite test (url: %p)", (registerDoiUri) => {
-  let app: INestApplication;
-  let mongoConnection: Connection;
-  let token: string;
-  let httpService: HttpService;
+describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
+  "Published data datacite test (url: %p)",
+  (registerDoiUri) => {
+    let app: INestApplication;
+    let mongoConnection: Connection;
+    let token: string;
+    let httpService: HttpService;
 
-  let doi: string;
+    let doi: string;
 
-  beforeAll(async () => {
-    if (registerDoiUri) {
-      process.env.REGISTER_DOI_URI = registerDoiUri;
-    } else {
-      delete process.env.REGISTER_DOI_URI;
-    }
-    const moduleFixture = await createTestingModuleFactory().compile();
-    app = await createTestingApp(moduleFixture);
-    mongoConnection = await app.get<Promise<Connection>>(getConnectionToken());
-    httpService = moduleFixture.get<HttpService>(HttpService);
-  });
-
-  beforeAll(async () => {
-    token = await getToken(app.getHttpServer(), {
-      username: "adminIngestor",
-      password: TestData.Accounts["adminIngestor"]["password"],
+    beforeAll(async () => {
+      if (registerDoiUri) {
+        process.env.REGISTER_DOI_URI = registerDoiUri;
+      } else {
+        delete process.env.REGISTER_DOI_URI;
+      }
+      const moduleFixture = await createTestingModuleFactory().compile();
+      app = await createTestingApp(moduleFixture);
+      mongoConnection =
+        await app.get<Promise<Connection>>(getConnectionToken());
+      httpService = moduleFixture.get<HttpService>(HttpService);
     });
-  });
 
-  beforeAll(async () => {
-    await request(app.getHttpServer())
-      .post("/api/v4/PublishedData")
-      .send(TestData.PublishedDataV4)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => (doi = encodeURIComponent(res.body["doi"])));
-  });
-
-  afterAll(async () => {
-    if (mongoConnection.db) await mongoConnection.db.dropDatabase();
-    await app.close();
-  });
-
-  it("Should register this new published data", async () => {
-    if (registerDoiUri && registerDoiUri.trim().length > 0) {
-      const mockAxiosResponse: AxiosResponse = {
-        data: {},
-        status: TestData.SuccessfulGetStatusCode,
-        statusText: "OK",
-        headers: {},
-        config: {},
-      };
-      jest.spyOn(httpService, "request").mockReturnValue(of(mockAxiosResponse));
-    }
-    await request(app.getHttpServer())
-      .post("/api/v4/PublishedData/" + doi + "/register")
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/);
-  });
-
-  it("Should fetch this new published data", async () => {
-    await request(app.getHttpServer())
-      .get("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(TestData.SuccessfulGetStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        expect(res.body.status).toEqual("registered");
+    beforeAll(async () => {
+      token = await getToken(app.getHttpServer(), {
+        username: "adminIngestor",
+        password: TestData.Accounts["adminIngestor"]["password"],
       });
-  });
-
-  it("Should not be able to delete published data in registrated", async () => {
-    const archiveManagerToken = await getToken(app.getHttpServer(), {
-      username: "archiveManager",
-      password: TestData.Accounts["archiveManager"]["password"],
     });
-    await request(app.getHttpServer())
-      .delete("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${archiveManagerToken}` })
-      .expect(TestData.BadRequestStatusCode)
-      .expect("Content-Type", /json/);
-  });
 
-  it("Should amend this new registered published data", async () => {
-    await request(app.getHttpServer())
-      .post("/api/v4/PublishedData/" + doi + "/amend")
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/);
-  });
+    beforeAll(async () => {
+      await request(app.getHttpServer())
+        .post("/api/v4/PublishedData")
+        .send(TestData.PublishedDataV4)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${token}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => (doi = encodeURIComponent(res.body["doi"])));
+    });
 
-  it("Should fetch this amended published data", async () => {
-    await request(app.getHttpServer())
-      .get("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(TestData.SuccessfulGetStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        expect(res.body.status).toEqual("amended");
+    afterAll(async () => {
+      if (mongoConnection.db) await mongoConnection.db.dropDatabase();
+      await app.close();
+    });
+
+    it("Should register this new published data", async () => {
+      if (registerDoiUri && registerDoiUri.trim().length > 0) {
+        const mockAxiosResponse: AxiosResponse = {
+          data: {},
+          status: TestData.SuccessfulGetStatusCode,
+          statusText: "OK",
+          headers: {},
+          config: {},
+        };
+        jest
+          .spyOn(httpService, "request")
+          .mockReturnValue(of(mockAxiosResponse));
+      }
+      await request(app.getHttpServer())
+        .post("/api/v4/PublishedData/" + doi + "/register")
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${token}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("Should fetch this new published data", async () => {
+      await request(app.getHttpServer())
+        .get("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${token}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          expect(res.body.status).toEqual("registered");
+        });
+    });
+
+    it("Should not be able to delete published data in registrated", async () => {
+      const archiveManagerToken = await getToken(app.getHttpServer(), {
+        username: "archiveManager",
+        password: TestData.Accounts["archiveManager"]["password"],
       });
-  });
-});
+      await request(app.getHttpServer())
+        .delete("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${archiveManagerToken}` })
+        .expect(TestData.BadRequestStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("Should amend this new registered published data", async () => {
+      await request(app.getHttpServer())
+        .post("/api/v4/PublishedData/" + doi + "/amend")
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${token}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("Should fetch this amended published data", async () => {
+      await request(app.getHttpServer())
+        .get("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${token}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          expect(res.body.status).toEqual("amended");
+        });
+    });
+  },
+);


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Registering a `PublishedData` through an API call (DataCite) only occurs if a `REGISTER_DOI_URI` configuration is set
## Motivation
<!-- Background on use case, changes needed -->
At PSI, registration of `PublishedData` is currently done by exposing OAI-PMH records to an external service that handles the registration to DataCite.
## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
