### PR TITLE
chore: remove mixup of filter and fields in v3 publish

### DIFF
--- a/src/published-data/interfaces/published-data.interface.ts
+++ b/src/published-data/interfaces/published-data.interface.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { FilterQuery } from "mongoose";
 import { PublishedDataDocument } from "../schemas/published-data.schema";
+import { ILimitsFilter } from "src/common/interfaces/common.interface";
 
 export interface IPublishedDataFilters {
   where?: FilterQuery<PublishedDataDocument>;
@@ -8,11 +9,7 @@ export interface IPublishedDataFilters {
   fields?: {
     status: string;
   };
-  limits?: {
-    skip: number;
-    limit: number;
-    order: string;
-  };
+  limits?: ILimitsFilter;
 }
 
 export class ICount {

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -1,7 +1,26 @@
 import { FilterPipe } from "src/common/pipes/filter.pipe";
-import { PublishedData } from "../schemas/published-data.schema";
+import {
+  PublishedData,
+  PublishedDataDocument,
+} from "../schemas/published-data.schema";
 import { publishedDataV3toV4FieldMap } from "../dto/published-data.obsolete.dto";
-import { JsonToStringPipe } from "src/common/pipes/json-to-string.pipe";
+import { PipeTransform } from "@nestjs/common";
+import { isEmpty } from "lodash";
+import { IPublishedDataFilters } from "../interfaces/published-data.interface";
+import { FilterQuery } from "mongoose";
+
+class AppendFieldsToFilterPipe implements PipeTransform {
+  transform(value: {
+    filter: IPublishedDataFilters;
+    fields: FilterQuery<PublishedDataDocument>;
+  }) {
+    if (isEmpty(value.fields)) return value;
+    const filter = value.filter ?? {};
+    if (isEmpty(filter.where)) filter.where = value.fields;
+    else filter.where = { $and: [value.fields, filter.where] };
+    return { ...value, filter };
+  }
+}
 
 export const V3_FILTER_PIPE = [
   new FilterPipe<PublishedData>({ apiToDBMap: publishedDataV3toV4FieldMap }),
@@ -9,6 +28,5 @@ export const V3_FILTER_PIPE = [
 
 export const V4_FILTER_PIPE = [
   new FilterPipe<PublishedData>({ allowObjectFields: false }),
-  new JsonToStringPipe("fields"),
-  new JsonToStringPipe("limits"),
+  new AppendFieldsToFilterPipe(),
 ];

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -5,7 +5,6 @@ import { JsonToStringPipe } from "src/common/pipes/json-to-string.pipe";
 
 export const V3_FILTER_PIPE = [
   new FilterPipe<PublishedData>({ apiToDBMap: publishedDataV3toV4FieldMap }),
-  new JsonToStringPipe("fields"),
 ];
 
 export const V4_FILTER_PIPE = [

--- a/src/published-data/pipes/registered.pipe.ts
+++ b/src/published-data/pipes/registered.pipe.ts
@@ -27,7 +27,7 @@ export class RegisteredFilterPipe implements PipeTransform<
       value?.filter ?? {},
       this.request.isAuthenticated(),
     );
-    return { filter: withRegistered };
+    return { ...value, filter: withRegistered };
   }
 }
 

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -17,7 +17,6 @@ import { firstValueFrom } from "rxjs";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import {
   addCreatedByFields,
-  createFullqueryFilter,
   handleAxiosRequestError,
   parseLimitFilters,
 } from "src/common/utils";
@@ -79,25 +78,13 @@ export class PublishedDataService {
   }
 
   async findAll(filter: IPublishedDataFilters): Promise<PublishedData[]> {
-    const whereFilter: FilterQuery<PublishedDataDocument> = filter.where ?? {};
-    const fields = filter.fields ?? {};
-    const filterQuery: FilterQuery<PublishedDataDocument> =
-      createFullqueryFilter<PublishedDataDocument>(
-        this.publishedDataModel,
-        "doi",
-        fields,
-      );
-    const whereClause: FilterQuery<PublishedDataDocument> = {
-      ...filterQuery,
-      ...whereFilter,
-    };
     const { limit, skip, sort } = parseLimitFilters(filter.limits);
-
     return this.publishedDataModel
-      .find(whereClause)
+      .find(filter.where ?? {})
       .limit(limit)
       .skip(skip)
       .sort(sort)
+      .select(filter.fields ?? {})
       .exec();
   }
 
@@ -105,21 +92,8 @@ export class PublishedDataService {
     filter: FilterQuery<PublishedDataDocument>,
     options?: object,
   ): Promise<ICount> {
-    const whereFilter: FilterQuery<PublishedDataDocument> = filter.where ?? {};
-    const fields = filter.fields ?? {};
-    const filterQuery: FilterQuery<PublishedDataDocument> =
-      createFullqueryFilter<PublishedDataDocument>(
-        this.publishedDataModel,
-        "doi",
-        fields,
-      );
-    const whereClause: FilterQuery<PublishedDataDocument> = {
-      ...filterQuery,
-      ...whereFilter,
-    };
-
     const count = await this.publishedDataModel
-      .countDocuments(whereClause, options)
+      .countDocuments(filter.where ?? {}, options)
       .exec();
     return { count };
   }

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -101,7 +101,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       .expect(TestData.NotFoundStatusCode);
   });
 
-  it("0025: should fetch all published data as admin ingestor with fields", async () => {
+  it("0023: should fetch all published data as admin ingestor with fields", async () => {
     const limits = { skip: 0 };
     return request(appUrl)
       .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify({}))}&limits=${encodeURIComponent(JSON.stringify(limits))}`)
@@ -111,6 +111,17 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.instanceof(Array).and.to.have.length(1);
+      });
+  });
+
+    it("0026: should fetch all published data as unatuh", async () => {
+    return request(appUrl)
+      .get("/api/v4/PublishedData")
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.instanceof(Array).and.to.have.length(0);
       });
   });
 

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -103,7 +103,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
 
   it("0023: should fetch all published data as admin ingestor with fields", async () => {
     const limits = { skip: 0 };
-    const fields = {createdBy: {$regex: "admin", $options: "i"}}
+    const fields = { createdBy: { $regex: "admin", $options: "i" } }
     return request(appUrl)
       .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify(fields))}&limits=${encodeURIComponent(JSON.stringify(limits))}`)
       .set("Accept", "application/json")
@@ -115,7 +115,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       });
   });
 
-  it("0026: should fetch all published data as unatuh", async () => {
+  it("0026: should fetch all published data as unauthorized user", async () => {
     return request(appUrl)
       .get("/api/v4/PublishedData")
       .set("Accept", "application/json")

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -103,8 +103,9 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
 
   it("0023: should fetch all published data as admin ingestor with fields", async () => {
     const limits = { skip: 0 };
+    const fields = {createdBy: {$regex: "admin", $options: "i"}}
     return request(appUrl)
-      .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify({}))}&limits=${encodeURIComponent(JSON.stringify(limits))}`)
+      .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify(fields))}&limits=${encodeURIComponent(JSON.stringify(limits))}`)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.SuccessfulGetStatusCode)
@@ -114,7 +115,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       });
   });
 
-    it("0026: should fetch all published data as unatuh", async () => {
+  it("0026: should fetch all published data as unatuh", async () => {
     return request(appUrl)
       .get("/api/v4/PublishedData")
       .set("Accept", "application/json")


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR simplifies the publishedData controllers by removing the overlap between fields and filters and delegating all to where, fields and order inside `filter`, as done by other endpoints.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
