### PR TITLE
feat: support v3 fields in publisheddata map filter

### DIFF
--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -8,10 +8,22 @@ import {
 } from "src/common/pipes/filter.pipe";
 import { JobClass } from "../schemas/job.schema";
 
-class JsonToStringPipe implements PipeTransform<object, string | object> {
+export class JsonToStringPipe implements PipeTransform<
+  object,
+  string | object
+> {
+  constructor(private readonly stringifyField?: string) {}
+
   transform(value: object): string | object {
     try {
-      return JSON.stringify(value);
+      if (!this.stringifyField) return JSON.stringify(value);
+      if (!(this.stringifyField in value)) return value;
+      return {
+        ...value,
+        [this.stringifyField]: JSON.stringify(
+          value[this.stringifyField as keyof typeof value],
+        ),
+      };
     } catch {
       return value;
     }

--- a/src/published-data/pipes/v3-filter.pipe.ts
+++ b/src/published-data/pipes/v3-filter.pipe.ts
@@ -1,0 +1,9 @@
+import { FilterPipe } from "src/common/pipes/filter.pipe";
+import { JsonToStringPipe } from "src/jobs/pipes/v3-filter.pipe";
+import { PublishedData } from "../schemas/published-data.schema";
+import { publishedDataV3toV4FieldMap } from "../dto/published-data.obsolete.dto";
+
+export const V3_FILTER_TO_V4_PIPE = [
+  new FilterPipe<PublishedData>({ apiToDBMap: publishedDataV3toV4FieldMap }),
+  new JsonToStringPipe("fields"),
+];

--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -37,7 +37,6 @@ import { Action } from "src/casl/action.enum";
 import { AppAbility } from "src/casl/casl-ability.factory";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { PoliciesGuard } from "src/casl/guards/policies.guard";
-import { FilterPipe } from "src/common/pipes/filter.pipe";
 import { handleAxiosRequestError } from "src/common/utils";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
@@ -70,6 +69,7 @@ import {
   PublishedData,
   PublishedDataDocument,
 } from "./schemas/published-data.schema";
+import { V3_FILTER_TO_V4_PIPE } from "./pipes/v3-filter.pipe";
 
 @ApiBearerAuth()
 @ApiTags("published data")
@@ -293,7 +293,7 @@ export class PublishedDataController {
     excludeExtraneousValues: true,
   })
   async findAll(
-    @Query(new FilterPipe(), RegisteredFilterPipe)
+    @Query(...V3_FILTER_TO_V4_PIPE, RegisteredFilterPipe)
     filter?: {
       filter: IPublishedDataFilters;
       fields: string;
@@ -341,7 +341,7 @@ export class PublishedDataController {
     description: "Results with a count of the published documents",
   })
   async count(
-    @Query(new FilterPipe(), RegisteredFilterPipe)
+    @Query(...V3_FILTER_TO_V4_PIPE, RegisteredFilterPipe)
     filter?: {
       filter: IPublishedDataFilters;
       fields: string;

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -84,7 +84,7 @@ describe("1600: PublishedData: Test of access to published data", () => {
     delete publishedData.status;
     return request(appUrl)
       .post("/api/v3/PublishedData")
-      .send(publishedData)
+      .send({ ...publishedData, creator: ["New Creator"] })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
@@ -210,6 +210,20 @@ describe("1600: PublishedData: Test of access to published data", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.count.should.equal(1);
+      });
+  });
+
+  it("0066: should fetch published data with filter", async () => {
+    const filter = { where: { creator: "New Creator" } };
+    return request(appUrl)
+      .get(`/api/v3/PublishedData?filter=${encodeURIComponent(JSON.stringify(filter))}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.length.should.equal(1);
+        res.body[0].should.have.property("creator").and.deep.equal(["New Creator"]);
       });
   });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Allows filtering with v3 returned fields. This converts fields in filter to DB fields which are then consumed by mongoose

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
