### PR TITLE
fix: fixup optimistic concurrency control

### DIFF
--- a/src/common/utils/check-unmodified-since.ts
+++ b/src/common/utils/check-unmodified-since.ts
@@ -21,7 +21,7 @@ export function checkUnmodifiedSince(
   const headerDate = new Date(headerDateString);
   if (isNaN(headerDate.getTime())) return;
 
-  if (headerDate <= resourceDate) {
+  if (headerDate < resourceDate) {
     throw new PreconditionFailedException(
       "Resource has been modified on server",
     );


### PR DESCRIPTION
## Description

If the time send by the client is equal to the ressource on the server,
the clients updated version is based on servers version with that time.

or in other words:

the client has taken into account the ressource on the server b/c the
client should use the timestamp received with the ressource from the
server.

from the RFC:

> The origin server MUST NOT perform the requested method
> if the selected representation's last modification date is more
> recent than the date provided in the field-value

Client receives t0
Client sends update w/ t0 -> OK

Server is on t1
Client received t0 (previously)
Client sends update w/ t0 -> FAIL

## Motivation

The current implementation does not accept timestamps equal to the server ressource as described above.

## Fixes

* Fixup for helper function in "fix: implementing optimistic concurrency control (#2331)"
