### PR TITLE
feat: mask emails when contained in text

### DIFF
--- a/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
+++ b/test/jest-e2e-tests/maskSensitiveData.e2e-spec.ts
@@ -54,7 +54,12 @@ describe("HidePersonalInfo test", () => {
         _id: "68b85b9cf830ebdccde06a0e",
       },
       scientificMetadata: {
-        nestedEmails: [{ email: "another@example.com" }],
+        nestedEmails: [
+          {
+            email: "another@example.com",
+            emailString: `${user1email}; ${user2email} some email in text (access3@group.site)|access4@group.site`,
+          },
+        ],
       },
     };
 
@@ -71,7 +76,10 @@ describe("HidePersonalInfo test", () => {
           expect(result.body.accessGroups).toEqual(["*****"]),
           expect(result.body.scientificMetadata.nestedEmails[0].email).toEqual(
             "*****",
-          )
+          ),
+          expect(
+            result.body.scientificMetadata.nestedEmails[0].emailString,
+          ).toEqual("user1@your.site; ***** some email in text (*****)|*****")
         ),
       );
 
@@ -89,7 +97,10 @@ describe("HidePersonalInfo test", () => {
           ),
           expect(
             result.body[0].scientificMetadata.nestedEmails[0].email,
-          ).toEqual("*****")
+          ).toEqual("*****"),
+          expect(
+            result.body[0].scientificMetadata.nestedEmails[0].emailString,
+          ).toEqual("user1@your.site; ***** some email in text (*****)|*****")
         ),
       );
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Some users add emails in plain text with extra text prepended or appended. This made the masking ineffective, as the matching rule was checking if the whole string was an email. The logic is now extended with a regex to match these cases

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
