### PR TITLE
fix: batch bulk writes to avoid OOM

### DIFF
--- a/migrations/20251117155200-encode-metadatakeys.js
+++ b/migrations/20251117155200-encode-metadatakeys.js
@@ -13,7 +13,10 @@ const {
 
 module.exports = {
   async up(db, client) {
-    const bulkOps = [];
+    let bulkOps = [];
+    const BATCH_SIZE = 10000;
+    let modifiedCount = 0;
+    let unModifiedCount = 0;
 
     for await (const dataset of db
       .collection("Dataset")
@@ -32,26 +35,42 @@ module.exports = {
         continue;
       }
 
-      console.log(
-        `Updating Dataset (Id: ${dataset._id}) with encoded scientificMetadata keys`,
-      );
-
       bulkOps.push({
         updateOne: {
           filter: { _id: dataset._id },
           update: { $set: { scientificMetadata: encodedMetadata } },
         },
       });
+
+      if (bulkOps.length === BATCH_SIZE) {
+        const bulkWriteResult = await db.collection("Dataset").bulkWrite(bulkOps, {
+          ordered: false
+        });
+        modifiedCount += bulkWriteResult.modifiedCount;
+        unModifiedCount += BATCH_SIZE - bulkWriteResult.modifiedCount;
+
+        bulkOps = [];
+        console.log("migrating, count, unModifiedCount: ",
+          modifiedCount,
+          unModifiedCount,
+        );
+      }
     }
 
     if (bulkOps.length > 0) {
       console.log(`Executing bulk update for ${bulkOps.length} datasets`);
-      await db.collection("Dataset").bulkWrite(bulkOps);
+      const bulkWriteResult = await db.collection("Dataset").bulkWrite(bulkOps, { ordered: false });
+      modifiedCount += bulkWriteResult.modifiedCount;
+      unModifiedCount += bulkOps.length - bulkWriteResult.modifiedCount;
     }
+    console.log("FINISHED: count, unModifiedCount: ", modifiedCount, unModifiedCount);
   },
 
   async down(db, client) {
-    const bulkOps = [];
+    let bulkOps = [];
+    const BATCH_SIZE = 10000;
+    let modifiedCount = 0;
+    let unModifiedCount = 0;
 
     for await (const dataset of db
       .collection("Dataset")
@@ -71,21 +90,34 @@ module.exports = {
         continue;
       }
 
-      console.log(
-        `Reverting Dataset (Id: ${dataset._id}) to decoded scientificMetadata keys`,
-      );
-
       bulkOps.push({
         updateOne: {
           filter: { _id: dataset._id },
           update: { $set: { scientificMetadata: decodedMetadata } },
         },
       });
+
+      if (bulkOps.length === BATCH_SIZE) {
+        const bulkWriteResult = await db.collection("Dataset").bulkWrite(bulkOps, {
+          ordered: false
+        });
+        modifiedCount += bulkWriteResult.modifiedCount;
+        unModifiedCount += BATCH_SIZE - bulkWriteResult.modifiedCount;
+
+        bulkOps = [];
+        console.log("migrating, count, unModifiedCount: ",
+          modifiedCount,
+          unModifiedCount,
+        );
+      }
     }
 
     if (bulkOps.length > 0) {
       console.log(`Executing bulk revert for ${bulkOps.length} datasets`);
-      await db.collection("Dataset").bulkWrite(bulkOps);
+      const bulkWriteResult = await db.collection("Dataset").bulkWrite(bulkOps, { ordered: false });
+      modifiedCount += bulkWriteResult.modifiedCount;
+      unModifiedCount += bulkOps.length - bulkWriteResult.modifiedCount;
     }
+    console.log("FINISHED: count, unModifiedCount: ", modifiedCount, unModifiedCount);
   },
 };


### PR DESCRIPTION
Added batch processing and logging for bulk updates and reverts.

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->

## Motivation
Without batches this can cause OOM since all documents are loaded in memory