### PR TITLE
fix(dataset): prevent duplicate metadata keys when renaming

### DIFF
--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -769,7 +769,7 @@ Set \`content-type\` header to \`application/merge-patch+json\` if you would lik
     description: "Id of the dataset to modify",
     type: String,
   })
-  @ApiConsumes("application/merge-patch+json", "application/json")
+  @ApiConsumes("application/json", "application/merge-patch+json")
   @ApiBody({
     description:
       "Fields that needs to be updated in the dataset. Only the fields that needs to be updated have to be passed in.",


### PR DESCRIPTION
## Description
This PR fixes an issue where renaming scientific metadata keys in the V4 dataset would create duplicate metadata key records instead of updating the existing one. 

The problem occurred because the default content-type was set to "application/merge-patch+json", which merges new keys with existing ones rather than replacing them. By changing the default content-type to "application/json", users must now provide all the metadata keys for the specific dataset when updating, as the new metadata will replace the old ones completely. 

Users can still use "application/merge-patch+json" by explicitly setting the content-type header if they need merge behavior.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
