### PR TITLE
refactor(config): set proposal default tab to details

### DIFF
--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -552,6 +552,6 @@
     }
   },
   "defaultTab": {
-    "proposal": "relatedProposals"
+    "proposal": "details"
   }
 }


### PR DESCRIPTION
## Description
This PR changes the default tab for proposals from "relatedProposals" to "details" in the frontend config.
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
