### PR TITLE
fix: use $text and $search for published data search and use correct count access check

### DIFF
--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -18,7 +18,7 @@ class AppendFieldsToFilterPipe implements PipeTransform {
     const filter = value.filter ?? {};
 
     if ("text" in value.fields) {
-      const search = value.fields.text;
+      const search = String(value.fields.text ?? "").trim();
       delete value.fields.text;
       (value.fields as FilterQuery<PublishedDataDocument>).$text = {
         $search: search,

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -16,6 +16,15 @@ class AppendFieldsToFilterPipe implements PipeTransform {
   }) {
     if (isEmpty(value.fields)) return value;
     const filter = value.filter ?? {};
+
+    if ("text" in value.fields) {
+      const search = value.fields.text;
+      delete value.fields.text;
+      (value.fields as FilterQuery<PublishedDataDocument>).$text = {
+        $search: search,
+      };
+    }
+
     if (isEmpty(filter.where)) filter.where = value.fields;
     else filter.where = { $and: [value.fields, filter.where] };
     return { ...value, filter };

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -17,12 +17,14 @@ class AppendFieldsToFilterPipe implements PipeTransform {
     if (isEmpty(value.fields)) return value;
     const filter = value.filter ?? {};
 
-    if ("text" in value.fields) {
+    if (value.fields["text"]) {
       const search = String(value.fields.text ?? "").trim();
       delete value.fields.text;
-      (value.fields as FilterQuery<PublishedDataDocument>).$text = {
-        $search: search,
-      };
+      if (search) {
+        (value.fields as FilterQuery<PublishedDataDocument>).$text = {
+          $search: search,
+        };
+      }
     }
 
     if (isEmpty(filter.where)) filter.where = value.fields;

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -20,11 +20,9 @@ class AppendFieldsToFilterPipe implements PipeTransform {
     if (value.fields["text"]) {
       const search = String(value.fields.text ?? "").trim();
       delete value.fields.text;
-      if (search) {
-        (value.fields as FilterQuery<PublishedDataDocument>).$text = {
-          $search: search,
-        };
-      }
+      (value.fields as FilterQuery<PublishedDataDocument>).$text = {
+        $search: search,
+      };
     }
 
     if (isEmpty(filter.where)) filter.where = value.fields;

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -189,7 +189,7 @@ export class PublishedDataV4Controller {
   ) {
     const jsonFilters: IPublishedDataFilters = filter?.filter ?? {};
 
-    const ability = this.caslAbilityFactory.datasetInstanceAccess(
+    const ability = this.caslAbilityFactory.publishedDataInstanceAccess(
       request.user as JWTUser,
     );
 

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -108,6 +108,35 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       });
   });
 
+  it("0016: should return results when searching published data by text", async () => {
+    const fields = { text: "published" };
+    const limits = { limit: 25, skip: 0, order: "createdAt:desc" };
+
+    return request(appUrl)
+      .get(
+        `/api/v4/PublishedData?fields=${encodeURIComponent(
+          JSON.stringify(fields),
+        )}&limits=${encodeURIComponent(JSON.stringify(limits))}`,
+      )
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.be.instanceof(Array);
+        res.body.length.should.be.greaterThan(0);
+
+        res.body
+          .some((item) => {
+            const title = (item.title || "").toLowerCase();
+            const abstract = (item.abstract || "").toLowerCase();
+            return (
+              title.includes("published") || abstract.includes("published")
+            );
+          })
+          .should.equal(true);
+      });
+  });
+
   it("0020: should not be able to fetch this new published data in private state anonymously", async () => {
     return request(appUrl)
       .get("/api/v4/PublishedData/" + doi)


### PR DESCRIPTION
## Description
This PR updates the `AppendFieldsToFilterPipe` used for published data filter to use $text and $search so the search would work and uses correct count access check.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Bug Fixes:
- Ensure published data search requests using a `text` field correctly map to `$text` / `$search` queries.