### PR TITLE
fix: assign correct size when 0 ds size

### DIFF
--- a/migrations/20250423114619-populate-overwritten-datasets-size.js
+++ b/migrations/20250423114619-populate-overwritten-datasets-size.js
@@ -1,155 +1,38 @@
 module.exports = {
   async up(db, client) {
-    await db
-      .collection("Dataset")
-      .find({ size: 0 })
-      .forEach(async (dataset) => {
-        const origDatablocks = await db
-          .collection("OrigDatablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-        const origDatablockSizeSum = origDatablocks.reduce(
-          (acc, origDatablock) => acc + origDatablock.size,
-          0,
-        );
+    for await (const dataset of db.collection("Dataset").find({ size: 0 })) {
+        let origDatablockSizeSum = 0;
+        let origDatablockNumberOfFilesSum = 0;
+        for await (const origDatablock of db.collection("OrigDatablock").find({datasetId: dataset._id})) {
+            origDatablockSizeSum += origDatablock.size;
+            origDatablockNumberOfFilesSum += origDatablock.dataFileList.length;
+          }
 
-        const datablocks = await db
-          .collection("Datablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-
-        const datablockSizeSum = datablocks.reduce(
-          (acc, datablock) => acc + datablock.size,
-          0,
-        );
-
-        const datasetSizeSum = origDatablockSizeSum + datablockSizeSum;
+        let datablockSizeSum = 0;
+        let datablockNumberOfFilesSum = 0;
+        for await (const datablock of db.collection("Datablock").find({datasetId: dataset._id})) {
+            datablockSizeSum += datablock.size;
+            datablockNumberOfFilesSum += datablock.dataFileList.length;
+        }
 
         console.log(
-          `Updating Dataset (Id: ${dataset._id}) with size =>${datasetSizeSum}<=`,
+          `Updating Dataset (Id: ${dataset._id}) with size: ${origDatablockSizeSum}, packedSize: ${datablockSizeSum}, numberOfFiles: ${origDatablockNumberOfFilesSum}, numberOfFilesArchived: ${datablockNumberOfFilesSum}`,
         );
+
         await db.collection("Dataset").updateOne(
           {
             _id: dataset._id,
           },
           {
             $set: {
-              size: datasetSizeSum,
+              size: origDatablockSizeSum,
+              packedSize: datablockSizeSum,
+              numberOfFiles: origDatablockNumberOfFilesSum,
+              numberOfFilesArchived: datablockNumberOfFilesSum
             },
           },
         );
-      });
-
-    await db
-      .collection("Dataset")
-      .find({ numberOfFiles: 0 })
-      .forEach(async (dataset) => {
-        const origDatablocks = await db
-          .collection("OrigDatablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-        const origDatablockNumberOfFilesSum = origDatablocks.reduce(
-          (acc, origDatablock) => acc + origDatablock.dataFileList.length,
-          0,
-        );
-
-        const datablocks = await db
-          .collection("Datablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-
-        const datablockNumberOfFilesSum = datablocks.reduce(
-          (acc, datablock) => acc + datablock.dataFileList.length,
-          0,
-        );
-
-        const datasetNumberOfFilesSum =
-          origDatablockNumberOfFilesSum + datablockNumberOfFilesSum;
-
-        console.log(
-          `Updating Dataset (Id: ${dataset._id}) with numberOfFiles =>${datasetNumberOfFilesSum}<=`,
-        );
-        await db.collection("Dataset").updateOne(
-          {
-            _id: dataset._id,
-          },
-          {
-            $set: {
-              numberOfFiles: datasetNumberOfFilesSum,
-            },
-          },
-        );
-      });
-
-    await db
-      .collection("Dataset")
-      .find({ packedSize: 0 })
-      .forEach(async (dataset) => {
-        const datablocks = await db
-          .collection("Datablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-
-        const datablockPackedSizeSum = datablocks.reduce(
-          (acc, datablock) => acc + datablock.packedSize,
-          0,
-        );
-
-        console.log(
-          `Updating Dataset (Id: ${dataset._id}) with packedSize =>${datablockPackedSizeSum}<=`,
-        );
-        await db.collection("Dataset").updateOne(
-          {
-            _id: dataset._id,
-          },
-          {
-            $set: {
-              packedSize: datablockPackedSizeSum,
-            },
-          },
-        );
-      });
-
-    await db
-      .collection("Dataset")
-      .find({ numberOfFilesArchived: 0 })
-      .forEach(async (dataset) => {
-        const datablocks = await db
-          .collection("Datablock")
-          .find({
-            datasetId: dataset._id,
-          })
-          .toArray();
-
-        const datablockNumberOfFilesArchivedSum = datablocks.reduce(
-          (acc, datablock) => acc + datablock.dataFileList.length,
-          0,
-        );
-
-        console.log(
-          `Updating Dataset (Id: ${dataset._id}) with numberOfFilesArchived =>${datablockNumberOfFilesArchivedSum}<=`,
-        );
-        await db.collection("Dataset").updateOne(
-          {
-            _id: dataset._id,
-          },
-          {
-            $set: {
-              numberOfFilesArchived: datablockNumberOfFilesArchivedSum,
-            },
-          },
-        );
-      });
+      };
   },
 
   async down(db, client) {},


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The logic before was wrong, as it was assignign the wrong size to the DS, mixing origs and datablocks. This PR fixes it.
