### PR TITLE
revert: Revert "chore: upgrade to node 24 (#2396)"

### DIFF
--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -6,7 +6,7 @@ on:
       - release
 
 env:
-  NODE_VERSION: 24.x
+  NODE_VERSION: 20.x
   PYTHON_VERSION: 3.x
   RELEASE_BRANCH: release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 env:
-  NODE_VERSION: 24.x
+  NODE_VERSION: 20.x
 
 on:
   pull_request:

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  NODE_VERSION: 24.x
+  NODE_VERSION: 20.x
   SDK_VERSION: 0.0.1
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS dev
+FROM node:20-alpine AS dev
 
 # Prepare app directory
 WORKDIR /home/node/app
@@ -12,7 +12,7 @@ RUN mkdir /home/node/app/dist
 RUN npm install glob rimraf
 RUN npm install
 
-FROM node:24-alpine AS builder
+FROM node:20-alpine AS builder
 
 # Prepare app directory
 WORKDIR /usr/src/app
@@ -27,7 +27,7 @@ RUN npm run build
 # Remove development dependencies
 RUN npm prune --production
 
-FROM node:24-alpine
+FROM node:20-alpine
 
 # Prepare app directory
 WORKDIR /home/node/app

--- a/test/DatasetFilter.js
+++ b/test/DatasetFilter.js
@@ -994,7 +994,7 @@ describe("0400: DatasetFilter: Test retrieving datasets using filtering capabili
         res.body.should.have
           .property("message")
           .and.be.equal(
-            "Invalid JSON in filter: Expected double-quoted property name in JSON at position 52 (line 1 column 53)",
+            "Invalid JSON in filter: Expected double-quoted property name in JSON at position 52",
           );
       });
   });

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -745,7 +745,7 @@ describe("2500: Datasets v4 tests", () => {
           res.body.should.have
             .property("message")
             .and.be.equal(
-              "Invalid JSON in filter: Expected double-quoted property name in JSON at position 22 (line 1 column 23)",
+              "Invalid JSON in filter: Expected double-quoted property name in JSON at position 22",
             );
         });
     });


### PR DESCRIPTION
This reverts commit 40d953f94398fd93f355a66b811815990195e962.

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
After node 24 upgrade QEMU from build and deploy causing problems

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
