### PR TITLE
chore: refactor FilterPipe to cover the JobsFilterPipe

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -172,7 +172,7 @@ export class OrderPipe<T = unknown> extends FilterPipeAbstract<T> {
  */
 @Injectable()
 export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
-  private wherePipe = new WherePipe();
+  private wherePipe: WherePipe<T>;
   private optionalPipes: {
     fields?: (value: unknown) => unknown;
     limits?: (value: unknown) => unknown;
@@ -191,6 +191,7 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
       apiToDBMap = {},
     } = options;
     super({ apiToDBMap });
+    this.wherePipe = new WherePipe({ apiToDBMap });
     if (allowObjectFields || !isEmpty(apiToDBMap)) {
       const fieldPipe = new FieldsPipe({ apiToDBMap });
       this.optionalPipes.fields = (val: unknown) =>

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -1,68 +1,13 @@
 import { Injectable, PipeTransform } from "@nestjs/common";
-import {
-  transformDeep,
-  TransformObjValuesPipe,
-} from "src/jobs/pipes/v3-filter.pipe";
+import { transformDeep } from "src/jobs/pipes/v3-filter.pipe";
 import { IFilters } from "../interfaces/common.interface";
-import _ from "lodash";
+import { isPlainObject, keys, pickBy } from "lodash";
 
-/**
- * @class FilterPipe
- * @description
- * A NestJS pipe that converts filter objects or JSON strings into a MongoDB-compatible format.
- *
- * - Recursively transforms all `where` keys at any depth.
- * - For all `where` relatives, replaces operators (`inq`, `nin`, `and`, `or`, `like`, `ilike`) with MongoDB equivalents.
- * - Adds `$options: "i"` for `ilike` to enable case-insensitive regex.
- * - Parses JSON strings if needed and returns the result in the same format (string or object).
- */
-@Injectable()
-export class FilterPipe<T = unknown> implements PipeTransform<
+abstract class FilterPipeAbstract<T = unknown> implements PipeTransform<
   { filter?: string } | string,
   { filter?: IFilters<T> } | IFilters<T>
 > {
-  private static readonly replaceOperatorsMap = {
-    inq: "$in",
-    nin: "$nin",
-    and: "$and",
-    or: "$or",
-    like: "$regex",
-    ilike: "$regex",
-    gte: "$gte",
-    lte: "$lte",
-    gt: "$gt",
-    lt: "$lt",
-  };
-  private readonly replaceOperatorsPipe: TransformObjValuesPipe;
-
-  constructor(options = { allowObjectFields: true }) {
-    const fields: { fields?: (value: unknown) => unknown } = {};
-    if (options.allowObjectFields)
-      fields.fields = (val: unknown) =>
-        _.isPlainObject(val)
-          ? _.keys(_.pickBy(val as Record<string, boolean>, Boolean))
-          : val;
-    this.replaceOperatorsPipe = new TransformObjValuesPipe({
-      where: (value: unknown) => {
-        return transformDeep(value, {
-          funcMap: {
-            ilike: (val: unknown, par: unknown) => {
-              const p = par as Record<string, unknown>;
-              p["$options"] = "i";
-              return val;
-            },
-          },
-          valueFn: (val: unknown) => {
-            if (typeof val !== "string") return val;
-            const dateFromString = new Date(val);
-            return isNaN(dateFromString.getTime()) ? val : dateFromString;
-          },
-          keyMap: FilterPipe.replaceOperatorsMap,
-        });
-      },
-      ...fields,
-    });
-  }
+  abstract applyTransform(value: unknown): unknown;
 
   transform(inValue: { filter?: string } | string):
     | {
@@ -76,11 +21,87 @@ export class FilterPipe<T = unknown> implements PipeTransform<
         ? JSON.parse(inValue)
         : JSON.parse(inValue.filter!);
 
-    const transformedFilter = this.replaceOperatorsPipe.transform(
-      parsedFilter,
-    ) as IFilters<T>;
+    const transformedFilter = this.applyTransform(parsedFilter) as IFilters<T>;
 
     if (typeof inValue === "string") return transformedFilter;
     return { ...inValue, filter: transformedFilter };
+  }
+}
+
+@Injectable()
+export class WherePipe<T = unknown> extends FilterPipeAbstract<T> {
+  private readonly replaceOperatorsMap = {
+    inq: "$in",
+    nin: "$nin",
+    and: "$and",
+    or: "$or",
+    like: "$regex",
+    ilike: "$regex",
+    gte: "$gte",
+    lte: "$lte",
+    gt: "$gt",
+    lt: "$lt",
+  };
+
+  applyTransform(value: unknown): unknown {
+    return transformDeep(value, {
+      funcMap: {
+        ilike: (val: unknown, par: unknown) => {
+          const p = par as Record<string, unknown>;
+          p["$options"] = "i";
+          return val;
+        },
+      },
+      valueFn: (val: unknown) => {
+        if (typeof val !== "string") return val;
+        const dateFromString = new Date(val);
+        return isNaN(dateFromString.getTime()) ? val : dateFromString;
+      },
+      keyMap: this.replaceOperatorsMap,
+    });
+  }
+}
+
+@Injectable()
+export class FieldsPipe<T = unknown> extends FilterPipeAbstract<T> {
+  applyTransform(value: unknown) {
+    if (isPlainObject(value)) {
+      return keys(pickBy(value as Record<string, boolean>, Boolean));
+    }
+    return value;
+  }
+}
+
+/**
+ * @class FilterPipe
+ * @description
+ * A NestJS pipe that converts filter objects or JSON strings into a MongoDB-compatible format.
+ *
+ * - Recursively transforms all `where` keys at any depth.
+ * - For all `where` relatives, replaces operators (`inq`, `nin`, `and`, `or`, `like`, `ilike`) with MongoDB equivalents.
+ * - Adds `$options: "i"` for `ilike` to enable case-insensitive regex.
+ * - Parses JSON strings if needed and returns the result in the same format (string or object).
+ */
+@Injectable()
+export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
+  private wherePipe = new WherePipe();
+  private fieldsPipe = new FieldsPipe();
+  private options: { allowObjectFields: boolean };
+
+  constructor(options?: { allowObjectFields: boolean }) {
+    super();
+    this.options = options ?? { allowObjectFields: true };
+  }
+
+  applyTransform(value: unknown): unknown {
+    const fields: { fields?: (value: unknown) => unknown } = {};
+    if (this.options.allowObjectFields)
+      fields.fields = (val) => this.fieldsPipe.applyTransform(val);
+    return transformDeep(value, {
+      funcMap: {
+        where: (val) => this.wherePipe.applyTransform(val),
+        ...fields,
+      },
+    });
   }
 }

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -121,6 +121,8 @@ export class FieldsPipe<T = unknown> extends FilterPipeAbstract<T> {
       );
       return activeKeys.map((key) => get(this.apiToDBMap, key, key));
     }
+    if (Array.isArray(value))
+      return value.map((key) => get(this.apiToDBMap, key, key));
     return value;
   }
 }

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -129,8 +129,21 @@ export class WherePipe<T = unknown> extends FilterPipeAbstract<T> {
 
 @Injectable()
 export class FieldsPipe<T = unknown> extends FilterPipeAbstract<T> {
+  private readonly allowObjectFields: boolean;
+
+  constructor({
+    apiToDBMap = {},
+    allowObjectFields = true,
+  }: {
+    apiToDBMap?: Record<string, string>;
+    allowObjectFields?: boolean;
+  } = {}) {
+    super({ apiToDBMap });
+    this.allowObjectFields = allowObjectFields;
+  }
+
   applyTransform(value: unknown) {
-    if (isPlainObject(value)) {
+    if (this.allowObjectFields && isPlainObject(value)) {
       const activeKeys = keys(
         pickBy(value as Record<string, boolean>, Boolean),
       );
@@ -192,7 +205,7 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
     super({ apiToDBMap });
     this.wherePipe = new WherePipe({ apiToDBMap });
     if (allowObjectFields || !isEmpty(apiToDBMap)) {
-      const fieldPipe = new FieldsPipe({ apiToDBMap });
+      const fieldPipe = new FieldsPipe({ apiToDBMap, allowObjectFields });
       this.optionalPipes.fields = (val: unknown) =>
         fieldPipe.applyTransform(val);
     }

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -23,8 +23,10 @@ export abstract class FilterPipeAbstract<T = unknown> implements PipeTransform<
 
   protected apiToDBMap: Record<string, string>;
 
-  constructor(protected options?: { apiToDBMap?: Record<string, string> }) {
-    this.apiToDBMap = options?.apiToDBMap || {};
+  constructor({
+    apiToDBMap = {},
+  }: { apiToDBMap?: Record<string, string> } = {}) {
+    this.apiToDBMap = apiToDBMap;
   }
 
   private static parseJson(value: string): string {
@@ -178,18 +180,15 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
     limits?: (value: unknown) => unknown;
   } = {};
 
-  constructor(
-    options: {
-      allowObjectFields?: boolean;
-      orderMap?: boolean;
-      apiToDBMap?: Record<string, string>;
-    } = {},
-  ) {
-    const {
-      allowObjectFields = true,
-      orderMap: orderMap = false,
-      apiToDBMap = {},
-    } = options;
+  constructor({
+    allowObjectFields = true,
+    orderMap = false,
+    apiToDBMap = {},
+  }: {
+    allowObjectFields?: boolean;
+    orderMap?: boolean;
+    apiToDBMap?: Record<string, string>;
+  } = {}) {
     super({ apiToDBMap });
     this.wherePipe = new WherePipe({ apiToDBMap });
     if (allowObjectFields || !isEmpty(apiToDBMap)) {

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -228,11 +228,9 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
 
   constructor({
     allowObjectFields = true,
-    orderMap = false,
     apiToDBMap = {},
   }: {
     allowObjectFields?: boolean;
-    orderMap?: boolean;
     apiToDBMap?: Record<string, string>;
   } = {}) {
     super({ apiToDBMap });
@@ -242,7 +240,7 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
       this.optionalPipes.fields = (val: unknown) =>
         fieldPipe.applyTransform(val);
     }
-    if (orderMap || !isEmpty(apiToDBMap)) {
+    if (!isEmpty(apiToDBMap)) {
       const orderPipe = new OrderPipe({ apiToDBMap });
       this.optionalPipes.limits = (val: unknown) =>
         orderPipe.applyTransform(val);

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -21,7 +21,11 @@ export abstract class FilterPipeAbstract<T = unknown> implements PipeTransform<
 > {
   abstract applyTransform(value: unknown): unknown;
 
-  constructor(protected apiToDBMap: Record<string, string> = {}) {}
+  protected apiToDBMap: Record<string, string>;
+
+  constructor(protected options?: { apiToDBMap?: Record<string, string> }) {
+    this.apiToDBMap = options?.apiToDBMap || {};
+  }
 
   protected static transformDeep(
     obj: unknown,
@@ -171,14 +175,14 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
       orderMap: orderMap = false,
       apiToDBMap = {},
     } = options;
-    super(apiToDBMap);
+    super({ apiToDBMap });
     if (allowObjectFields || !isEmpty(apiToDBMap)) {
-      const fieldPipe = new FieldsPipe(apiToDBMap);
+      const fieldPipe = new FieldsPipe({ apiToDBMap });
       this.optionalPipes.fields = (val: unknown) =>
         fieldPipe.applyTransform(val);
     }
     if (orderMap || !isEmpty(apiToDBMap)) {
-      const orderPipe = new OrderPipe(apiToDBMap);
+      const orderPipe = new OrderPipe({ apiToDBMap });
       this.optionalPipes.limits = (val: unknown) =>
         orderPipe.applyTransform(val);
     }

--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -166,19 +166,19 @@ export class FilterPipe<T = unknown> extends FilterPipeAbstract<T> {
       apiToDBMap?: Record<string, string>;
     } = {},
   ) {
-    super(options.apiToDBMap);
     const {
       allowObjectFields = true,
       orderMap: orderMap = false,
       apiToDBMap = {},
     } = options;
+    super(apiToDBMap);
     if (allowObjectFields || !isEmpty(apiToDBMap)) {
-      const fieldPipe = new FieldsPipe(options.apiToDBMap);
+      const fieldPipe = new FieldsPipe(apiToDBMap);
       this.optionalPipes.fields = (val: unknown) =>
         fieldPipe.applyTransform(val);
     }
     if (orderMap || !isEmpty(apiToDBMap)) {
-      const orderPipe = new OrderPipe(options.apiToDBMap);
+      const orderPipe = new OrderPipe(apiToDBMap);
       this.optionalPipes.limits = (val: unknown) =>
         orderPipe.applyTransform(val);
     }

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -54,10 +54,10 @@ import { DatasetLookupKeysEnum } from "src/datasets/types/dataset-lookup";
 import { PartialOutputDatasetDto } from "src/datasets/dto/output-dataset.dto";
 import { ALLOWED_JOB_KEYS, ALLOWED_JOB_FILTER_KEYS } from "./types/job-lookup";
 import {
-  V3ConditionToV4Pipe,
-  V3FieldsToV4Pipe,
-  V3FilterToV4Pipe,
-  V3LimitsToV4Pipe,
+  V3_WHERE_TO_V4_PIPE,
+  V3_FIELDS_TO_V4_PIPE,
+  V3_FILTER_TO_V4_PIPE,
+  V3_ORDER_TO_V4_PIPE,
 } from "./pipes/v3-filter.pipe";
 
 @ApiBearerAuth()
@@ -183,8 +183,8 @@ export class JobsController {
   @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
   async fullQuery(
     @Req() request: Request,
-    @Query("fields", new V3ConditionToV4Pipe()) fields?: string,
-    @Query("limits", new V3LimitsToV4Pipe()) limits?: string,
+    @Query("fields", ...V3_WHERE_TO_V4_PIPE) fields?: string,
+    @Query("limits", ...V3_ORDER_TO_V4_PIPE) limits?: string,
   ): Promise<OutputJobV3Dto[] | null> {
     const jobs = (await this.jobsControllerUtils.fullQueryJobs(request, {
       fields,
@@ -231,8 +231,8 @@ export class JobsController {
   })
   async fullFacet(
     @Req() request: Request,
-    @Query("facets", new V3FieldsToV4Pipe()) facets?: string,
-    @Query("fields", new V3ConditionToV4Pipe()) fields?: string,
+    @Query("facets", ...V3_FIELDS_TO_V4_PIPE) facets?: string,
+    @Query("fields", ...V3_WHERE_TO_V4_PIPE) fields?: string,
   ): Promise<Record<string, unknown>[]> {
     return this.jobsControllerUtils.fullFacetJobs(request, { facets, fields });
   }
@@ -448,7 +448,7 @@ export class JobsController {
 
     @Query(
       "filter",
-      new V3FilterToV4Pipe(),
+      ...V3_FILTER_TO_V4_PIPE,
       new FilterValidationPipe(ALLOWED_JOB_KEYS, ALLOWED_JOB_FILTER_KEYS, {
         where: false,
         include: true,

--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -3,29 +3,10 @@ import { jobV3toV4FieldMap } from "../types/jobs-filter-content";
 import {
   FieldsPipe,
   FilterPipe,
-  FilterPipeAbstract,
   OrderPipe,
   WherePipe,
 } from "src/common/pipes/filter.pipe";
 import { JobClass } from "../schemas/job.schema";
-
-class ParseDeepJsonPipe extends FilterPipeAbstract<JobClass> {
-  private parseJson(value: string): string {
-    if (!value || typeof value !== "string") return value;
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value;
-    }
-  }
-
-  applyTransform(value: string): string | object {
-    const parsed = this.parseJson(value);
-    return FilterPipeAbstract.transformDeep(parsed, {
-      valueFn: (val) => this.parseJson(val as string),
-    }) as object;
-  }
-}
 
 class JsonToStringPipe implements PipeTransform<object, string | object> {
   transform(value: object): string | object {
@@ -38,22 +19,18 @@ class JsonToStringPipe implements PipeTransform<object, string | object> {
 }
 
 export const V3_WHERE_TO_V4_PIPE = [
-  new ParseDeepJsonPipe(),
   new WherePipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
   new JsonToStringPipe(),
 ];
 export const V3_ORDER_TO_V4_PIPE = [
-  new ParseDeepJsonPipe(),
   new OrderPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
   new JsonToStringPipe(),
 ];
 export const V3_FIELDS_TO_V4_PIPE = [
-  new ParseDeepJsonPipe(),
   new FieldsPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
   new JsonToStringPipe(),
 ];
 export const V3_FILTER_TO_V4_PIPE = [
-  new ParseDeepJsonPipe(),
   new FilterPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
   new JsonToStringPipe(),
 ];

--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -1,52 +1,16 @@
-import { PipeTransform, Injectable, ArgumentMetadata } from "@nestjs/common";
+import { PipeTransform } from "@nestjs/common";
 import { jobV3toV4FieldMap } from "../types/jobs-filter-content";
-import _ from "lodash";
+import {
+  FieldsPipe,
+  FilterPipe,
+  FilterPipeAbstract,
+  OrderPipe,
+  WherePipe,
+} from "src/common/pipes/filter.pipe";
+import { JobClass } from "../schemas/job.schema";
 
-type KeyMap = Record<string, string>;
-
-type Func = (value: unknown) => unknown;
-
-type FuncMap = Record<string, (value: unknown, parent: unknown) => unknown>;
-
-interface TransformDeepOptions {
-  keyMap?: KeyMap;
-  funcMap?: FuncMap;
-  arrayFn?: Func;
-  valueFn?: Func;
-}
-
-export const transformDeep = (
-  obj: unknown,
-  opts: TransformDeepOptions = {},
-): unknown => {
-  const { keyMap = {}, funcMap = {}, arrayFn, valueFn } = opts;
-
-  if (Array.isArray(obj)) {
-    return obj.map((item) =>
-      arrayFn ? arrayFn(transformDeep(item, opts)) : transformDeep(item, opts),
-    );
-  }
-
-  if (obj && typeof obj === "object") {
-    const newObj: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj)) {
-      const mappedKey = keyMap[key] ?? key;
-      let transformed: unknown;
-      if (funcMap[key]) {
-        transformed = funcMap[key](value, newObj);
-      } else {
-        transformed = transformDeep(value, opts);
-      }
-      newObj[mappedKey] = valueFn ? valueFn(transformed) : transformed;
-    }
-    return newObj;
-  }
-
-  return obj;
-};
-
-class ParseJsonPipe implements PipeTransform<string, string> {
-  transform(value: string): string {
+class ParseDeepJsonPipe extends FilterPipeAbstract<JobClass> {
+  private parseJson(value: string): string {
     if (!value || typeof value !== "string") return value;
     try {
       return JSON.parse(value);
@@ -54,64 +18,12 @@ class ParseJsonPipe implements PipeTransform<string, string> {
       return value;
     }
   }
-}
 
-class ParseDeepJsonPipe implements PipeTransform<string, string | object> {
-  private jsonPipe = new ParseJsonPipe();
-
-  transform(value: string): string | object {
-    const parsed = this.jsonPipe.transform(value);
-    return transformDeep(parsed, {
-      valueFn: (value) => this.jsonPipe.transform(value as string),
+  applyTransform(value: string): string | object {
+    const parsed = this.parseJson(value);
+    return FilterPipeAbstract.transformDeep(parsed, {
+      valueFn: (val) => this.parseJson(val as string),
     }) as object;
-  }
-}
-
-export class ReplaceObjKeysPipe implements PipeTransform<unknown, unknown> {
-  constructor(private keyMap: KeyMap) {}
-
-  transform(value: unknown): unknown {
-    return transformDeep(value, { keyMap: this.keyMap });
-  }
-}
-
-export class TransformObjValuesPipe implements PipeTransform<unknown, unknown> {
-  constructor(private funcMap: FuncMap) {}
-
-  transform(value: unknown): unknown {
-    return transformDeep(value, { funcMap: this.funcMap });
-  }
-}
-
-class TransformArrayValuesPipe implements PipeTransform<unknown, unknown> {
-  constructor(private arrayFn: (item: unknown) => unknown) {}
-
-  transform(value: unknown): unknown {
-    return transformDeep(value, { arrayFn: this.arrayFn });
-  }
-}
-
-class ComposePipe<T = unknown> implements PipeTransform<T, T> {
-  private readonly pipes: PipeTransform[];
-  private readonly jsonToString = new JsonToStringPipe();
-  private readonly parseDeepJson = new ParseDeepJsonPipe();
-
-  constructor(
-    pipes: PipeTransform[],
-    private readonly jsonTransform = true,
-  ) {
-    this.pipes = [...pipes];
-    if (this.jsonTransform) {
-      this.pipes.unshift(this.parseDeepJson);
-      this.pipes.push(this.jsonToString);
-    }
-  }
-
-  transform(value: T, metadata: ArgumentMetadata = {} as ArgumentMetadata): T {
-    return this.pipes.reduce(
-      (val, pipe) => pipe.transform(val, metadata),
-      value,
-    );
   }
 }
 
@@ -125,73 +37,23 @@ class JsonToStringPipe implements PipeTransform<object, string | object> {
   }
 }
 
-@Injectable()
-export class V3ConditionToV4Pipe extends ComposePipe<object> {
-  // it replaces object keys following the keyMappings object
-  // for example, it replaces keys from the v3 DTO (user-facing)
-  // to database fields later used in the aggregation pipeline
-  // for example from {where: {user-facing-1: 'abc'} to {where: {db-field1: 'abc'}
-
-  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
-    super([new ReplaceObjKeysPipe(keyMappings)], jsonTransform);
-  }
-}
-
-@Injectable()
-export class V3LimitsToV4Pipe extends ComposePipe<object> {
-  // it replaces list elements following the <keyMappings object>:asc|desc
-  // for example, it replaces {order: ['user-facing1:asc', 'user-facing2:asc']}
-  // with {order: ['db-field1:asc', 'db-field2:asc']}
-
-  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
-    const sortToOrderPipe = new TransformObjValuesPipe({
-      order: (value: unknown) => {
-        const isArray = _.isArray(value);
-        const order = (isArray ? value : [value]).reduce((acc, orderValue) => {
-          const [field, direction] = (orderValue as string).split(":");
-          return acc.concat(`${keyMappings[field]}:${direction ?? "asc"}`);
-        }, [] as string[]);
-        return isArray ? order : order[0];
-      },
-    });
-    super([sortToOrderPipe], jsonTransform);
-  }
-}
-
-@Injectable()
-export class V3FieldsToV4Pipe extends ComposePipe<object> {
-  // it replaces list elements following the keyMappings object
-  // for example, it replaces the fields: [user-facing1, user-facing2]
-  // with [db-field1, db-field2]
-
-  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
-    super(
-      [
-        new TransformArrayValuesPipe((item) => {
-          if (_.isString(item) && keyMappings[item]) return keyMappings[item];
-          return item;
-        }),
-      ],
-      jsonTransform,
-    );
-  }
-}
-
-@Injectable()
-export class V3FilterToV4Pipe extends ComposePipe<string> {
-  // it combines the 3 pipes together
-  // for example
-  // from {where: {user-facing1: 'abc'}, limits: {order: ['user-facing1:asc']}, fields: ['user-facing1']}
-  // to {where: {db-field1: 'abc'}, limits: {order: ['db-field1:asc']}, fields: ['db-field1']}
-
-  constructor(keyMappings = jobV3toV4FieldMap, jsonTransform = true) {
-    super(
-      [
-        new V3LimitsToV4Pipe(keyMappings, false),
-        new V3ConditionToV4Pipe(keyMappings, false),
-        new V3FieldsToV4Pipe(keyMappings, false),
-      ],
-      jsonTransform,
-    );
-  }
-}
+export const V3_WHERE_TO_V4_PIPE = [
+  new ParseDeepJsonPipe(),
+  new WherePipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new JsonToStringPipe(),
+];
+export const V3_ORDER_TO_V4_PIPE = [
+  new ParseDeepJsonPipe(),
+  new OrderPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new JsonToStringPipe(),
+];
+export const V3_FIELDS_TO_V4_PIPE = [
+  new ParseDeepJsonPipe(),
+  new FieldsPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new JsonToStringPipe(),
+];
+export const V3_FILTER_TO_V4_PIPE = [
+  new ParseDeepJsonPipe(),
+  new FilterPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new JsonToStringPipe(),
+];


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Refactor and extend FilterPipe to cover the functionalities previously scattered between FilterPipe and the jobs FilterPipe. This will allow to also easily apply these Pipes to filters in other controllers, for example the publishedData one which is required to fix the landingPage filtering and sorting bugs 
