### PR TITLE
fix: return fields intersection in fullquery

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -625,6 +625,9 @@ export const createFullqueryFilter = <T>(
         ...mapScientificQuery(key, fields[key]),
       };
     } else if (key === "userGroups") {
+      // this is applied both on accessGroups and ownerGroup
+      // (thus requiring the ORs list) being a generic user 
+      // permission filter
       accessConditions.push({
         ownerGroup: searchExpression<T>(
           model,

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -598,8 +598,12 @@ export const createFullqueryFilter = <T>(
   idField: keyof T,
   fields: FilterQuery<T> = {},
 ): FilterQuery<T> => {
-  let filterQuery: FilterQuery<T> = {};
   const accessConditions: Record<string, unknown>[] = [];
+  let filterQuery: FilterQuery<T> & {
+    ownerGroup?: object;
+    accessGroups?: object;
+    sharedWith?: object;
+  } = {};
 
   Object.keys(fields).forEach((key) => {
     if (key === "mode") {
@@ -636,29 +640,23 @@ export const createFullqueryFilter = <T>(
         ) as object,
       });
     } else if (key === "ownerGroup") {
-      accessConditions.push({
-        ownerGroup: searchExpression<T>(
-          model,
-          "ownerGroup",
-          fields[key],
-        ) as object,
-      });
+      filterQuery.ownerGroup = searchExpression<T>(
+        model,
+        "ownerGroup",
+        fields[key],
+      ) as object;
     } else if (key === "accessGroups") {
-      accessConditions.push({
-        accessGroups: searchExpression<T>(
-          model,
-          "accessGroups",
-          fields[key],
-        ) as object,
-      });
+      filterQuery.accessGroups = searchExpression<T>(
+        model,
+        "accessGroups",
+        fields[key],
+      ) as object;
     } else if (key === "sharedWith") {
-      accessConditions.push({
-        sharedWith: searchExpression<T>(
-          model,
-          "sharedWith",
-          fields[key],
-        ) as object,
-      });
+      filterQuery.sharedWith = searchExpression<T>(
+        model,
+        "sharedWith",
+        fields[key],
+      ) as object;
     } else {
       filterQuery[key as keyof FilterQuery<T>] = searchExpression<T>(
         model,

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -626,7 +626,7 @@ export const createFullqueryFilter = <T>(
       };
     } else if (key === "userGroups") {
       // this is applied both on accessGroups and ownerGroup
-      // (thus requiring the ORs list) being a generic user 
+      // (thus requiring the ORs list) being a generic user
       // permission filter
       accessConditions.push({
         ownerGroup: searchExpression<T>(

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -524,7 +524,7 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       .then((res) => {
         // Make test resilient - check that we get a valid response
         // without enforcing exactly how many datasets are returned
-        res.body.should.be.an("array");
+        res.body.should.be.an("array").and.have.lengthOf(2);
         console.log(`User 3 fullquery returned ${res.body.length} datasets`);
 
         // If datasets exist, verify they have expected properties
@@ -532,6 +532,20 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
           res.body[0].should.have.property("pid");
           res.body[0].should.have.property("type");
         }
+      });
+  });
+
+  it("0335: full query for datasets for User 3", async () => {
+    const fields = { ownerGroup: ["group2"] };
+    return request(appUrl)
+      .get(`/api/v3/Datasets/fullquery?fields=${encodeURIComponent(JSON.stringify(fields))}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").and.have.lengthOf(1);
+        res.body[0].ownerGroup.should.be.equal("group2");
       });
   });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Full query used to do the union of permission fields. This PR fixes it to be an intersection, meaning that the where condition with multiple fields is changed from a list of ORs to a list of ANDs. This is a bug particularly in the datasets overview web page when using filters 

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
