### PR TITLE
fix(legacy-history): pass plain js object to legacy history adapter

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -617,7 +617,7 @@ export class DatasetsController {
         documentId: datasetId,
         subsystem: "Dataset",
       }),
-      currentDataset,
+      currentDataset.toObject(),
     ).reverse();
   }
 


### PR DESCRIPTION
The [omit in convertGenericHistoryToLegacyHistory](https://github.com/SciCatProject/scicat-backend-next/blob/684a89ee9621b6792b26c1af07d3ee916da8a12f/src/datasets/utils/history.util.ts#L88) does not work as expected when the passed dataset is a mongose document. Hence, pass the dataset as a plain object.

(Instead, we could also convert just the lifecycle to plain object in the `convertGenericHistoryToLegacyHistory` function, but a plain dataset object is sufficient for reconstructing legacy history, and would avoid similar surprises in the future)

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
