### PR TITLE
fix: exclude arrays from returning filter object

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -80,6 +80,12 @@ export abstract class FilterPipeAbstract<T = unknown> implements PipeTransform<
     return obj;
   }
 
+  private hasFilterDataProperty(
+    obj: Record<string, unknown>,
+  ): obj is { filter: unknown } {
+    return Object.hasOwn(obj, "filter") && typeof obj.filter !== "function";
+  }
+
   transform(
     inValue: { filter?: string | IFilters<T> } | string | IFilters<T> | unknown,
   ):
@@ -92,9 +98,9 @@ export abstract class FilterPipeAbstract<T = unknown> implements PipeTransform<
     const parsedFilter = FilterPipeAbstract.transformDeep(
       FilterPipeAbstract.parseJson(inValue as string),
       { valueFn: (val) => FilterPipeAbstract.parseJson(val as string) },
-    ) as object;
+    ) as Record<string, unknown>;
 
-    if (!("filter" in parsedFilter))
+    if (!this.hasFilterDataProperty(parsedFilter))
       return this.applyTransform(parsedFilter) as IFilters<T>;
     const transformedFilter = this.applyTransform(
       parsedFilter.filter,

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -1046,11 +1046,12 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       });
   });
 
-  it("0315: Fullfacet via /api/v3 jobs that were created by user5.1, as a user from ADMIN_GROUPS", async () => {
+  it("0315: Fullfacet via /api/v3 jobs that were created by user5.1, as a user from ADMIN_GROUPS with fields and facets", async () => {
     const query = { createdBy: "user5.1", emailJobInitiator: "test@email.scicat" };
     return request(appUrl)
       .get(`/api/v3/Jobs/fullfacet`)
       .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .query("facets=" + encodeURIComponent(JSON.stringify([])))
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
       .expect(TestData.SuccessfulGetStatusCode)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The IF condition wrongly returned an object with the filter key when the input was an array as the array has the "filter" method. The filter object should only be returned when the Pipe is applied on an object with the filter key. The IF is tightened in this PR 

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
