### PR TITLE
fix: try except encode and decode functions

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1224,17 +1224,33 @@ export function makeHttpException(
 }
 
 export function encodeURIComponentExtended(str: string): string {
-  let encoded = encodeURIComponent(str);
+  try {
+    let encoded = encodeURIComponent(str);
 
-  // encodeURIComponent does not encode "." automatically, so we manually replace it with "%2E" for MongoDB compatibility.
-  encoded = encoded.replace(/\./g, "%2E");
-  return encoded;
+    // encodeURIComponent does not encode "." automatically, so we manually replace it with "%2E" for MongoDB compatibility.
+    encoded = encoded.replace(/\./g, "%2E");
+    return encoded;
+  } catch (error) {
+    Logger.error(
+      `Error encoding string: ${str}. Error: ${(error as Error).message}`,
+      "encodeURIComponentExtended",
+    );
+    throw error;
+  }
 }
 
 export function decodeURIComponentExtended(str: string): string {
-  let decoded = decodeURIComponent(str);
-  decoded = decoded.replace(/%2E/g, ".");
-  return decoded;
+  try {
+    let decoded = decodeURIComponent(str);
+    decoded = decoded.replace(/%2E/g, ".");
+    return decoded;
+  } catch (error) {
+    Logger.error(
+      `Error decoding string: ${str}. Error: ${(error as Error).message}`,
+      "decodeURIComponentExtended",
+    );
+    throw error;
+  }
 }
 
 export function encodeScientificMetadataKeys(

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1235,6 +1235,7 @@ export function encodeURIComponentExtended(str: string): string {
       `Error encoding string: ${str}. Error: ${(error as Error).message}`,
       "encodeURIComponentExtended",
     );
+    return str;
   }
 }
 
@@ -1248,6 +1249,7 @@ export function decodeURIComponentExtended(str: string): string {
       `Error decoding string: ${str}. Error: ${(error as Error).message}`,
       "decodeURIComponentExtended",
     );
+    return str;
   }
 }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1235,7 +1235,6 @@ export function encodeURIComponentExtended(str: string): string {
       `Error encoding string: ${str}. Error: ${(error as Error).message}`,
       "encodeURIComponentExtended",
     );
-    throw error;
   }
 }
 
@@ -1249,7 +1248,6 @@ export function decodeURIComponentExtended(str: string): string {
       `Error decoding string: ${str}. Error: ${(error as Error).message}`,
       "decodeURIComponentExtended",
     );
-    throw error;
   }
 }
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
In some rare cases encodeURIComponent and decodeURIComponent fail. 
This makes sure no 500s are returned when encoding fails 
