### PR TITLE
feat: update relationship schema

### DIFF
--- a/src/datasets/dto/create-relationship.dto.ts
+++ b/src/datasets/dto/create-relationship.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional, IsString, IsUrl } from "class-validator";
 
 export class CreateRelationshipDto {
   @ApiProperty({
@@ -10,11 +10,30 @@ export class CreateRelationshipDto {
   @IsString()
   readonly pid: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
-    required: true,
-    description: "Relationship between this dataset and the related one.",
+    description: "Relationship between this dataset and the related entity.",
+    default: "is related to",
   })
   @IsString()
-  relationship: string;
+  @IsOptional()
+  readonly relationship?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      "Type of the related entity (e.g., 'Dataset', 'Logbook', 'Other').",
+    default: "Other",
+  })
+  @IsString()
+  @IsOptional()
+  readonly relatedEntityType?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: "URL to access the related entity, if applicable.",
+  })
+  @IsString()
+  @IsUrl()
+  readonly url?: string;
 }

--- a/src/datasets/dto/create-relationship.dto.ts
+++ b/src/datasets/dto/create-relationship.dto.ts
@@ -1,19 +1,33 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsOptional, IsString, IsUrl } from "class-validator";
+import { IsOptional, IsString, Validate } from "class-validator";
+import { RelatedIdentifierMatchesType } from "../utils/related-identifier-validator.util";
 
 export class CreateRelationshipDto {
   @ApiProperty({
     type: String,
     required: true,
-    description: "Persistent identifier of the related dataset.",
+    description:
+      "Identifier of the related entity (e.g. 'https://example.org/datasets/123', '10.1016/j.epsl.2011.11.037', 'arXiv:0706.0001').",
   })
+  @Validate(RelatedIdentifierMatchesType)
   @IsString()
-  readonly pid: string;
+  readonly relatedIdentifier: string;
 
   @ApiPropertyOptional({
     type: String,
-    description: "Relationship between this dataset and the related entity.",
-    default: "is related to",
+    description:
+      "Type of the related identifier (e.g., 'URL', 'DOI', 'arXiv', 'Other').",
+    default: "Other",
+  })
+  @IsString()
+  @IsOptional()
+  readonly relatedIdentifierType?: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      "Relationship between this dataset and the related entity (e.g., 'IsReferencedBy', 'IsSupplementTo', 'IsCitedBy').",
+    default: "IsReferencedBy",
   })
   @IsString()
   @IsOptional()
@@ -31,9 +45,9 @@ export class CreateRelationshipDto {
 
   @ApiPropertyOptional({
     type: String,
-    description: "URL to access the related entity, if applicable.",
+    description: "Identifier of the related entity in the external system.",
   })
   @IsString()
-  @IsUrl()
-  readonly url?: string;
+  @IsOptional()
+  readonly targetId?: string;
 }

--- a/src/datasets/dto/create-relationship.dto.ts
+++ b/src/datasets/dto/create-relationship.dto.ts
@@ -11,17 +11,17 @@ export class CreateRelationshipDto {
   })
   @Validate(RelatedIdentifierMatchesType)
   @IsString()
-  readonly relatedIdentifier: string;
+  readonly identifier: string;
 
   @ApiPropertyOptional({
     type: String,
     description:
-      "Type of the related identifier (e.g., 'URL', 'DOI', 'arXiv', 'Other').",
+      "Type of the related identifier (e.g., 'URL', 'DOI', 'arXiv', 'Other'). We may use 'Local' for SciCat identifiers",
     default: "Other",
   })
   @IsString()
   @IsOptional()
-  readonly relatedIdentifierType?: string;
+  readonly identifierType?: string;
 
   @ApiPropertyOptional({
     type: String,
@@ -41,13 +41,14 @@ export class CreateRelationshipDto {
   })
   @IsString()
   @IsOptional()
-  readonly relatedEntityType?: string;
+  readonly entityType?: string;
 
   @ApiPropertyOptional({
     type: String,
-    description: "Identifier of the related entity in the external system.",
+    description:
+      "Identifier of the related entity in the external system. Not used for SciCat-internal relationships.",
   })
   @IsString()
   @IsOptional()
-  readonly targetId?: string;
+  readonly externalId?: string;
 }

--- a/src/datasets/dto/update-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-dataset-obsolete.dto.ts
@@ -23,7 +23,6 @@ import {
 import { TechniqueClass } from "../schemas/technique.schema";
 import { Type, Transform } from "class-transformer";
 import { CreateTechniqueDto } from "./create-technique.dto";
-import { RelationshipClass } from "../schemas/relationship.schema";
 import { CreateRelationshipDto } from "./create-relationship.dto";
 import { LifecycleClass } from "../schemas/lifecycle.schema";
 import { encodeScientificMetadataKeys } from "src/common/utils";
@@ -246,17 +245,18 @@ export class UpdateDatasetObsoleteDto extends OwnableDto {
 
   // it needs to be discussed if this fields is managed by the user or by the system
   @ApiProperty({
-    type: "array",
-    items: { $ref: getSchemaPath(RelationshipClass) },
+    type: CreateRelationshipDto,
     required: false,
+    isArray: true,
     default: [],
-    description: "Stores the relationships with other datasets.",
+    description: `Array of relationships with other entities (possibly external to the catalog).
+      Inspired by DataCite's relatedIdentifier schema: https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/`,
   })
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => CreateRelationshipDto)
-  readonly relationships?: RelationshipClass[];
+  readonly relationships?: CreateRelationshipDto[];
 
   @ApiProperty({
     type: LifecycleClass,

--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -23,7 +23,6 @@ import {
 import { TechniqueClass } from "../schemas/technique.schema";
 import { Transform, Type } from "class-transformer";
 import { CreateTechniqueDto } from "./create-technique.dto";
-import { RelationshipClass } from "../schemas/relationship.schema";
 import { CreateRelationshipDto } from "./create-relationship.dto";
 import { LifecycleClass } from "../schemas/lifecycle.schema";
 import { HistoryClass } from "../schemas/history.schema";
@@ -249,17 +248,18 @@ export class UpdateDatasetDto extends OwnableDto {
 
   // it needs to be discussed if this fields is managed by the user or by the system
   @ApiProperty({
-    type: RelationshipClass,
+    type: CreateRelationshipDto,
     required: false,
     isArray: true,
     default: [],
-    description: "Stores the relationships with other datasets.",
+    description: `Array of relationships with other entities (possibly external to the catalog).
+      Inspired by DataCite's relatedIdentifier schema: https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/`,
   })
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => CreateRelationshipDto)
-  readonly relationships?: RelationshipClass[];
+  readonly relationships?: CreateRelationshipDto[];
 
   @ApiProperty({
     type: LifecycleClass,

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -481,4 +481,5 @@ export class DatasetClass extends OwnableClass {
 export const DatasetSchema = SchemaFactory.createForClass(DatasetClass);
 
 DatasetSchema.index({ "$**": "text" });
-DatasetSchema.index({ "relationships.pid": 1 });
+DatasetSchema.index({ "relationships.relatedIdentifier": 1 });
+DatasetSchema.index({ "relationships.targetId": 1 });

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -481,5 +481,5 @@ export class DatasetClass extends OwnableClass {
 export const DatasetSchema = SchemaFactory.createForClass(DatasetClass);
 
 DatasetSchema.index({ "$**": "text" });
-DatasetSchema.index({ "relationships.relatedIdentifier": 1 });
-DatasetSchema.index({ "relationships.targetId": 1 });
+DatasetSchema.index({ "relationships.identifier": 1 });
+DatasetSchema.index({ "relationships.externalId": 1 });

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -290,8 +290,8 @@ export class DatasetClass extends OwnableClass {
     items: { $ref: getSchemaPath(RelationshipClass) },
     required: false,
     default: [],
-    description:
-      "Array of relationships with other datasets. It contains relationship type and destination dataset",
+    description: `Array of relationships with other entities (possibly external to the catalog).
+      Inspired by DataCite's relatedIdentifier schema: https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/`,
   })
   @Prop({ type: [RelationshipSchema], required: false, default: [] })
   relationships?: RelationshipClass[];
@@ -481,3 +481,4 @@ export class DatasetClass extends OwnableClass {
 export const DatasetSchema = SchemaFactory.createForClass(DatasetClass);
 
 DatasetSchema.index({ "$**": "text" });
+DatasetSchema.index({ "relationships.pid": 1 });

--- a/src/datasets/schemas/relationship.schema.ts
+++ b/src/datasets/schemas/relationship.schema.ts
@@ -13,16 +13,16 @@ export class RelationshipClass {
       "Identifier of the related entity (e.g. 'https://example.org/datasets/123', '10.1016/j.epsl.2011.11.037', 'arXiv:0706.0001')",
   })
   @Prop({ type: String, required: true })
-  relatedIdentifier: string;
+  identifier: string;
 
   @ApiProperty({
     type: String,
     description:
-      "Type of the related identifier (e.g., 'URL', 'DOI', 'arXiv', 'Other').",
+      "Type of the related `identifier` (e.g., 'URL', 'DOI', 'arXiv', 'Other'). We may use 'Local' for SciCat identifiers",
     default: "Other",
   })
   @Prop({ type: String, default: "Other" })
-  relatedIdentifierType: string;
+  identifierType: string;
 
   @ApiProperty({
     type: String,
@@ -40,14 +40,15 @@ export class RelationshipClass {
     default: "Other",
   })
   @Prop({ type: String, default: "Other" })
-  relatedEntityType: string;
+  entityType: string;
 
   @ApiPropertyOptional({
     type: String,
-    description: "Identifier of the related entity in the external system.",
+    description:
+      "Identifier of the related entity in the external system. Not used for SciCat-internal relationships.",
   })
   @Prop({ type: String, required: false })
-  targetId?: string;
+  externalId?: string;
 }
 
 export const RelationshipSchema =

--- a/src/datasets/schemas/relationship.schema.ts
+++ b/src/datasets/schemas/relationship.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Document } from "mongoose";
 
 export type RelationshipDocument = RelationshipClass & Document;
@@ -9,18 +9,34 @@ export class RelationshipClass {
   @ApiProperty({
     type: String,
     required: true,
-    description: "Persistent identifier of the related dataset.",
+    description: "Persistent identifier of the related entity.",
   })
   @Prop({ type: String, required: true })
   pid: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
-    required: true,
-    description: "Relationship between this dataset and the related one.",
+    description: "Relationship between this dataset and the related entity.",
+    default: "is related to",
   })
-  @Prop({ type: String, required: true })
+  @Prop({ type: String, default: "is related to" })
   relationship: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      "Type of the related entity (e.g., 'Dataset', 'Logbook', 'Other').",
+    default: "Other",
+  })
+  @Prop({ type: String, default: "Other" })
+  relatedEntityType: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description: "URL to access the related entity, if applicable.",
+  })
+  @Prop({ type: String, required: false })
+  url?: string;
 }
 
 export const RelationshipSchema =

--- a/src/datasets/schemas/relationship.schema.ts
+++ b/src/datasets/schemas/relationship.schema.ts
@@ -9,20 +9,31 @@ export class RelationshipClass {
   @ApiProperty({
     type: String,
     required: true,
-    description: "Persistent identifier of the related entity.",
+    description:
+      "Identifier of the related entity (e.g. 'https://example.org/datasets/123', '10.1016/j.epsl.2011.11.037', 'arXiv:0706.0001')",
   })
   @Prop({ type: String, required: true })
-  pid: string;
+  relatedIdentifier: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     type: String,
-    description: "Relationship between this dataset and the related entity.",
-    default: "is related to",
+    description:
+      "Type of the related identifier (e.g., 'URL', 'DOI', 'arXiv', 'Other').",
+    default: "Other",
   })
-  @Prop({ type: String, default: "is related to" })
+  @Prop({ type: String, default: "Other" })
+  relatedIdentifierType: string;
+
+  @ApiProperty({
+    type: String,
+    description:
+      "Relationship between this dataset and the related entity (e.g., 'IsReferencedBy', 'IsSupplementTo', 'IsCitedBy').",
+    default: "IsReferencedBy",
+  })
+  @Prop({ type: String, default: "IsReferencedBy" })
   relationship: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     type: String,
     description:
       "Type of the related entity (e.g., 'Dataset', 'Logbook', 'Other').",
@@ -33,10 +44,10 @@ export class RelationshipClass {
 
   @ApiPropertyOptional({
     type: String,
-    description: "URL to access the related entity, if applicable.",
+    description: "Identifier of the related entity in the external system.",
   })
   @Prop({ type: String, required: false })
-  url?: string;
+  targetId?: string;
 }
 
 export const RelationshipSchema =

--- a/src/datasets/utils/related-identifier-validator.util.spec.ts
+++ b/src/datasets/utils/related-identifier-validator.util.spec.ts
@@ -11,47 +11,44 @@ describe("RelatedIdentifierMatchesType", () => {
     ({
       targetName: "CreateRelationshipDto",
       object,
-      property: "relatedIdentifier",
-      value: object.relatedIdentifier,
+      property: "identifier",
+      value: object.identifier,
       constraints: [],
     }) as ValidationArguments;
 
-  it("validates URL when relatedIdentifierType is URL", () => {
+  it("validates URL when identifierType is URL", () => {
     expect(
       validator.validate(
         "https://example.org/datasets/123",
         makeArgs({
-          relatedIdentifier: "https://example.org/datasets/123",
-          relatedIdentifierType: "URL",
+          identifier: "https://example.org/datasets/123",
+          identifierType: "URL",
         }),
       ),
     ).toBe(true);
   });
 
-  it("rejects invalid URL when relatedIdentifierType is URL", () => {
+  it("rejects invalid URL when identifierType is URL", () => {
     expect(
       validator.validate(
         "noturl/datasets/123",
         makeArgs({
-          relatedIdentifier: "noturl/datasets/123",
-          relatedIdentifierType: "URL",
+          identifier: "noturl/datasets/123",
+          identifierType: "URL",
         }),
       ),
     ).toBe(false);
   });
 
-  it("accepts any string when relatedIdentifierType is missing", () => {
+  it("accepts any string when identifierType is missing", () => {
     expect(
-      validator.validate(
-        "anything123",
-        makeArgs({ relatedIdentifier: "Other" }),
-      ),
+      validator.validate("anything123", makeArgs({ identifier: "Other" })),
     ).toBe(true);
   });
 
   it("provides a descriptive default message", () => {
     const message = validator.defaultMessage(
-      makeArgs({ relatedIdentifier: "foo", relatedIdentifierType: "URL" }),
+      makeArgs({ identifier: "foo", identifierType: "URL" }),
     );
     expect(message).toContain("URL");
   });

--- a/src/datasets/utils/related-identifier-validator.util.spec.ts
+++ b/src/datasets/utils/related-identifier-validator.util.spec.ts
@@ -1,0 +1,58 @@
+import { CreateRelationshipDto } from "../dto/create-relationship.dto";
+import { RelatedIdentifierMatchesType } from "./related-identifier-validator.util";
+import { ValidationArguments } from "class-validator";
+
+describe("RelatedIdentifierMatchesType", () => {
+  const validator = new RelatedIdentifierMatchesType();
+
+  const makeArgs = (
+    object: Partial<CreateRelationshipDto>,
+  ): ValidationArguments =>
+    ({
+      targetName: "CreateRelationshipDto",
+      object,
+      property: "relatedIdentifier",
+      value: object.relatedIdentifier,
+      constraints: [],
+    }) as ValidationArguments;
+
+  it("validates URL when relatedIdentifierType is URL", () => {
+    expect(
+      validator.validate(
+        "https://example.org/datasets/123",
+        makeArgs({
+          relatedIdentifier: "https://example.org/datasets/123",
+          relatedIdentifierType: "URL",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects invalid URL when relatedIdentifierType is URL", () => {
+    expect(
+      validator.validate(
+        "noturl/datasets/123",
+        makeArgs({
+          relatedIdentifier: "noturl/datasets/123",
+          relatedIdentifierType: "URL",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts any string when relatedIdentifierType is missing", () => {
+    expect(
+      validator.validate(
+        "anything123",
+        makeArgs({ relatedIdentifier: "Other" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("provides a descriptive default message", () => {
+    const message = validator.defaultMessage(
+      makeArgs({ relatedIdentifier: "foo", relatedIdentifierType: "URL" }),
+    );
+    expect(message).toContain("URL");
+  });
+});

--- a/src/datasets/utils/related-identifier-validator.util.ts
+++ b/src/datasets/utils/related-identifier-validator.util.ts
@@ -8,9 +8,7 @@ import {
 
 @Injectable()
 @ValidatorConstraint({ name: "relatedIdentifierMatchesType", async: false })
-export class RelatedIdentifierMatchesType
-  implements ValidatorConstraintInterface
-{
+export class RelatedIdentifierMatchesType implements ValidatorConstraintInterface {
   validate(value: unknown, args: ValidationArguments) {
     if (typeof value !== "string") {
       return false;

--- a/src/datasets/utils/related-identifier-validator.util.ts
+++ b/src/datasets/utils/related-identifier-validator.util.ts
@@ -5,18 +5,22 @@ import {
   ValidationArguments,
   isURL,
 } from "class-validator";
+import { CreateRelationshipDto } from "../dto/create-relationship.dto";
 
 @Injectable()
-@ValidatorConstraint({ name: "relatedIdentifierMatchesType", async: false })
+@ValidatorConstraint({
+  name: "relatedIdentifierMatchesType",
+  async: false,
+})
 export class RelatedIdentifierMatchesType implements ValidatorConstraintInterface {
   validate(value: unknown, args: ValidationArguments) {
     if (typeof value !== "string") {
       return false;
     }
 
-    const dto = args.object as { relatedIdentifierType?: string };
+    const dto = args.object as Partial<CreateRelationshipDto>;
 
-    switch (dto.relatedIdentifierType) {
+    switch (dto.identifierType) {
       case "URL":
         return isURL(value);
       default:
@@ -25,8 +29,8 @@ export class RelatedIdentifierMatchesType implements ValidatorConstraintInterfac
   }
 
   defaultMessage(args: ValidationArguments) {
-    const dto = args.object as { relatedIdentifierType?: string };
-    const type = dto.relatedIdentifierType ?? "the configured type";
-    return `relatedIdentifier must be a valid ${type} when relatedIdentifierType is set to '${dto.relatedIdentifierType}'.`;
+    const dto = args.object as Partial<CreateRelationshipDto>;
+    const type = dto.identifierType ?? "the configured type";
+    return `identifier must be a valid ${type} when identifierType is set to '${dto.identifierType}'.`;
   }
 }

--- a/src/datasets/utils/related-identifier-validator.util.ts
+++ b/src/datasets/utils/related-identifier-validator.util.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  isURL,
+} from "class-validator";
+
+@Injectable()
+@ValidatorConstraint({ name: "relatedIdentifierMatchesType", async: false })
+export class RelatedIdentifierMatchesType
+  implements ValidatorConstraintInterface
+{
+  validate(value: unknown, args: ValidationArguments) {
+    if (typeof value !== "string") {
+      return false;
+    }
+
+    const dto = args.object as { relatedIdentifierType?: string };
+
+    switch (dto.relatedIdentifierType) {
+      case "URL":
+        return isURL(value);
+      default:
+        return true;
+    }
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const dto = args.object as { relatedIdentifierType?: string };
+    const type = dto.relatedIdentifierType ?? "the configured type";
+    return `relatedIdentifier must be a valid ${type} when relatedIdentifierType is set to '${dto.relatedIdentifierType}'.`;
+  }
+}


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Add fields to relationship schema used by `relationships` field in the dataset schema.

Testing:
PATCH /api/v4/datasets/:pid
```json
{
  "relationships": [
    {
      "identifier": "https://scilog.development.psi.ch/logbooks/6895bea625f055bca783dfdd",
      "identifierType": "URL",
      "entityType": "Logbook",
      "externalId": "6895bea625f055bca783dfdd"
    },
    {
      "identifier": "10.1016/j.epsl.2011.11.037",
      "identifierType": "DOI",
      "entityType": "JournalArticle"
    }
  ]
}
```
Updated dataset contains:
```json
"relationships": [
  {
    "identifier": "https://scilog.development.psi.ch/logbooks/6895bea625f055bca783dfdd",
    "identifierType": "URL",
    "relationship": "IsReferencedBy",
    "entityType": "Logbook",
    "externalId": "6895bea625f055bca783dfdd",
    "_id": "69d7b7e797c6654f48cab9df"
  },
  {
    "identifier": "10.1016/j.epsl.2011.11.037",
    "identifierType": "DOI",
    "relationship": "IsReferencedBy",
    "entityType": "JournalArticle",
    "_id": "69d7b7e797c6654f48cab9e0"
  }
]
```

A corresponding frontend feature (widget / tab on dataset detail page) will follow.

## Motivation
<!-- Background on use case, changes needed -->
Previously, RelationshipClass was dataset specific. However, there is a need to link to related entities outside of SciCat, e.g. a SciLog logbook.
So we add `relatedEntityType` (inspired by datacite's [resourceTypeGeneral](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/#f-resourcetypegeneral)) . The existing `relationship` field is roughly  [relationType](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/#b-relationtype)

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* NA

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* generalize description of pid and relationship fields from "dataset" to "entity"
* add additional fields to the schema as indicated above

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
