### PR TITLE
feat(config): add documentation for frontend configuration options

### DIFF
--- a/docs/frontend-config-guide/frontend-config.md
+++ b/docs/frontend-config-guide/frontend-config.md
@@ -4,73 +4,96 @@
 
 This guide documents frontend configuration options that control various UI behaviors and features in SciCat. These settings are defined in the configuration file specified by the `FRONTEND_CONFIG_FILE` environment variable (default `src/config/frontend.config.json`).
 
+**TODO:** Many of these configuration options were added a long time ago and may no longer be in use. This documentation should be reviewed and updated to reflect the current state of the application and remove obsolete configuration flags.
+
 ## Configuration Options
 
 | **Configuration Options** | **Type** | **Default Value** | **Description** |
 |------------------------|----------|-------------------|-----------------|
-| `defaultMainPage` | object | `{"nonAuthenticatedUser": "DATASETS", "authenticatedUser": "PROPOSALS"}` | Defines the default landing page for authenticated and non-authenticated users. |
-| `defaultProposalTab` | string | "details" | Specifies which tab is shown by default when viewing a proposal. Valid values: "details", "datasets", "relatedProposals" & "logbook" |
-| `checkBoxFilterClickTrigger` | boolean | false | Enable/disable automatic filter application when clicking checkboxes in filters. |
-| `accessTokenPrefix` | string | "Bearer " | Set the backend token prefix. Should be empty string for old backend or "Bearer " if using scicat-backend-next. |
-| `addDatasetEnabled` | boolean | false | Show/hide the "Create Dataset" button in the Datasets Dashboard. |
-| `archiveWorkflowEnabled` | boolean | false | Enable/disable the archive/retrieve workflow. |
-| `datasetReduceEnabled` | boolean | true | Enable/disable the automatic Dataset reduction/analysis workflow. |
-| `datasetJsonScientificMetadata` | boolean | true | |
-| `editDatasetEnabled` | boolean | true | |
-| `editDatasetSampleEnabled` | boolean | true | Enable/disable editing of which Sample a Dataset belongs to. |
-| `editMetadataEnabled` | boolean | true | Enable/disable editing of Scientific Metadata. |
-| `addSampleEnabled` | boolean | false | |
-| `externalAuthEndpoint` | string | "/api/v3/auth/msad" | Endpoint used for third party authentication, e.g., LDAP. |
-| `facility` | string | "SciCat Vanilla" | Facility running the SciCat instance. |
-| `siteIcon` | string | | Path to the site icon/logo image file. |
-| `siteTitle` | string | | Title displayed in the browser tab and header. |
-| `siteSciCatLogo` | string | "full" | |
-| `loginFacilityLabel` | string | | Label for the facility login option. |
-| `loginLdapLabel` | string | | Label for the LDAP login option. |
-| `loginLocalLabel` | string | | Label for the local login option. |
-| `loginFacilityEnabled` | boolean | true | Enable/disable facility login option. |
-| `loginLdapEnabled` | boolean | true | Enable/disable LDAP login option. |
-| `loginLocalEnabled` | boolean | true | Enable/disable local login option. |
-| `fileColorEnabled` | boolean | true | Enable/disable file size color representation in the Datasets Dashboard. |
-| `fileDownloadEnabled` | boolean | true | Enable/disable download workflow for Dataset datafiles. |
-| `gettingStarted` | string | null | URL to Getting Started guide for SciCat, displayed on the Help page. |
-| `ingestManual` | string | null | URL to Ingest Manual for SciCat, displayed on the Help page. |
-| `jobsEnabled` | boolean | true | Enable/disable Job workflow. |
-| `jsonMetadataEnabled` | boolean | true | Show/hide the "Show Metadata" button on the details pages, allowing users to see the JSON representation of the current document. |
-| `jupyterHubUrl` | string | "" | URL to Jupyter Hub instance used for data analysis. |
-| `landingPage` | string | | URL to the facility's Landing Page for Published Data. |
-| `lbBaseURL` | string | | URL to the SciCat Backend. |
-| `logbookEnabled` | boolean | true | Enable/disable SciChat Logbook integration. |
-| `loginFormEnabled` | boolean | true | Enable/disable the local Login form. Should be disabled if using oAuth2 for authentication. |
-| `metadataPreviewEnabled` | boolean | true | Enable/disable Scientific Metadata preview on the Datasets Dashboard. |
-| `metadataStructure` | string | "" | Allow tree structure for Scientific Metadata. Set to empty string for flat structure, or "tree" for tree structure. |
-| `multipleDownloadAction` | string | | URL to service handling direct download of datafiles. |
-| `multipleDownloadEnabled` | boolean | true | Enable/disable ability to download multiple datafiles. |
-| `oAuth2Endpoints` | array | [] | List of endpoints used for oAuth2 authentication. Each endpoint should have `authURL` and `displayText` properties. |
-| `policiesEnabled` | boolean | true | Enable/disable Dataset Policies workflow. |
-| `retrieveDestinations` | array | [] | List of destinations for Dataset retrievals. |
-| `riotBaseUrl` | string | | URL to SciChat client. |
-| `scienceSearchEnabled` | boolean | true | Enable/disable filtering documents on Scientific Metadata. |
-| `scienceSearchUnitsEnabled` | boolean | true | Enable/disable filtering documents on Scientific Metadata using units. |
-| `searchPublicDataEnabled` | boolean | true | Enable/disable filtering Datasets on public or non-public data. |
-| `searchSamples` | boolean | true | Enable/disable searching Samples on Samples Dashboard. |
-| `sftpHost` | string | | URL to SFTP service used for downloading files exceeding maximum allowed file size. |
-| `sourceFolder` | string | | Default source folder path for datasets. |
-| `maxDirectDownloadSize` | number | | Set a maximum allowed file size for downloading datafiles over HTTP (in bytes). |
-| `maxFileSizeWarning` | string | | Warning message displayed when files exceed the maximum direct download size. Supports placeholders: `<maxDirectDownloadSize>`, `<sftpHost>`, `<sourceFolder>`. |
-| `shareEnabled` | boolean | true | Enable/disable workflow for sharing Datasets with other users using their email address. |
-| `shoppingCartEnabled` | boolean | true | Enable/disable the Dataset cart used for bulk actions. |
-| `shoppingCartOnHeader` | boolean | true | Toggle Dataset cart placement, either on header or to the left on the Datasets Dashboard. |
-| `tableSciDataEnabled` | boolean | true | Enable/disable Scientific Metadata table view on details pages. If disabled, Scientific Metadata is displayed as raw JSON. |
-| `datasetDetailsShowMissingProposalId` | boolean | false | |
-| `notificationInterceptorEnabled` | boolean | true | |
-| `metadataEditingUnitListDisabled` | boolean | true | |
-| `hideEmptyMetadataTable` | boolean | false | |
-| `datafilesActionsEnabled` | boolean | true | Enable/disable custom datafile actions configuration. |
-| `datafilesActions` | array | [] | Array of custom action configurations for datafiles. Each action can define download, notebook generation, or other custom behaviors. |
-| `labelsLocalization` | object | {} | Localization configuration for labels in datasets and proposals. Maps field names to display labels. |
-| `dateFormat` | string | "yyyy-MM-dd HH:mm" | Default date format used throughout the application. |
-| `mainMenu` | object | {} | Configuration for main menu visibility based on user authentication status. |
+| **`defaultMainPage`** | object | | Defines the default landing page for authenticated and non-authenticated users. |
+| &nbsp;&nbsp;&nbsp;&nbsp;`nonAuthenticatedUser` | string | `"DATASETS"` | Default landing page for non-authenticated users. |
+| &nbsp;&nbsp;&nbsp;&nbsp;`authenticatedUser` | string | `"PROPOSALS"` | Default landing page for authenticated users. |
+| `checkBoxFilterClickTrigger` | boolean | `false` | Enable/disable automatic filter application when clicking checkboxes in filters. |
+| `accessTokenPrefix` | string | `"Bearer "` | Set the backend token prefix. Should be empty string for old backend or "Bearer " if using scicat-backend-next. |
+| `addDatasetEnabled` | boolean | `false` | Show/hide the "Create Dataset" button in the Datasets Dashboard. |
+| `archiveWorkflowEnabled` | boolean | `false` | Enable/disable the archive/retrieve workflow. |
+| `datasetReduceEnabled` | boolean | `true` | Enable/disable the automatic Dataset reduction/analysis workflow. |
+| `datasetJsonScientificMetadata` | boolean | `true` | |
+| `editDatasetEnabled` | boolean | `true` | |
+| `editDatasetSampleEnabled` | boolean | `true` | Enable/disable editing of which Sample a Dataset belongs to. |
+| `editMetadataEnabled` | boolean | `true` | Enable/disable editing of Scientific Metadata. |
+| `addSampleEnabled` | boolean | `false` | |
+| `externalAuthEndpoint` | string | `"/api/v3/auth/msad"` | Endpoint used for third party authentication, e.g., LDAP. |
+| `facility` | string | `"SciCat Vanilla"` | Facility running the SciCat instance. |
+| `siteIcon` | string | `""` | Path to the site icon/logo image file. |
+| `siteTitle` | string | `""` | Title displayed in the browser tab and header. |
+| `siteSciCatLogo` | string | `"full"` | |
+| `loginFacilityLabel` | string | `""` | Label for the facility login option. |
+| `loginLdapLabel` | string | `""` | Label for the LDAP login option. |
+| `loginLocalLabel` | string | `""` | Label for the local login option. |
+| `loginFacilityEnabled` | boolean | `true` | Enable/disable facility login option. |
+| `loginLdapEnabled` | boolean | `true` | Enable/disable LDAP login option. |
+| `loginLocalEnabled` | boolean | `true` | Enable/disable local login option. |
+| `fileColorEnabled` | boolean | `true` | Enable/disable file size color representation in the Datasets Dashboard. |
+| `fileDownloadEnabled` | boolean | `true` | Enable/disable download workflow for Dataset datafiles. |
+| `gettingStarted` | string | `null` | URL to Getting Started guide for SciCat, displayed on the Help page. |
+| `ingestManual` | string | `null` | URL to Ingest Manual for SciCat, displayed on the Help page. |
+| `jobsEnabled` | boolean | `true` | Enable/disable Job workflow. |
+| `jsonMetadataEnabled` | boolean | `true` | Show/hide the "Show Metadata" button on the details pages, allowing users to see the JSON representation of the current document. |
+| `jupyterHubUrl` | string | `""` | URL to Jupyter Hub instance used for data analysis. |
+| `landingPage` | string | `""` | URL to the facility's Landing Page for Published Data. |
+| `lbBaseURL` | string | `""` | URL to the SciCat Backend. |
+| `logbookEnabled` | boolean | `true` | Enable/disable SciChat Logbook integration. |
+| `loginFormEnabled` | boolean | `true` | Enable/disable the local Login form. Should be disabled if using oAuth2 for authentication. |
+| `metadataPreviewEnabled` | boolean | `true` | Enable/disable Scientific Metadata preview on the Datasets Dashboard. |
+| `metadataStructure` | string | `""` | Allow tree structure for Scientific Metadata. Set to empty string for flat structure, or "tree" for tree structure. |
+| `multipleDownloadAction` | string | `""` | URL to service handling direct download of datafiles. |
+| `multipleDownloadEnabled` | boolean | `true` | Enable/disable ability to download multiple datafiles. |
+| `oAuth2Endpoints` | array | `[]` | List of endpoints used for oAuth2 authentication. Each endpoint should have `authURL` and `displayText` properties. |
+| `policiesEnabled` | boolean | `true` | Enable/disable Dataset Policies workflow. |
+| `retrieveDestinations` | array | `[]` | List of destinations for Dataset retrievals. |
+| `riotBaseUrl` | string | `""` | URL to SciChat client. |
+| `scienceSearchEnabled` | boolean | `true` | Enable/disable filtering documents on Scientific Metadata. |
+| `scienceSearchUnitsEnabled` | boolean | `true` | Enable/disable filtering documents on Scientific Metadata using units. |
+| `searchPublicDataEnabled` | boolean | `true` | Enable/disable filtering Datasets on public or non-public data. |
+| `searchSamples` | boolean | `true` | Enable/disable searching Samples on Samples Dashboard. |
+| `sftpHost` | string | `""` | URL to SFTP service used for downloading files exceeding maximum allowed file size. |
+| `sourceFolder` | string | `""` | Default source folder path for datasets. |
+| `maxDirectDownloadSize` | number | `0` | Set a maximum allowed file size for downloading datafiles over HTTP (in bytes). |
+| `maxFileSizeWarning` | string | `""` | Warning message displayed when files exceed the maximum direct download size. Supports placeholders: `<maxDirectDownloadSize>`, `<sftpHost>`, `<sourceFolder>`. |
+| `shareEnabled` | boolean | `true` | Enable/disable workflow for sharing Datasets with other users using their email address. |
+| `shoppingCartEnabled` | boolean | `true` | Enable/disable the Dataset cart used for bulk actions. |
+| `shoppingCartOnHeader` | boolean | `true` | Toggle Dataset cart placement, either on header or to the left on the Datasets Dashboard. |
+| `tableSciDataEnabled` | boolean | `true` | Enable/disable Scientific Metadata table view on details pages. If disabled, Scientific Metadata is displayed as raw JSON. |
+| `datasetDetailsShowMissingProposalId` | boolean | `false` | |
+| `notificationInterceptorEnabled` | boolean | `true` | |
+| `metadataEditingUnitListDisabled` | boolean | `true` | |
+| `hideEmptyMetadataTable` | boolean | `false` | |
+| `datafilesActionsEnabled` | boolean | `true` | Enable/disable custom datafile actions configuration. |
+| `datafilesActions` | array | `[]` | Array of custom action configurations for datafiles. Each action can define download, notebook generation, or other custom behaviors. |
+| `labelsLocalization` | object | `{}` | Localization configuration for labels in datasets and proposals. Maps field names to display labels. |
+| `dateFormat` | string | `"yyyy-MM-dd HH:mm"` | Default date format used throughout the application. |
+| **`mainMenu`** | object | | Configuration for main menu visibility based on user authentication status. |
+| &nbsp;&nbsp;&nbsp;&nbsp;**`nonAuthenticatedUser`** | object | | Menu configuration for non-authenticated users. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`datasets` | boolean | `true` | Show/hide datasets menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`files` | boolean | `false` | Show/hide files menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`instruments` | boolean | `true` | Show/hide instruments menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`jobs` | boolean | `false` | Show/hide jobs menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`policies` | boolean | `false` | Show/hide policies menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`proposals` | boolean | `true` | Show/hide proposals menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`publishedData` | boolean | `true` | Show/hide published data menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`samples` | boolean | `false` | Show/hide samples menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;**`authenticatedUser`** | object | | Menu configuration for authenticated users. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`datasets` | boolean | `true` | Show/hide datasets menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`files` | boolean | `true` | Show/hide files menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`instruments` | boolean | `true` | Show/hide instruments menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`jobs` | boolean | `true` | Show/hide jobs menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`policies` | boolean | `false` | Show/hide policies menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`proposals` | boolean | `true` | Show/hide proposals menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`publishedData` | boolean | `true` | Show/hide published data menu item. |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`samples` | boolean | `true` | Show/hide samples menu item. |
+| **`defaultTab`** | object | | Specifies which tab is shown by default when viewing different entities. |
+| &nbsp;&nbsp;&nbsp;&nbsp;`proposal` | string | `"details"` | Default tab for proposals. Valid values: `"details"`, `"datasets"`, `"relatedProposals"`, `"logbook"`. |
 
 ## See Also
 

--- a/docs/frontend-config-guide/frontend-config.md
+++ b/docs/frontend-config-guide/frontend-config.md
@@ -1,0 +1,78 @@
+# Frontend Configuration Guide
+
+## Overview
+
+This guide documents frontend configuration flags that control various UI behaviors and features in SciCat. These settings are defined in the configuration file specified by the `FRONTEND_CONFIG_FILE` environment variable (default `src/config/frontend.config.json`).
+
+## Configuration Flags
+
+| **Configuration Flag** | **Type** | **Default Value** | **Description** |
+|------------------------|----------|-------------------|-----------------|
+| `defaultMainPage` | object | `{"nonAuthenticatedUser": "DATASETS", "authenticatedUser": "PROPOSALS"}` | Defines the default landing page for authenticated and non-authenticated users. |
+| `defaultProposalTab` | string | "details" | Specifies which tab is shown by default when viewing a proposal. Valid values: "details", "datasets", "relatedProposals" & "logbook" |
+| `checkBoxFilterClickTrigger` | boolean | false | Enable/disable automatic filter application when clicking checkboxes in filters. |
+| `accessTokenPrefix` | string | "Bearer " | Set the backend token prefix. Should be empty string for old backend or "Bearer " if using scicat-backend-next. |
+| `addDatasetEnabled` | boolean | false | Show/hide the "Create Dataset" button in the Datasets Dashboard. |
+| `archiveWorkflowEnabled` | boolean | false | Enable/disable the archive/retrieve workflow. |
+| `datasetReduceEnabled` | boolean | true | Enable/disable the automatic Dataset reduction/analysis workflow. |
+| `datasetJsonScientificMetadata` | boolean | true | |
+| `editDatasetEnabled` | boolean | true | |
+| `editDatasetSampleEnabled` | boolean | true | Enable/disable editing of which Sample a Dataset belongs to. |
+| `editMetadataEnabled` | boolean | true | Enable/disable editing of Scientific Metadata. |
+| `addSampleEnabled` | boolean | false | |
+| `externalAuthEndpoint` | string | "/api/v3/auth/msad" | Endpoint used for third party authentication, e.g., LDAP. |
+| `facility` | string | "SciCat Vanilla" | Facility running the SciCat instance. |
+| `siteIcon` | string | | Path to the site icon/logo image file. |
+| `siteTitle` | string | | Title displayed in the browser tab and header. |
+| `siteSciCatLogo` | string | "full" | |
+| `loginFacilityLabel` | string | | Label for the facility login option. |
+| `loginLdapLabel` | string | | Label for the LDAP login option. |
+| `loginLocalLabel` | string | | Label for the local login option. |
+| `loginFacilityEnabled` | boolean | true | Enable/disable facility login option. |
+| `loginLdapEnabled` | boolean | true | Enable/disable LDAP login option. |
+| `loginLocalEnabled` | boolean | true | Enable/disable local login option. |
+| `fileColorEnabled` | boolean | true | Enable/disable file size color representation in the Datasets Dashboard. |
+| `fileDownloadEnabled` | boolean | true | Enable/disable download workflow for Dataset datafiles. |
+| `gettingStarted` | string | null | URL to Getting Started guide for SciCat, displayed on the Help page. |
+| `ingestManual` | string | null | URL to Ingest Manual for SciCat, displayed on the Help page. |
+| `jobsEnabled` | boolean | true | Enable/disable Job workflow. |
+| `jsonMetadataEnabled` | boolean | true | Show/hide the "Show Metadata" button on the details pages, allowing users to see the JSON representation of the current document. |
+| `jupyterHubUrl` | string | "" | URL to Jupyter Hub instance used for data analysis. |
+| `landingPage` | string | | URL to the facility's Landing Page for Published Data. |
+| `lbBaseURL` | string | | URL to the SciCat Backend. |
+| `logbookEnabled` | boolean | true | Enable/disable SciChat Logbook integration. |
+| `loginFormEnabled` | boolean | true | Enable/disable the local Login form. Should be disabled if using oAuth2 for authentication. |
+| `metadataPreviewEnabled` | boolean | true | Enable/disable Scientific Metadata preview on the Datasets Dashboard. |
+| `metadataStructure` | string | "" | Allow tree structure for Scientific Metadata. Set to empty string for flat structure, or "tree" for tree structure. |
+| `multipleDownloadAction` | string | | URL to service handling direct download of datafiles. |
+| `multipleDownloadEnabled` | boolean | true | Enable/disable ability to download multiple datafiles. |
+| `oAuth2Endpoints` | array | [] | List of endpoints used for oAuth2 authentication. Each endpoint should have `authURL` and `displayText` properties. |
+| `policiesEnabled` | boolean | true | Enable/disable Dataset Policies workflow. |
+| `retrieveDestinations` | array | [] | List of destinations for Dataset retrievals. |
+| `riotBaseUrl` | string | | URL to SciChat client. |
+| `scienceSearchEnabled` | boolean | true | Enable/disable filtering documents on Scientific Metadata. |
+| `scienceSearchUnitsEnabled` | boolean | true | Enable/disable filtering documents on Scientific Metadata using units. |
+| `searchPublicDataEnabled` | boolean | true | Enable/disable filtering Datasets on public or non-public data. |
+| `searchSamples` | boolean | true | Enable/disable searching Samples on Samples Dashboard. |
+| `sftpHost` | string | | URL to SFTP service used for downloading files exceeding maximum allowed file size. |
+| `sourceFolder` | string | | Default source folder path for datasets. |
+| `maxDirectDownloadSize` | number | | Set a maximum allowed file size for downloading datafiles over HTTP (in bytes). |
+| `maxFileSizeWarning` | string | | Warning message displayed when files exceed the maximum direct download size. Supports placeholders: `<maxDirectDownloadSize>`, `<sftpHost>`, `<sourceFolder>`. |
+| `shareEnabled` | boolean | true | Enable/disable workflow for sharing Datasets with other users using their email address. |
+| `shoppingCartEnabled` | boolean | true | Enable/disable the Dataset cart used for bulk actions. |
+| `shoppingCartOnHeader` | boolean | true | Toggle Dataset cart placement, either on header or to the left on the Datasets Dashboard. |
+| `tableSciDataEnabled` | boolean | true | Enable/disable Scientific Metadata table view on details pages. If disabled, Scientific Metadata is displayed as raw JSON. |
+| `datasetDetailsShowMissingProposalId` | boolean | false | |
+| `notificationInterceptorEnabled` | boolean | true | |
+| `metadataEditingUnitListDisabled` | boolean | true | |
+| `hideEmptyMetadataTable` | boolean | false | |
+| `datafilesActionsEnabled` | boolean | true | Enable/disable custom datafile actions configuration. |
+| `datafilesActions` | array | [] | Array of custom action configurations for datafiles. Each action can define download, notebook generation, or other custom behaviors. |
+| `labelsLocalization` | object | {} | Localization configuration for labels in datasets and proposals. Maps field names to display labels. |
+| `dateFormat` | string | "yyyy-MM-dd HH:mm" | Default date format used throughout the application. |
+| `mainMenu` | object | {} | Configuration for main menu visibility based on user authentication status. |
+
+## See Also
+
+- [Default List Settings Configuration](./default-list-settings.md)
+- [Dynamic Dataset Detail Component Configuration](./dynamic-dataset-detail-component.md)

--- a/docs/frontend-config-guide/frontend-config.md
+++ b/docs/frontend-config-guide/frontend-config.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This guide documents frontend configuration flags that control various UI behaviors and features in SciCat. These settings are defined in the configuration file specified by the `FRONTEND_CONFIG_FILE` environment variable (default `src/config/frontend.config.json`).
+This guide documents frontend configuration options that control various UI behaviors and features in SciCat. These settings are defined in the configuration file specified by the `FRONTEND_CONFIG_FILE` environment variable (default `src/config/frontend.config.json`).
 
-## Configuration Flags
+## Configuration Options
 
-| **Configuration Flag** | **Type** | **Default Value** | **Description** |
+| **Configuration Options** | **Type** | **Default Value** | **Description** |
 |------------------------|----------|-------------------|-----------------|
 | `defaultMainPage` | object | `{"nonAuthenticatedUser": "DATASETS", "authenticatedUser": "PROPOSALS"}` | Defines the default landing page for authenticated and non-authenticated users. |
 | `defaultProposalTab` | string | "details" | Specifies which tab is shown by default when viewing a proposal. Valid values: "details", "datasets", "relatedProposals" & "logbook" |

--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -64,6 +64,7 @@
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
   "hideEmptyMetadataTable": false,
+  "defaultProposalTab": "details",
   "datafilesActionsEnabled": true,
   "datafilesActions": [
     {

--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -64,7 +64,6 @@
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
   "hideEmptyMetadataTable": false,
-  "defaultProposalTab": "details",
   "datafilesActionsEnabled": true,
   "datafilesActions": [
     {
@@ -551,5 +550,8 @@
       "publishedData": true,
       "samples": true
     }
+  },
+  "defaultTab": {
+    "proposal": "relatedProposals"
   }
 }


### PR DESCRIPTION
## Description
This PR introduces a new configuration option `defaultTab` to control the default tab displayed only for the proposal details page for now. Additionally, it adds a new documentation in `frontend-config.md` for all frontend configuration options that are not already documented in other files.
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
