### PR TITLE
fix: changed filter field to text area in swagger for origdatablocks v4

### DIFF
--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -501,7 +501,7 @@ export class OrigDatablocksV4Controller {
     description: "Database filters to apply when retrieving origdatablocks",
     required: false,
     type: String,
-    example: getSwaggerOrigDatablockFilterContent(),
+    content: getSwaggerOrigDatablockFilterContent(),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -526,6 +526,7 @@ export class OrigDatablocksV4Controller {
       request.user as JWTUser,
       parsedFilter,
     );
+    console.log("origdatablocks findAll",JSON.stringify(mergedFilter));
 
     const origdatablocks =
       await this.origDatablocksService.findAllComplete(mergedFilter);

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -526,7 +526,6 @@ export class OrigDatablocksV4Controller {
       request.user as JWTUser,
       parsedFilter,
     );
-    console.log("origdatablocks findAll",JSON.stringify(mergedFilter));
 
     const origdatablocks =
       await this.origDatablocksService.findAllComplete(mergedFilter);


### PR DESCRIPTION
## Description
This PR includes a change on the swagger api related to the origidatablocks v4 to convert the filter field from a text field to a text area, which is more readable from the user prospective.

## Motivation
While working on a different project where I needed to query the origdatablocks v4, I realized that the structure of the filter content was not clear due to the fact how it was presented.

## Changes:
* origidatablock controller v4

## Tests included
n/a

## Documentation
n/a
