### PR TITLE
fix: add explicit mappings for v3v4 publish

### DIFF
--- a/src/published-data/dto/published-data.obsolete.dto.ts
+++ b/src/published-data/dto/published-data.obsolete.dto.ts
@@ -11,22 +11,23 @@ import { PublishedDataStatus } from "../interfaces/published-data.interface";
 import { PublishedData } from "../schemas/published-data.schema";
 import { createDeepMapper } from "src/common/utils/deep-mapper.util";
 
-export const publishedDataV3toV4FieldMap = new Proxy(
-  {
-    pidArray: "datasetPids",
-    creator: "metadata.creators.name",
-    authors: "metadata.contributors.name",
-    publisher: "metadata.publisher.name",
-    relatedPublications: "metadata.relatedIdentifiers.relatedIdentifier",
-  },
-  {
-    get: (target: Record<string, string>, key: string) => {
-      if (key in target) return target[key];
-      if (typeof key === "string") return `metadata.${key}`;
-      return Reflect.get(target, key);
-    },
-  },
-);
+export const publishedDataV3toV4FieldMap: Record<string, string> = {
+  pidArray: "datasetPids",
+  creator: "metadata.creators.name",
+  authors: "metadata.contributors.name",
+  publisher: "metadata.publisher.name",
+  relatedPublications: "metadata.relatedIdentifiers.relatedIdentifier",
+  affiliation: "metadata.affiliation",
+  publicationYear: "metadata.publicationYear",
+  url: "metadata.url",
+  dataDescription: "metadata.dataDescription",
+  resourceType: "metadata.resourceType",
+  numberOfFiles: "metadata.numberOfFiles",
+  sizeOfArchive: "metadata.sizeOfArchive",
+  scicatUser: "metadata.scicatUser",
+  thumbnail: "metadata.thumbnail",
+  downloadLink: "metadata.downloadLink",
+};
 
 const mapPublishedDataV3toV4Field = createDeepMapper<
   PublishedData,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Explicit mappings avoid defaulting to `metadata.<field>` when not in mapping which causes top level properties not in map to result in metadata.<field> which is wrong. For example createdAt in v3 would be mapped to metadata.createdAt, even if it should stay createdAt.
