### PR TITLE
fix: add @IsNotEmpty() to sourceFolder to prevent empty string

### DIFF
--- a/src/datasets/dto/update-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-dataset-obsolete.dto.ts
@@ -11,6 +11,7 @@ import {
   IsDateString,
   IsEmail,
   IsInt,
+  IsNotEmpty,
   IsNumber,
   IsObject,
   IsOptional,
@@ -75,6 +76,7 @@ export class UpdateDatasetObsoleteDto extends OwnableDto {
       "Absolute file path on file server containing the files of this dataset, e.g. /some/path/to/sourcefolder. In case of a single file dataset, e.g. HDF5 data, it contains the path up to, but excluding the filename. Trailing slashes are removed.",
   })
   @IsString()
+  @IsNotEmpty()
   readonly sourceFolder: string;
 
   @ApiProperty({

--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -11,6 +11,7 @@ import {
   IsDateString,
   IsEmail,
   IsInt,
+  IsNotEmpty,
   IsNumber,
   IsObject,
   IsOptional,
@@ -77,6 +78,7 @@ export class UpdateDatasetDto extends OwnableDto {
       "Absolute file path on file server containing the files of this dataset, e.g. /some/path/to/sourcefolder. In case of a single file dataset, e.g. HDF5 data, it contains the path up to, but excluding the filename. Trailing slashes are removed.",
   })
   @IsString()
+  @IsNotEmpty()
   readonly sourceFolder: string;
 
   @ApiProperty({


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Adds `@IsNotEmpty()` to sourceFolder in the DTO to prevent empty strings from passing validation.
Previously, empty values bypassed DTO validation and failed later at the Mongoose schema level with 500.
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
