### PR TITLE
feat: add ability to exclude fields

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -1,6 +1,7 @@
 import { Injectable, PipeTransform } from "@nestjs/common";
 import { IFilters } from "../interfaces/common.interface";
-import { get, isEmpty, isPlainObject, keys, pickBy } from "lodash";
+import { get, isEmpty, isPlainObject, mapKeys } from "lodash";
+import { normalizeProjection } from "../utils";
 
 type KeyMap = Record<string, string>;
 
@@ -170,10 +171,10 @@ export class FieldsPipe<T = unknown> extends FilterPipeAbstract<T> {
 
   applyTransform(value: unknown) {
     if (this.allowObjectFields && isPlainObject(value)) {
-      const activeKeys = keys(
-        pickBy(value as Record<string, boolean>, Boolean),
+      const fields = mapKeys(value as object, (_, key) =>
+        get(this.apiToDBMap, key, key),
       );
-      return activeKeys.map((key) => get(this.apiToDBMap, key, key));
+      return normalizeProjection(fields);
     }
     if (Array.isArray(value))
       return value.map((key) => get(this.apiToDBMap, key, key));

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -202,7 +202,7 @@ export class DatasetsService {
     applyDefaults = true,
   ): Promise<PartialOutputDatasetDto[]> {
     const whereFilter: FilterQuery<DatasetDocument> = filter.where ?? {};
-    let fieldsProjection = (filter.fields ?? []) as string[];
+    const fieldsProjection = (filter.fields ?? []) as string[];
     const filterDefaults = {
       limit: 10,
       skip: 0,
@@ -219,14 +219,11 @@ export class DatasetsService {
       applyDefaults,
     );
 
-    if (Array.isArray(fieldsProjection) && fieldsProjection.length > 0) {
-      fieldsProjection = Array.from(
-        new Set([...fieldsProjection, ...addedRelations]),
-      );
-    }
-
     if (!isEmpty(fieldsProjection)) {
-      const projection = parsePipelineProjection(fieldsProjection);
+      const projection = parsePipelineProjection(
+        fieldsProjection,
+        addedRelations,
+      );
       pipeline.push({ $project: projection });
     }
 

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -826,6 +826,26 @@ describe("2500: Datasets v4 tests", () => {
           firstDataset.should.not.have.property("datablocks");
         });
     });
+
+    it("0212: should fetch specific dataset fields excluding fields provided in field", async () => {
+      const filter = {
+        fields: {datasetName: 0, contactEmail: 1},
+      };
+
+      return request(appUrl)
+        .get(`/api/v4/datasets`)
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("array");
+          const [firstDataset] = res.body;
+
+          firstDataset.should.not.have.property("datasetName");
+          firstDataset.should.have.property("contactEmail");
+        });
+    });
   });
 
   describe("Datasets v4 findOne tests", () => {

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -224,6 +224,50 @@ describe("1600: PublishedData: Test of access to published data", () => {
       .then((res) => {
         res.body.length.should.equal(1);
         res.body[0].should.have.property("creator").and.deep.equal(["New Creator"]);
+        res.body[0].should.have.property("thumbnail");
+      });
+  });
+
+  it("0067: should fetch published data excluding thumbnail using list", async () => {
+    const filter = { 
+      where: { creator: "New Creator" }, 
+      fields: { thumbnail: 0,  creator: 1} 
+    };
+    return request(appUrl)
+      .get(`/api/v3/PublishedData?filter=${encodeURIComponent(JSON.stringify(filter))}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body[0].should.have.property("creator");
+        res.body[0].should.not.have.property("thumbnail");
+      });
+  });
+
+  it("0068: should fetch published data including creator only", async () => {
+    const filter = { where: { creator: "New Creator" } };
+    filter.fields = { creator: 1 };
+    await request(appUrl)
+      .get(`/api/v3/PublishedData?filter=${encodeURIComponent(JSON.stringify(filter))}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body[0].should.have.property("creator");
+        res.body[0].should.not.have.property("thumbnail");
+      });
+    filter.fields = ["creator"];
+    return request(appUrl)
+      .get(`/api/v3/PublishedData?filter=${encodeURIComponent(JSON.stringify(filter))}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body[0].should.have.property("creator");
+        res.body[0].should.not.have.property("thumbnail");
       });
   });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Queries with `fields: ["-field1"]` enable excluding specific fields on demand. This is useful especially with publishedData to exclude thumbnail which slow down GET all. It's open agains #2493 

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
