### PR TITLE
fix: allow retrieve of public and owned ds

### DIFF
--- a/src/jobs/dto/create-job.dto.ts
+++ b/src/jobs/dto/create-job.dto.ts
@@ -20,19 +20,19 @@ export class CreateJobDto {
    */
   @IsString()
   @IsOptional()
-  readonly ownerUser?: string;
+  ownerUser?: string;
 
   /**
    * Group that this job belongs to. Applicable only if requesting user has adequate permissions level.
    */
   @IsString()
   @IsOptional()
-  readonly ownerGroup?: string;
+  ownerGroup?: string;
 
   /**
    * Email to contact regarding this job. If the job is submitted anonymously, an email has to be provided.
    */
   @IsEmail()
   @IsOptional()
-  readonly contactEmail?: string;
+  contactEmail?: string;
 }

--- a/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
+++ b/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
@@ -15,6 +15,12 @@ import { UsersService } from "src/users/users.service";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { JobConfigService } from "src/config/job-config/jobconfig.service";
 import { JobsControllerUtils } from "src/jobs/jobs.controller.utils";
+import { omit } from "lodash";
+import { CreateJobAuth } from "../types/jobs-auth.enum";
+import { DatasetDocument } from "src/datasets/schemas/dataset.schema";
+import { ConfigService } from "@nestjs/config";
+import { AccessGroupsType } from "src/config/configuration";
+import { FilterQuery } from "mongoose";
 
 interface JobParams {
   datasetList: DatasetListDto[];
@@ -29,12 +35,18 @@ interface JobParams {
  */
 @Injectable()
 export class CreateJobV3MappingInterceptor implements NestInterceptor {
+  adminUsers: Set<string>;
   constructor(
     @Inject(UsersService) readonly usersService: UsersService,
     @Inject(DatasetsService) readonly datasetsService: DatasetsService,
     @Inject(JobConfigService) readonly jobConfigService: JobConfigService,
+    @Inject(ConfigService) readonly configService: ConfigService,
     private readonly jobsControllerUtils: JobsControllerUtils,
-  ) {}
+  ) {
+    this.adminUsers = new Set(
+      this.configService.get<AccessGroupsType>("accessGroups")?.admin ?? [],
+    );
+  }
 
   async intercept(
     context: ExecutionContext,
@@ -47,108 +59,115 @@ export class CreateJobV3MappingInterceptor implements NestInterceptor {
     const jobConfig = this.jobsControllerUtils.getJobTypeConfiguration(
       dtoV3.type,
     );
-    if (jobConfig) {
-      // ensure datasetList comes from a top level field in the dto and not from jobParams
-      if (
-        dtoV3.jobParams &&
-        Object.keys(dtoV3.jobParams).includes("datasetList")
-      ) {
-        delete dtoV3.jobParams.datasetList;
-      }
-      const jobParams: JobParams = {
-        datasetList: dtoV3.datasetList ?? [],
-        ...dtoV3.jobParams,
-      };
-      // to preserve the executionTime field, if provided, add it to jobParams
-      if (dtoV3.executionTime) {
-        jobParams.executionTime = dtoV3.executionTime;
-      }
-      // to preserve the jobStatusMessage field, if provided, add it to jobParams
-      if (dtoV3.jobStatusMessage) {
-        jobParams.jobStatusMessage = dtoV3.jobStatusMessage;
-      }
-      // assign jobParams and contactEmail to the new body
-      let newBody: CreateJobDto = {
-        type: dtoV3.type,
-        jobParams: jobParams,
-      };
-      if (dtoV3.emailJobInitiator || requestUser) {
-        newBody = {
-          ...newBody,
-          contactEmail: dtoV3.emailJobInitiator ?? requestUser.email,
-        };
-      }
-      // ensure compatibility with the FE, which provides the username field in jobParams
-      // and compatibility with v4 which requires ownerUser in the dto of jobs created by normal users
-      // if username is not provided, use the username from the request user
-      let jobUser: JWTUser | null = null;
-      if (Object.keys(jobParams).includes("username")) {
-        const jwtUser = await this.usersService.findByUsername2JWTUser(
-          jobParams.username as string,
-        );
-        jobUser = jwtUser;
-      } else if (requestUser) {
-        jobUser = requestUser;
-      }
-      if (jobUser) {
-        newBody = {
-          ...newBody,
-          ownerUser: jobUser?.username,
-        };
-      }
-      // ensure compatibility with v4 which requires ownerGroup in the dto of jobs created by normal user
-      if (Object.keys(jobParams).includes("ownerGroup")) {
-        newBody = {
-          ...newBody,
-          ownerGroup: jobParams.ownerGroup as string,
-        };
-      } else if (Array.isArray(jobParams.datasetList)) {
-        if (jobConfig.create.auth === "#datasetAccess") {
-          let isAllPublished = true;
-          const datasetGroups = [];
-          for (const datasetDto of jobParams.datasetList) {
-            if (datasetDto.pid) {
-              const dataset = await this.datasetsService.findOne({
-                where: { pid: datasetDto.pid },
-              });
-              isAllPublished =
-                isAllPublished && (dataset?.isPublished ?? false);
-              datasetGroups.push([
-                ...(dataset?.accessGroups ?? []),
-                dataset?.ownerGroup,
-              ]);
-            }
-          }
-          const commonGroups = intersection([
-            ...datasetGroups,
-            jobUser?.currentGroups ?? [],
-          ]);
-          if (isAllPublished) {
-            newBody = {
-              ...newBody,
-              ownerGroup: jobUser?.currentGroups?.[0],
-            };
-          } else if (commonGroups.length > 0) {
-            newBody = {
-              ...newBody,
-              ownerGroup: commonGroups[0],
-            };
-          }
-        } else if (jobConfig.create.auth !== "#datasetPublic") {
-          if (jobParams.datasetList.length > 0) {
-            const dataset = await this.datasetsService.findOne({
-              where: { pid: jobParams.datasetList[0].pid },
-            });
-            newBody = {
-              ...newBody,
-              ownerGroup: dataset?.ownerGroup,
-            };
-          }
-        }
-      }
-      request.body = newBody;
-    }
+    if (!jobConfig) return next.handle();
+    const jobParams: JobParams = this.buildJobParams(dtoV3);
+    const newBody: CreateJobDto = {
+      type: dtoV3.type,
+      jobParams: jobParams,
+    };
+    if (dtoV3.emailJobInitiator || requestUser)
+      newBody.contactEmail = dtoV3.emailJobInitiator ?? requestUser.email;
+    // ensure compatibility with the FE, which provides the username field in jobParams
+    // and compatibility with v4 which requires ownerUser in the dto of jobs created by normal users
+    // if username is not provided, use the username from the request user
+    const jobUser: JWTUser | null = await this.buildOwnerUser(
+      jobParams,
+      requestUser,
+    );
+    if (jobUser) newBody.ownerUser = jobUser?.username;
+    // ensure compatibility with v4 which requires ownerGroup in the dto of jobs created by normal user
+    const ownerGroup = await this.buildOwnerGroup(
+      jobParams,
+      jobConfig.create.auth,
+      jobUser?.currentGroups ?? null,
+    );
+    if (ownerGroup) newBody.ownerGroup = ownerGroup;
+    request.body = newBody;
     return next.handle();
+  }
+
+  private async buildOwnerUser(jobParams: JobParams, requestUser: JWTUser) {
+    if ("username" in jobParams) {
+      const jwtUser = await this.usersService.findByUsername2JWTUser(
+        jobParams.username as string,
+      );
+      return jwtUser;
+    }
+    if (requestUser) return requestUser;
+    return null;
+  }
+
+  private buildJobParams(dtoV3: CreateJobDtoV3) {
+    // ensure datasetList comes from a top level field in the dto and not from jobParams
+    const jobParams: JobParams = {
+      ...omit(dtoV3.jobParams ?? {}, ["datasetList"]),
+      datasetList: dtoV3.datasetList ?? [],
+    };
+    // to preserve the executionTime field, if provided, add it to jobParams
+    if (dtoV3.executionTime) jobParams.executionTime = dtoV3.executionTime;
+    // to preserve the jobStatusMessage field, if provided, add it to jobParams
+    if (dtoV3.jobStatusMessage)
+      jobParams.jobStatusMessage = dtoV3.jobStatusMessage;
+    return jobParams;
+  }
+
+  private async buildOwnerGroup(
+    jobParams: JobParams,
+    jobConfigCreateAuth: string,
+    jobUserCurrentGroups: string[] | null,
+  ): Promise<string | undefined> {
+    if ("ownerGroup" in jobParams) return jobParams.ownerGroup as string;
+    const datasetList = jobParams.datasetList;
+    if (datasetList.length === 0) return undefined;
+    const datasetPid = datasetList.map((datasetDto) => datasetDto.pid);
+    if (jobConfigCreateAuth === CreateJobAuth.DatasetPublic) return undefined;
+    const datasetsFilter: FilterQuery<DatasetDocument> = {
+      where: { pid: { $in: datasetPid } },
+      fields: ["ownerGroup"],
+    };
+    const isAdmin = jobUserCurrentGroups?.some((group) =>
+      this.adminUsers.has(group),
+    );
+    if (jobConfigCreateAuth === CreateJobAuth.DatasetOwner && !isAdmin)
+      datasetsFilter.where.ownerGroup = { $in: jobUserCurrentGroups ?? [] };
+    if (jobConfigCreateAuth === CreateJobAuth.DatasetAccess) {
+      datasetsFilter.where.$or = [
+        { isPublished: true },
+        { ownerGroup: { $in: jobUserCurrentGroups ?? [] } },
+        { accessGroups: { $in: jobUserCurrentGroups ?? [] } },
+      ];
+      datasetsFilter.fields.push("isPublished", "accessGroups");
+    }
+    const datasets = await this.datasetsService.findAll(datasetsFilter);
+    if (datasets.length !== datasetList.length) return undefined;
+    if (datasets.length === 0) return undefined;
+    if (
+      jobConfigCreateAuth === CreateJobAuth.DatasetAccess &&
+      datasets.every((dataset) => dataset?.isPublished)
+    )
+      return jobUserCurrentGroups?.[0];
+    if (jobConfigCreateAuth === CreateJobAuth.DatasetOwner && isAdmin)
+      return datasets[0].ownerGroup;
+    const commonGroups = this.buildCommonGroups(datasets, jobUserCurrentGroups);
+    if (commonGroups.length > 0) return commonGroups[0];
+    return undefined;
+  }
+
+  private buildCommonGroups(
+    datasets: DatasetDocument[],
+    jobUserCurrentGroups: string[] | null,
+  ): string[] {
+    const datasetGroups = datasets
+      .filter((dataset) => !dataset.isPublished)
+      .map((dataset) => [
+        ...(dataset?.accessGroups ?? []),
+        dataset?.ownerGroup,
+      ]);
+    const commonGroups = intersection([
+      ...datasetGroups,
+      jobUserCurrentGroups ?? [],
+    ]);
+    return commonGroups;
   }
 }
 

--- a/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
+++ b/src/jobs/interceptors/create-job-v3-mapping.interceptor.ts
@@ -146,35 +146,9 @@ export class CreateJobV3MappingInterceptor implements NestInterceptor {
       datasets.every((dataset) => dataset?.isPublished)
     )
       return jobUserCurrentGroups?.[0];
-    if (jobConfigCreateAuth === CreateJobAuth.DatasetOwner && isAdmin)
-      return datasets[0].ownerGroup;
-    const commonGroups = this.buildCommonGroups(datasets, jobUserCurrentGroups);
-    if (commonGroups.length > 0) return commonGroups[0];
-    return undefined;
+    const nonPublishedDatasets = datasets.filter(
+      (dataset) => !dataset?.isPublished,
+    );
+    return nonPublishedDatasets[0].ownerGroup;
   }
-
-  private buildCommonGroups(
-    datasets: DatasetDocument[],
-    jobUserCurrentGroups: string[] | null,
-  ): string[] {
-    const datasetGroups = datasets
-      .filter((dataset) => !dataset.isPublished)
-      .map((dataset) => [
-        ...(dataset?.accessGroups ?? []),
-        dataset?.ownerGroup,
-      ]);
-    const commonGroups = intersection([
-      ...datasetGroups,
-      jobUserCurrentGroups ?? [],
-    ]);
-    return commonGroups;
-  }
-}
-
-function intersection<T>(arrays: T[][]): T[] {
-  if (arrays.length === 0) return [];
-  return arrays.reduce((a, b) => {
-    const setB = new Set(b);
-    return a.filter((x) => setB.has(x));
-  });
 }

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -9,6 +9,8 @@ let accessTokenAdminIngestor = null,
 
   datasetPid1 = null,
   datasetPid2 = null,
+  datasetPid3 = null,
+  datasetPid4 = null,
   datablockId1 = null,
   datablockId2 = null,
   datablockId3 = null,
@@ -42,6 +44,22 @@ const dataset2 = {
   isPublished: true,
   ownerGroup: "group5",
   accessGroups: ["group1"],
+};
+
+const dataset3 = {
+  ...TestData.RawCorrect,
+  isPublished: false,
+  ownerGroup: "group1",
+  accessGroups: [],
+};
+
+// Published dataset with no accessGroups: used to verify that published datasets
+// are excluded from the #datasetAccess group intersection (they don't block access).
+const dataset4 = {
+  ...TestData.RawCorrect,
+  isPublished: true,
+  ownerGroup: "group1",
+  accessGroups: [],
 };
 
 const jobOwnerAccess = {
@@ -118,6 +136,39 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("isPublished").and.equal(true);
         res.body.should.have.property("pid").and.be.string;
         datasetPid2 = res.body["pid"];
+      });
+  });
+
+  it("0026: Add dataset 4 as Admin Ingestor", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset4)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.equal("group1");
+        res.body.should.have.property("isPublished").and.equal(true);
+        res.body.should.have.property("pid").and.be.string;
+        datasetPid4 = res.body["pid"];
+      });
+  });
+
+  it("0025: Add dataset 3 as Admin Ingestor", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset3)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.equal("group1");
+        res.body.should.have.property("type").and.equal("raw");
+        res.body.should.have.property("isPublished").and.equal(false);
+        res.body.should.have.property("pid").and.be.string;
+        datasetPid3 = res.body["pid"];
       });
   });
 
@@ -1151,8 +1202,32 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("message")
           .and.be.equal(
-            "Invalid new job. User owning the job should match user logged in.",
+            "Invalid new job. Owner group should be specified.",
           );
+      });
+  });
+
+  it("0365: Add via /api/v3 an owner_access job with datasets from different owner groups, which should fail", async () => {
+    const newJob = {
+      ...jobOwnerAccess,
+      datasetList: [
+        { pid: datasetPid1, files: [] },
+        { pid: datasetPid3, files: [] },
+      ],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal("Invalid new job. Owner group should be specified.");
       });
   });
 
@@ -1243,6 +1318,37 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("id");
+      });
+  });
+
+  it("0415: Add via /api/v3 a dataset_access job as user5.1 with a locked published dataset and an owned non-published dataset, which should succeed because published datasets are excluded from the group intersection", async () => {
+    // dataset4: published, ownerGroup=group1, accessGroups=[] — "locked" published dataset
+    // dataset1: non-published, ownerGroup=group5, accessGroups=[group1] — user5.1 owns via group5
+    // Old behaviour (published included in intersection):
+    //   intersection([group1], [group5, group1], [group5]) = [] → no ownerGroup → 422
+    // New behaviour (published excluded):
+    //   intersection([group5, group1], [group5]) = [group5] → ownerGroup=group5 → 201
+    const newJob = {
+      ...jobDatasetAccess,
+      datasetList: [
+        { pid: datasetPid4, files: [] },
+        { pid: datasetPid1, files: [] },
+      ],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("id");
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have
+          .property("datasetList")
+          .that.deep.equals(newJob.datasetList);
       });
   });
 

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -1221,7 +1221,7 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       .send(newJob)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenUser51}` })
-      .expect(TestData.BadRequestStatusCode)
+      .expect(TestData.AccessForbiddenStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The computation of job.ownerGroup, error thrown if empty, suffered from having
jobs trying to access public and owned datasets because public datasets might
be not owned by the user submitting the job. It also includes a refactor to
simplify maintenance as well as more verbose error messages

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* public datasets excluded from intersection computation

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* refactor
* more verbose error messages/cleaner error codes
* speed up dataset retrieval with a findAll rather than looping on all datasets

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Adjust job creation mapping and validation to correctly handle public and owned datasets while improving ownership checks and error reporting.

Bug Fixes:
- Exclude published datasets from group intersection when resolving ownerGroup for #datasetAccess jobs so mixed public and owned datasets can be used.
- Ensure ownerGroup resolution for #datasetOwner jobs validates that all datasets share the same owner group and fails with a clear error otherwise.
- Align HTTP status codes for invalid ownership, group membership, and anonymous job email validation with semantic 403 and 422 responses instead of generic 400s.

Enhancements:
- Refactor the v3 job creation interceptor into smaller helpers for building job parameters, owner user, and owner group.
- Relax immutability on CreateJobDto ownership fields so they can be populated server-side before persistence.
- Improve error messages around job ownership and group validation for clearer diagnostics.

Tests:
- Extend job authorization tests to cover mixed public and owned datasets, differing owner groups, and updated error status codes and messages.
- Add new test datasets to verify published datasets do not block dataset access jobs via group intersection.