### PR TITLE
fix(ownableSchema): ownerGroup should be unempty field

### DIFF
--- a/src/common/dto/ownable.dto.ts
+++ b/src/common/dto/ownable.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
 
 export class OwnableDto {
   @ApiProperty({
@@ -8,6 +8,7 @@ export class OwnableDto {
     description: "Name of the group owning this item.",
   })
   @IsString()
+  @IsNotEmpty()
   readonly ownerGroup: string;
 
   @ApiProperty({

--- a/src/common/schemas/ownable.schema.ts
+++ b/src/common/schemas/ownable.schema.ts
@@ -11,6 +11,7 @@ export class OwnableClass extends QueryableClass {
   @Prop({
     type: String,
     index: true,
+    required: true,
   })
   ownerGroup: string;
 

--- a/src/common/schemas/ownable.schema.ts
+++ b/src/common/schemas/ownable.schema.ts
@@ -11,7 +11,6 @@ export class OwnableClass extends QueryableClass {
   @Prop({
     type: String,
     index: true,
-    required: true,
   })
   ownerGroup: string;
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
onwerGroup should not contain empty string

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Enforce non-empty ownerGroup ownership metadata across DTO and schema definitions.

Bug Fixes:
- Prevent ownerGroup from being omitted or provided as an empty string in ownable resources.

Enhancements:
- Make the ownerGroup field required in the persistence schema to ensure consistent ownership information.