### PR TITLE
feat: add include filter support to the GET /api/v3/proposals endpoint

### DIFF
--- a/src/common/pipes/include-validation.pipe.ts
+++ b/src/common/pipes/include-validation.pipe.ts
@@ -4,6 +4,7 @@ import { PipelineStage } from "mongoose";
 import { isJsonString } from "src/common/utils";
 import { DatasetLookupKeysEnum } from "src/datasets/types/dataset-lookup";
 import { OrigDatablockLookupKeysEnum } from "src/origdatablocks/types/origdatablock-lookup";
+import { ProposalLookupKeysEnum } from "src/proposals/types/proposal-lookup";
 
 @Injectable()
 export class IncludeValidationPipe implements PipeTransform<
@@ -13,7 +14,8 @@ export class IncludeValidationPipe implements PipeTransform<
   constructor(
     private lookupFields:
       | Record<DatasetLookupKeysEnum, PipelineStage.Lookup | undefined>
-      | Record<OrigDatablockLookupKeysEnum, PipelineStage.Lookup | undefined>,
+      | Record<OrigDatablockLookupKeysEnum, PipelineStage.Lookup | undefined>
+      | Record<ProposalLookupKeysEnum, PipelineStage.Lookup | undefined>,
   ) {}
   transform(
     inValue: string | string[] | { relation: string }[],

--- a/src/proposals/interfaces/proposal-relations.interface.ts
+++ b/src/proposals/interfaces/proposal-relations.interface.ts
@@ -1,0 +1,27 @@
+import { IFilters, IFiltersV4 } from "src/common/interfaces/common.interface";
+import { ProposalLookupKeysEnum } from "../types/proposal-lookup";
+import { SampleDocument } from "src/samples/schemas/sample.schema";
+import { ISampleFields } from "src/samples/interfaces/sample-filters.interface";
+
+export type IProposalScopesV4 = IFiltersV4<SampleDocument, ISampleFields>;
+
+export type IProposalScopesV3 = IFilters<SampleDocument, ISampleFields>;
+
+export interface IProposalRelationV4<T = IProposalScopesV4> {
+  relation: ProposalLookupKeysEnum;
+  scope: T;
+}
+
+export type IProposalFilters<T, Y = null> =
+  | (IFilters<T, Y> & {
+      include?: (ProposalLookupKeysEnum | IProposalRelationV4<IProposalScopesV3>)[];
+    })
+  | (IFiltersV4<T, Y> & {
+      include?: (ProposalLookupKeysEnum | IProposalRelationV4)[];
+    });
+
+export type IProposalScopes = IProposalScopesV3 | IProposalScopesV4;
+
+export type IProposalRelation =
+  | IProposalRelationV4<IProposalScopesV3>
+  | IProposalRelationV4;

--- a/src/proposals/interfaces/proposal-relations.interface.ts
+++ b/src/proposals/interfaces/proposal-relations.interface.ts
@@ -1,36 +1,15 @@
-import { IFilters, IFiltersV4 } from "src/common/interfaces/common.interface";
+import { IFilters } from "src/common/interfaces/common.interface";
 import { ProposalLookupKeysEnum } from "../types/proposal-lookup";
 import { SampleDocument } from "src/samples/schemas/sample.schema";
 import { ISampleFields } from "src/samples/interfaces/sample-filters.interface";
 
-export type IProposalScopesV4 = IFiltersV4<SampleDocument, ISampleFields>;
+export type IProposalScopes = IFilters<SampleDocument, ISampleFields>;
 
-export type IProposalScopesV3 = IFilters<SampleDocument, ISampleFields>;
-
-export interface IProposalRelationV4<T = IProposalScopesV4> {
+export interface IProposalRelation<T = IProposalScopes> {
   relation: ProposalLookupKeysEnum;
   scope: T;
 }
 
-export type IProposalFiltersV4<T, Y = null> = IFiltersV4<
-  T,
-  Y,
-  (ProposalLookupKeysEnum | IProposalRelationV4)[]
->;
-
-export type IProposalFiltersV3<T, Y = null> = Omit<
-  IFilters<T, Y>,
-  "include"
-> & {
-  include?: (ProposalLookupKeysEnum | IProposalRelationV4<IProposalScopesV3>)[];
+export type IProposalFilters<T, Y = null> = Omit<IFilters<T, Y>, "include"> & {
+  include?: (ProposalLookupKeysEnum | IProposalRelation)[];
 };
-
-export type IProposalFilters<T, Y = null> =
-  | IProposalFiltersV3<T, Y>
-  | IProposalFiltersV4<T, Y>;
-
-export type IProposalScopes = IProposalScopesV3 | IProposalScopesV4;
-
-export type IProposalRelation =
-  | IProposalRelationV4<IProposalScopesV3>
-  | IProposalRelationV4;

--- a/src/proposals/interfaces/proposal-relations.interface.ts
+++ b/src/proposals/interfaces/proposal-relations.interface.ts
@@ -12,13 +12,22 @@ export interface IProposalRelationV4<T = IProposalScopesV4> {
   scope: T;
 }
 
+export type IProposalFiltersV4<T, Y = null> = IFiltersV4<
+  T,
+  Y,
+  (ProposalLookupKeysEnum | IProposalRelationV4)[]
+>;
+
+export type IProposalFiltersV3<T, Y = null> = Omit<
+  IFilters<T, Y>,
+  "include"
+> & {
+  include?: (ProposalLookupKeysEnum | IProposalRelationV4<IProposalScopesV3>)[];
+};
+
 export type IProposalFilters<T, Y = null> =
-  | (IFilters<T, Y> & {
-      include?: (ProposalLookupKeysEnum | IProposalRelationV4<IProposalScopesV3>)[];
-    })
-  | (IFiltersV4<T, Y> & {
-      include?: (ProposalLookupKeysEnum | IProposalRelationV4)[];
-    });
+  | IProposalFiltersV3<T, Y>
+  | IProposalFiltersV4<T, Y>;
 
 export type IProposalScopes = IProposalScopesV3 | IProposalScopesV4;
 

--- a/src/proposals/proposals.controller.spec.ts
+++ b/src/proposals/proposals.controller.spec.ts
@@ -7,6 +7,7 @@ import { ProposalsService } from "./proposals.service";
 import { NotFoundException, HttpException } from "@nestjs/common";
 import { PartialUpdateProposalDto } from "./dto/update-proposal.dto";
 import { ProposalClass } from "./schemas/proposal.schema";
+import { ProposalLookupKeysEnum } from "./types/proposal-lookup";
 
 class AttachmentsServiceMock {}
 
@@ -14,10 +15,26 @@ class DatasetsServiceMock {}
 
 class ProposalsServiceMock {
   findOne = jest.fn();
+  findAll = jest.fn();
+  findAllComplete = jest.fn();
   update = jest.fn();
 }
 
-class CaslAbilityFactoryMock {}
+class CaslAbilityFactoryMock {
+  proposalsInstanceAccess = jest.fn().mockReturnValue({
+    can: jest.fn().mockReturnValue(true),
+  });
+}
+
+const mockProposal: Partial<ProposalClass> = {
+  proposalId: "ABCDEF",
+  title: "Test Proposal",
+  email: "test@example.com",
+  ownerGroup: "testGroup",
+  accessGroups: [],
+  isPublished: false,
+  updatedAt: new Date("2023-01-01"),
+};
 
 describe("ProposalsController", () => {
   let controller: ProposalsController;
@@ -40,6 +57,87 @@ describe("ProposalsController", () => {
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  describe("findAll", () => {
+    const mockAdminRequest = {
+      user: { currentGroups: ["admin"], username: "admin" },
+    } as any;
+
+    it("should call findAll when no include is provided", async () => {
+      proposalsService.findAll.mockResolvedValue([mockProposal]);
+
+      const result = await controller.findAll(mockAdminRequest, "{}");
+
+      expect(proposalsService.findAll).toHaveBeenCalled();
+      expect(proposalsService.findAllComplete).not.toHaveBeenCalled();
+      expect(result).toEqual([mockProposal]);
+    });
+
+    it("should call findAllComplete when include is provided", async () => {
+      proposalsService.findAllComplete.mockResolvedValue([mockProposal]);
+      const filters = JSON.stringify({
+        where: { proposalId: "ABCDEF" },
+        include: [ProposalLookupKeysEnum.samples],
+      });
+
+      const result = await controller.findAll(mockAdminRequest, filters);
+
+      expect(proposalsService.findAllComplete).toHaveBeenCalled();
+      expect(proposalsService.findAll).not.toHaveBeenCalled();
+      expect(result).toEqual([mockProposal]);
+    });
+
+    it("should pass where filter through to the service", async () => {
+      proposalsService.findAll.mockResolvedValue([]);
+      const filters = JSON.stringify({ where: { proposalId: "TEST123" } });
+
+      await controller.findAll(mockAdminRequest, filters);
+
+      const calledWith = proposalsService.findAll.mock.calls[0][0];
+      expect(calledWith.where).toMatchObject({ proposalId: "TEST123" });
+    });
+
+    it("should pass include and where to findAllComplete", async () => {
+      proposalsService.findAllComplete.mockResolvedValue([]);
+      const filters = JSON.stringify({
+        where: { proposalId: "TEST123" },
+        include: [{ relation: "samples", scope: { limits: { limit: 5 } } }],
+      });
+
+      await controller.findAll(mockAdminRequest, filters);
+
+      const calledWith = proposalsService.findAllComplete.mock.calls[0][0];
+      expect(calledWith.where).toMatchObject({ proposalId: "TEST123" });
+      expect(calledWith.include).toEqual([
+        { relation: "samples", scope: { limits: { limit: 5 } } },
+      ]);
+    });
+
+    it("should handle undefined filters (no query param)", async () => {
+      proposalsService.findAll.mockResolvedValue([]);
+      await controller.findAll(mockAdminRequest, undefined);
+      expect(proposalsService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe("updateFiltersForList", () => {
+    it("should restrict to isPublished when user is not authenticated", () => {
+      const result = controller.updateFiltersForList(
+        { user: null } as any,
+        { where: {} },
+      );
+      expect(result.where?.isPublished).toBe(true);
+    });
+
+    it("should not restrict when admin can view all", () => {
+      const request = {
+        user: { currentGroups: ["admin"] },
+      } as any;
+
+      const result = controller.updateFiltersForList(request, { where: {} });
+      expect(result.where?.isPublished).toBeUndefined();
+    });
   });
 
   describe("update", () => {

--- a/src/proposals/proposals.controller.spec.ts
+++ b/src/proposals/proposals.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import type { Request } from "express";
 import { AttachmentsService } from "src/attachments/attachments.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { DatasetsService } from "src/datasets/datasets.service";
@@ -62,7 +63,7 @@ describe("ProposalsController", () => {
   describe("findAll", () => {
     const mockAdminRequest = {
       user: { currentGroups: ["admin"], username: "admin" },
-    } as any;
+    } as unknown as Request;
 
     it("should call findAll when no include is provided", async () => {
       proposalsService.findAll.mockResolvedValue([mockProposal]);
@@ -124,7 +125,7 @@ describe("ProposalsController", () => {
   describe("updateFiltersForList", () => {
     it("should restrict to isPublished when user is not authenticated", () => {
       const result = controller.updateFiltersForList(
-        { user: null } as any,
+        { user: null } as unknown as Request,
         { where: {} },
       );
       expect(result.where?.isPublished).toBe(true);
@@ -133,7 +134,7 @@ describe("ProposalsController", () => {
     it("should not restrict when admin can view all", () => {
       const request = {
         user: { currentGroups: ["admin"] },
-      } as any;
+      } as unknown as Request;
 
       const result = controller.updateFiltersForList(request, { where: {} });
       expect(result.where?.isPublished).toBeUndefined();

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -406,8 +406,10 @@ export class ProposalsController {
       this.updateFiltersForList(request, rest);
 
     if (include) {
-      const proposalFilters: IProposalFilters<ProposalDocument, IProposalFields> =
-        { ...baseFilters, include };
+      const proposalFilters: IProposalFilters<
+        ProposalDocument,
+        IProposalFields
+      > = { ...baseFilters, include };
       return this.proposalsService.findAllComplete(proposalFilters);
     }
     return this.proposalsService.findAll(baseFilters);

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -52,6 +52,9 @@ import {
   IFilters,
   ILimitsFilter,
 } from "src/common/interfaces/common.interface";
+import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe";
+import { IProposalFilters } from "./interfaces/proposal-relations.interface";
+import { PROPOSAL_LOOKUP_FIELDS } from "./types/proposal-lookup";
 import { plainToInstance } from "class-transformer";
 import { validate, ValidatorOptions } from "class-validator";
 import {
@@ -395,12 +398,19 @@ export class ProposalsController {
   })
   async findAll(
     @Req() request: Request,
-    @Query("filters") filters?: string,
+    @Query("filters", new IncludeValidationPipe(PROPOSAL_LOOKUP_FIELDS))
+    filters?: string,
   ): Promise<ProposalClass[]> {
-    const proposalFilters: IFilters<ProposalDocument, IProposalFields> =
-      this.updateFiltersForList(request, JSON.parse(filters ?? "{}"));
+    const { include, ...rest } = JSON.parse(filters ?? "{}");
+    const baseFilters: IFilters<ProposalDocument, IProposalFields> =
+      this.updateFiltersForList(request, rest);
 
-    return this.proposalsService.findAll(proposalFilters);
+    if (include) {
+      const proposalFilters: IProposalFilters<ProposalDocument, IProposalFields> =
+        { ...baseFilters, include };
+      return this.proposalsService.findAllComplete(proposalFilters);
+    }
+    return this.proposalsService.findAll(baseFilters);
   }
 
   // GET /proposals/count

--- a/src/proposals/proposals.service.spec.ts
+++ b/src/proposals/proposals.service.spec.ts
@@ -1,9 +1,15 @@
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Model } from "mongoose";
+import { REQUEST } from "@nestjs/core";
+import { BadRequestException } from "@nestjs/common";
 import { ProposalsService } from "./proposals.service";
 import { ProposalClass } from "./schemas/proposal.schema";
 import { MetadataKeysService } from "src/metadata-keys/metadatakeys.service";
+import { ProposalLookupKeysEnum } from "./types/proposal-lookup";
+import { IProposalFilters } from "./interfaces/proposal-relations.interface";
+import { IFilters } from "src/common/interfaces/common.interface";
+import { IProposalFields } from "./interfaces/proposal-filters.interface";
 
 class MetadataKeysServiceMock {
   insertManyFromSource = jest.fn().mockResolvedValue([]);
@@ -34,34 +40,197 @@ const mockProposal: ProposalClass = {
   isPublished: false,
 };
 
+class ProposalModelMock {
+  new = jest.fn().mockResolvedValue(mockProposal);
+  find = jest.fn().mockReturnValue({
+    limit: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([mockProposal]),
+  });
+  aggregate = jest.fn().mockReturnValue({
+    exec: jest.fn().mockResolvedValue([mockProposal]),
+  });
+  create = jest.fn();
+  exec = jest.fn();
+}
+
 describe("ProposalsService", () => {
   let service: ProposalsService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let model: Model<ProposalClass>;
+  let model: ProposalModelMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ProposalsService,
         {
-          provide: getModelToken("ProposalClass"),
-          useValue: {
-            new: jest.fn().mockResolvedValue(mockProposal),
-            constructor: jest.fn().mockResolvedValue(mockProposal),
-            find: jest.fn(),
-            create: jest.fn(),
-            exec: jest.fn(),
-          },
+          provide: getModelToken(ProposalClass.name),
+          useClass: ProposalModelMock,
         },
         { provide: MetadataKeysService, useClass: MetadataKeysServiceMock },
+        { provide: REQUEST, useValue: { user: { username: "testUser" } } },
       ],
     }).compile();
 
     service = await module.resolve<ProposalsService>(ProposalsService);
-    model = module.get<Model<ProposalClass>>(getModelToken("ProposalClass"));
+    model = module.get(getModelToken(ProposalClass.name));
   });
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("findAll", () => {
+    it("should return proposals using find()", async () => {
+      const filter: IFilters<any, IProposalFields> = {
+        where: { proposalId: "ABCDEF" },
+        limits: { limit: 5, skip: 0 },
+      };
+
+      const result = await service.findAll(filter);
+
+      expect(model.find).toHaveBeenCalledWith({ proposalId: "ABCDEF" });
+      expect(result).toEqual([mockProposal]);
+    });
+
+    it("should apply default limits when not provided", async () => {
+      await service.findAll({});
+      expect(model.find).toHaveBeenCalled();
+    });
+  });
+
+  describe("findAllComplete", () => {
+    it("should call aggregate and return proposals", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: { proposalId: "ABCDEF" },
+      };
+
+      const result = await service.findAllComplete(filter);
+
+      expect(model.aggregate).toHaveBeenCalled();
+      expect(result).toEqual([mockProposal]);
+    });
+
+    it("should include a $lookup stage for samples when include is set", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: { proposalId: "ABCDEF" },
+        include: [ProposalLookupKeysEnum.samples],
+      };
+
+      await service.findAllComplete(filter);
+
+      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find((s) => s.$lookup);
+      expect(lookupStage).toBeDefined();
+      expect(lookupStage.$lookup.from).toBe("Sample");
+      expect(lookupStage.$lookup.as).toBe("samples");
+    });
+
+    it("should include a $match stage inside the $lookup pipeline when scope.where is provided", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: { proposalId: "ABCDEF" },
+        include: [
+          {
+            relation: ProposalLookupKeysEnum.samples,
+            scope: { where: { ownerGroup: "group1" } },
+          },
+        ],
+      };
+
+      await service.findAllComplete(filter);
+
+      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find((s) => s.$lookup);
+      expect(lookupStage.$lookup.pipeline).toContainEqual({
+        $match: { ownerGroup: "group1" },
+      });
+    });
+
+    it("should include $limit and $skip from scope.limits inside the $lookup pipeline", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: {},
+        include: [
+          {
+            relation: ProposalLookupKeysEnum.samples,
+            scope: { limits: { limit: 3, skip: 1 } },
+          },
+        ],
+      };
+
+      await service.findAllComplete(filter);
+
+      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find((s) => s.$lookup);
+      expect(lookupStage.$lookup.pipeline).toContainEqual({ $limit: 3 });
+      expect(lookupStage.$lookup.pipeline).toContainEqual({ $skip: 1 });
+    });
+
+    it("should expand 'all' into all non-all relations", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: {},
+        include: [ProposalLookupKeysEnum.all],
+      };
+
+      await service.findAllComplete(filter);
+
+      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      const lookupStages = pipeline.filter((s) => s.$lookup);
+      // 'all' should expand to every defined relation (excluding 'all' itself)
+      expect(lookupStages.length).toBeGreaterThan(0);
+      expect(lookupStages.every((s) => s.$lookup.as !== "all")).toBe(true);
+    });
+
+    it("should throw BadRequestException when aggregate fails", async () => {
+      model.aggregate.mockReturnValueOnce({
+        exec: jest.fn().mockRejectedValue(new Error("DB error")),
+      });
+
+      const filter: IProposalFilters<any, IProposalFields> = { where: {} };
+
+      await expect(service.findAllComplete(filter)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("should apply outer $skip and $limit to the pipeline", async () => {
+      const filter: IProposalFilters<any, IProposalFields> = {
+        where: {},
+        limits: { limit: 20, skip: 5 },
+      };
+
+      await service.findAllComplete(filter);
+
+      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      expect(pipeline).toContainEqual({ $skip: 5 });
+      expect(pipeline).toContainEqual({ $limit: 20 });
+    });
+  });
+
+  describe("addLookupFields", () => {
+    it("should add a $lookup stage for samples", () => {
+      const pipeline: any[] = [{ $match: {} }];
+      service.addLookupFields(pipeline, [ProposalLookupKeysEnum.samples]);
+
+      const lookupStage = pipeline.find((s) => s.$lookup);
+      expect(lookupStage).toBeDefined();
+      expect(lookupStage.$lookup.from).toBe("Sample");
+      expect(lookupStage.$lookup.as).toBe("samples");
+    });
+
+    it("should not add any stage for an empty include list", () => {
+      const pipeline: any[] = [{ $match: {} }];
+      const added = service.addLookupFields(pipeline, []);
+
+      expect(pipeline).toHaveLength(1);
+      expect(added).toEqual([]);
+    });
+
+    it("should return the list of added relation names", () => {
+      const pipeline: any[] = [];
+      const added = service.addLookupFields(pipeline, [
+        ProposalLookupKeysEnum.samples,
+      ]);
+      expect(added).toEqual(["samples"]);
+    });
   });
 });

--- a/src/proposals/proposals.service.spec.ts
+++ b/src/proposals/proposals.service.spec.ts
@@ -1,15 +1,11 @@
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
-import { Model } from "mongoose";
 import { REQUEST } from "@nestjs/core";
 import { BadRequestException } from "@nestjs/common";
 import { ProposalsService } from "./proposals.service";
 import { ProposalClass } from "./schemas/proposal.schema";
 import { MetadataKeysService } from "src/metadata-keys/metadatakeys.service";
 import { ProposalLookupKeysEnum } from "./types/proposal-lookup";
-import { IProposalFilters } from "./interfaces/proposal-relations.interface";
-import { IFilters } from "src/common/interfaces/common.interface";
-import { IProposalFields } from "./interfaces/proposal-filters.interface";
 
 class MetadataKeysServiceMock {
   insertManyFromSource = jest.fn().mockResolvedValue([]);
@@ -82,12 +78,10 @@ describe("ProposalsService", () => {
 
   describe("findAll", () => {
     it("should return proposals using find()", async () => {
-      const filter: IFilters<any, IProposalFields> = {
+      const result = await service.findAll({
         where: { proposalId: "ABCDEF" },
         limits: { limit: 5, skip: 0 },
-      };
-
-      const result = await service.findAll(filter);
+      });
 
       expect(model.find).toHaveBeenCalledWith({ proposalId: "ABCDEF" });
       expect(result).toEqual([mockProposal]);
@@ -101,33 +95,31 @@ describe("ProposalsService", () => {
 
   describe("findAllComplete", () => {
     it("should call aggregate and return proposals", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      const result = await service.findAllComplete({
         where: { proposalId: "ABCDEF" },
-      };
-
-      const result = await service.findAllComplete(filter);
+      });
 
       expect(model.aggregate).toHaveBeenCalled();
       expect(result).toEqual([mockProposal]);
     });
 
     it("should include a $lookup stage for samples when include is set", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      await service.findAllComplete({
         where: { proposalId: "ABCDEF" },
         include: [ProposalLookupKeysEnum.samples],
-      };
+      });
 
-      await service.findAllComplete(filter);
-
-      const pipeline: any[] = model.aggregate.mock.calls[0][0];
-      const lookupStage = pipeline.find((s) => s.$lookup);
+      const pipeline = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find(
+        (s: { $lookup?: unknown }) => s.$lookup,
+      );
       expect(lookupStage).toBeDefined();
       expect(lookupStage.$lookup.from).toBe("Sample");
       expect(lookupStage.$lookup.as).toBe("samples");
     });
 
     it("should include a $match stage inside the $lookup pipeline when scope.where is provided", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      await service.findAllComplete({
         where: { proposalId: "ABCDEF" },
         include: [
           {
@@ -135,19 +127,19 @@ describe("ProposalsService", () => {
             scope: { where: { ownerGroup: "group1" } },
           },
         ],
-      };
+      });
 
-      await service.findAllComplete(filter);
-
-      const pipeline: any[] = model.aggregate.mock.calls[0][0];
-      const lookupStage = pipeline.find((s) => s.$lookup);
+      const pipeline = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find(
+        (s: { $lookup?: unknown }) => s.$lookup,
+      );
       expect(lookupStage.$lookup.pipeline).toContainEqual({
         $match: { ownerGroup: "group1" },
       });
     });
 
     it("should include $limit and $skip from scope.limits inside the $lookup pipeline", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      await service.findAllComplete({
         where: {},
         include: [
           {
@@ -155,29 +147,32 @@ describe("ProposalsService", () => {
             scope: { limits: { limit: 3, skip: 1 } },
           },
         ],
-      };
+      });
 
-      await service.findAllComplete(filter);
-
-      const pipeline: any[] = model.aggregate.mock.calls[0][0];
-      const lookupStage = pipeline.find((s) => s.$lookup);
+      const pipeline = model.aggregate.mock.calls[0][0];
+      const lookupStage = pipeline.find(
+        (s: { $lookup?: unknown }) => s.$lookup,
+      );
       expect(lookupStage.$lookup.pipeline).toContainEqual({ $limit: 3 });
       expect(lookupStage.$lookup.pipeline).toContainEqual({ $skip: 1 });
     });
 
     it("should expand 'all' into all non-all relations", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      await service.findAllComplete({
         where: {},
         include: [ProposalLookupKeysEnum.all],
-      };
+      });
 
-      await service.findAllComplete(filter);
-
-      const pipeline: any[] = model.aggregate.mock.calls[0][0];
-      const lookupStages = pipeline.filter((s) => s.$lookup);
-      // 'all' should expand to every defined relation (excluding 'all' itself)
+      const pipeline = model.aggregate.mock.calls[0][0];
+      const lookupStages = pipeline.filter(
+        (s: { $lookup?: unknown }) => s.$lookup,
+      );
       expect(lookupStages.length).toBeGreaterThan(0);
-      expect(lookupStages.every((s) => s.$lookup.as !== "all")).toBe(true);
+      expect(
+        lookupStages.every(
+          (s: { $lookup: { as: string } }) => s.$lookup.as !== "all",
+        ),
+      ).toBe(true);
     });
 
     it("should throw BadRequestException when aggregate fails", async () => {
@@ -185,22 +180,18 @@ describe("ProposalsService", () => {
         exec: jest.fn().mockRejectedValue(new Error("DB error")),
       });
 
-      const filter: IProposalFilters<any, IProposalFields> = { where: {} };
-
-      await expect(service.findAllComplete(filter)).rejects.toThrow(
+      await expect(service.findAllComplete({ where: {} })).rejects.toThrow(
         BadRequestException,
       );
     });
 
     it("should apply outer $skip and $limit to the pipeline", async () => {
-      const filter: IProposalFilters<any, IProposalFields> = {
+      await service.findAllComplete({
         where: {},
         limits: { limit: 20, skip: 5 },
-      };
+      });
 
-      await service.findAllComplete(filter);
-
-      const pipeline: any[] = model.aggregate.mock.calls[0][0];
+      const pipeline = model.aggregate.mock.calls[0][0];
       expect(pipeline).toContainEqual({ $skip: 5 });
       expect(pipeline).toContainEqual({ $limit: 20 });
     });
@@ -208,17 +199,23 @@ describe("ProposalsService", () => {
 
   describe("addLookupFields", () => {
     it("should add a $lookup stage for samples", () => {
-      const pipeline: any[] = [{ $match: {} }];
+      const pipeline: Parameters<typeof service.addLookupFields>[0] = [
+        { $match: {} },
+      ];
       service.addLookupFields(pipeline, [ProposalLookupKeysEnum.samples]);
 
-      const lookupStage = pipeline.find((s) => s.$lookup);
+      const lookupStage = pipeline.find((s) => "$lookup" in s) as
+        | { $lookup: { from: string; as: string } }
+        | undefined;
       expect(lookupStage).toBeDefined();
-      expect(lookupStage.$lookup.from).toBe("Sample");
-      expect(lookupStage.$lookup.as).toBe("samples");
+      expect(lookupStage!.$lookup.from).toBe("Sample");
+      expect(lookupStage!.$lookup.as).toBe("samples");
     });
 
     it("should not add any stage for an empty include list", () => {
-      const pipeline: any[] = [{ $match: {} }];
+      const pipeline: Parameters<typeof service.addLookupFields>[0] = [
+        { $match: {} },
+      ];
       const added = service.addLookupFields(pipeline, []);
 
       expect(pipeline).toHaveLength(1);
@@ -226,7 +223,7 @@ describe("ProposalsService", () => {
     });
 
     it("should return the list of added relation names", () => {
-      const pipeline: any[] = [];
+      const pipeline: Parameters<typeof service.addLookupFields>[0] = [];
       const added = service.addLookupFields(pipeline, [
         ProposalLookupKeysEnum.samples,
       ]);

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, NotFoundException, Scope } from "@nestjs/common";
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  NotFoundException,
+  Scope,
+} from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 import { Request } from "express";
 import { InjectModel } from "@nestjs/mongoose";
@@ -14,9 +20,22 @@ import {
   createFullfacetPipeline,
   createFullqueryFilter,
   parseLimitFilters,
+  parseOrderLimits,
+  parsePipelineProjection,
+  parsePipelineSort,
   addCreatedByFields,
   addUpdatedByField,
 } from "src/common/utils";
+import { isEmpty } from "lodash";
+import {
+  IProposalFilters,
+  IProposalRelation,
+  IProposalScopes,
+} from "./interfaces/proposal-relations.interface";
+import {
+  PROPOSAL_LOOKUP_FIELDS,
+  ProposalLookupKeysEnum,
+} from "./types/proposal-lookup";
 import { CreateProposalDto } from "./dto/create-proposal.dto";
 import { PartialUpdateProposalDto } from "./dto/update-proposal.dto";
 import { IProposalFields } from "./interfaces/proposal-filters.interface";
@@ -36,6 +55,123 @@ export class ProposalsService {
     private metadataKeysService: MetadataKeysService,
     @Inject(REQUEST) private request: Request,
   ) {}
+
+  private extractRelationsAndScopes(
+    proposalLookupFields:
+      | (ProposalLookupKeysEnum | IProposalRelation)[]
+      | undefined,
+  ) {
+    const scopes = {} as Record<ProposalLookupKeysEnum, IProposalScopes>;
+    const fieldsList: ProposalLookupKeysEnum[] = [];
+    let isAll = false;
+    proposalLookupFields?.forEach((f) => {
+      if (typeof f === "object" && "relation" in f) {
+        fieldsList.push(f.relation);
+        scopes[f.relation] = f.scope;
+        isAll = f.relation === ProposalLookupKeysEnum.all;
+        return;
+      }
+      isAll = f === ProposalLookupKeysEnum.all;
+      fieldsList.push(f);
+    });
+
+    const relations = isAll
+      ? (Object.keys(PROPOSAL_LOOKUP_FIELDS).filter(
+          (field) => field !== ProposalLookupKeysEnum.all,
+        ) as ProposalLookupKeysEnum[])
+      : fieldsList;
+    return { scopes, relations };
+  }
+
+  addLookupFields(
+    pipeline: PipelineStage[],
+    proposalLookupFields?: (ProposalLookupKeysEnum | IProposalRelation)[],
+  ) {
+    const relationsAndScopes =
+      this.extractRelationsAndScopes(proposalLookupFields);
+
+    const scopes = relationsAndScopes.scopes;
+    const addedRelations: string[] = [];
+    for (const field of relationsAndScopes.relations) {
+      const fieldValue = structuredClone(PROPOSAL_LOOKUP_FIELDS[field]);
+      if (!fieldValue) continue;
+      fieldValue.$lookup.as = field;
+      const scope = scopes[field];
+
+      const includePipeline = [];
+      if (scope?.where) includePipeline.push({ $match: scope.where });
+      if (scope?.fields)
+        includePipeline.push({
+          $project: parsePipelineProjection(scope.fields as unknown as string[]),
+        });
+      if (scope?.limits?.skip)
+        includePipeline.push({ $skip: scope.limits.skip });
+      if (scope?.limits?.limit)
+        includePipeline.push({ $limit: scope.limits.limit });
+
+      const limits = parseOrderLimits(scope?.limits);
+      if (limits?.sort) {
+        const sort = parsePipelineSort(limits.sort);
+        includePipeline.push({ $sort: sort });
+      }
+
+      if (includePipeline.length > 0)
+        fieldValue.$lookup.pipeline = (
+          fieldValue.$lookup.pipeline ?? []
+        ).concat(includePipeline);
+
+      pipeline.push(fieldValue);
+      addedRelations.push(field);
+    }
+    return addedRelations;
+  }
+
+  async findAllComplete(
+    filter: IProposalFilters<ProposalDocument, IProposalFields>,
+  ): Promise<ProposalClass[]> {
+    const whereFilter: FilterQuery<ProposalDocument> = filter.where ?? {};
+    const fieldsProjection = (filter.fields ?? []) as string[];
+    const filterDefaults = {
+      limit: 10,
+      skip: 0,
+      sort: { createdAt: "desc" } as Record<string, "asc" | "desc">,
+    };
+    const limits = parseLimitFilters({
+      ...filterDefaults,
+      ...filter.limits,
+    });
+
+    const pipeline: PipelineStage[] = [{ $match: whereFilter }];
+    const addedRelations = this.addLookupFields(
+      pipeline,
+      filter.include as (ProposalLookupKeysEnum | IProposalRelation)[],
+    );
+
+    if (!isEmpty(fieldsProjection)) {
+      const projection = parsePipelineProjection(
+        fieldsProjection,
+        addedRelations,
+      );
+      pipeline.push({ $project: projection });
+    }
+
+    if (!isEmpty(limits.sort)) {
+      const sort = parsePipelineSort(limits.sort);
+      pipeline.push({ $sort: sort });
+    }
+
+    pipeline.push({ $skip: limits.skip || 0 });
+    pipeline.push({ $limit: limits.limit || 10 });
+
+    try {
+      return await this.proposalModel.aggregate<ProposalClass>(pipeline).exec();
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new BadRequestException(error.message);
+      }
+      throw new BadRequestException("An unknown error occurred");
+    }
+  }
 
   private createMetadataKeysInstance(
     doc: UpdateQuery<ProposalDocument>,

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -102,7 +102,9 @@ export class ProposalsService {
       if (scope?.where) includePipeline.push({ $match: scope.where });
       if (scope?.fields)
         includePipeline.push({
-          $project: parsePipelineProjection(scope.fields as unknown as string[]),
+          $project: parsePipelineProjection(
+            scope.fields as unknown as string[],
+          ),
         });
       if (scope?.limits?.skip)
         includePipeline.push({ $skip: scope.limits.skip });

--- a/src/proposals/types/proposal-lookup.ts
+++ b/src/proposals/types/proposal-lookup.ts
@@ -1,0 +1,51 @@
+import { PipelineStage } from "mongoose";
+import { ProposalClass } from "../schemas/proposal.schema";
+
+export enum ProposalLookupKeysEnum {
+  samples = "samples",
+  all = "all",
+}
+
+export const PROPOSAL_LOOKUP_FIELDS: Record<
+  ProposalLookupKeysEnum,
+  PipelineStage.Lookup | undefined
+> = {
+  samples: {
+    $lookup: {
+      from: "Sample",
+      as: "",
+      let: { proposalId: "$proposalId" },
+      pipeline: [
+        { $match: { $expr: { $eq: ["$proposalId", "$$proposalId"] } } },
+      ],
+    },
+  },
+  all: undefined,
+};
+
+export const ALLOWED_PROPOSAL_KEYS = [...Object.keys(new ProposalClass())];
+
+export const ALLOWED_PROPOSAL_FILTER_KEYS: Record<string, string[]> = {
+  where: [
+    "where",
+    "$in",
+    "$or",
+    "$and",
+    "$nor",
+    "$match",
+    "$eq",
+    "$gt",
+    "$gte",
+    "$lt",
+    "$lte",
+    "$ne",
+    "$nin",
+    "$not",
+    "$exists",
+    "$regex",
+    "$options",
+  ],
+  include: ["include"],
+  limits: ["limits", "limit", "skip", "sort"],
+  fields: ["fields"],
+};


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add `include` filter support to the GET /api/v3/proposals endpoint, allowing callers to request associated samples inline within a single query.

## Motivation
The proposals endpoint only supported simple find() queries with no relation expansion. We used to need to make separate requests to fetch samples belonging to a proposal. The dataset endpoint already supports this pattern via MongoDB aggregation $lookup stages - this change brings proposals to parity.

The following query now works
```
curl -X 'GET' \
  '<backend>/api/v3/proposals' \
  -H 'Authorization: Bearer <token>' \
  -H 'accept: application/json' \
  --data-urlencode 'filter={"where":{"proposalId":"123456"},"include":[{"relation":"samples"}]}'
```

## Fixes
SWAP-5421


## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

- Added src/proposals/types/proposal-lookup.ts — defines ProposalLookupKeysEnum and PROPOSAL_LOOKUP_FIELDS with a $lookup stage joining Sample on Sample.proposalId = Proposal.proposalId
- Added src/proposals/interfaces/proposal-relations.interface.ts — IProposalFilters, IProposalRelation, IProposalScopes types mirroring the dataset filter interface pattern
- Added findAllComplete(), addLookupFields(), and extractRelationsAndScopes() to ProposalsService — builds an aggregation pipeline with optional $lookup stages and applies scope-level where, fields, limits
- Updated GET /proposals in ProposalsController — routes to findAllComplete() when include is present in the filter, otherwise falls back to existing findAll()
- Updated IncludeValidationPipe — extended the strict union type to include ProposalLookupKeysEnum alongside the existing dataset and origdatablock enum types

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

