### PR TITLE
fix: stringify limits in V4 publish data

### DIFF
--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -11,4 +11,5 @@ export const V3_FILTER_PIPE = [
 export const V4_FILTER_PIPE = [
   new FilterPipe<PublishedData>({ allowObjectFields: false }),
   new JsonToStringPipe("fields"),
+  new JsonToStringPipe("limits"),
 ];

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -101,9 +101,10 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       .expect(TestData.NotFoundStatusCode);
   });
 
-    it("0025: should fetch all published data as admin ingestor with fields", async () => {
+  it("0025: should fetch all published data as admin ingestor with fields", async () => {
+    const limits = { skip: 0 };
     return request(appUrl)
-      .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify({}))}`)
+      .get(`/api/v4/PublishedData?fields=${encodeURIComponent(JSON.stringify({}))}&limits=${encodeURIComponent(JSON.stringify(limits))}`)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.SuccessfulGetStatusCode)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Published data v4 limits need to be stringified. Bug introduced by #2488 
