### PR TITLE
fix(origdatablocks): replace JS map/reduce with aggregation in updateDatasetSizeAndFiles

### DIFF
--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -22,6 +22,7 @@ class CaslAbilityFactoryMock {}
 describe("OrigDatablocksController", () => {
   let controller: OrigDatablocksController;
   let origDatablocksService: OrigDatablocksServiceMock;
+  let datasetsService: DatasetsServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -37,10 +38,10 @@ describe("OrigDatablocksController", () => {
     controller = module.get<OrigDatablocksController>(OrigDatablocksController);
     origDatablocksService = module.get<OrigDatablocksService>(
       OrigDatablocksService,
-    );
-
-    // Mock internal methods to isolate the handler under test
-    controller["updateDatasetSizeAndFiles"] = jest.fn();
+    ) as unknown as OrigDatablocksServiceMock;
+    datasetsService = module.get<DatasetsService>(
+      DatasetsService,
+    ) as unknown as DatasetsServiceMock;
   });
 
   it("should be defined", () => {
@@ -57,6 +58,11 @@ describe("OrigDatablocksController", () => {
       updatedAt: new Date(Date.now() - 1000),
       datasetId: "ds1",
     };
+
+    beforeEach(() => {
+      // Isolate the update handler from the side-effect helper
+      controller["updateDatasetSizeAndFiles"] = jest.fn();
+    });
 
     it("should throw NotFoundException if datablock not found before update", async () => {
       origDatablocksService.findOne.mockResolvedValue(null);
@@ -165,61 +171,35 @@ describe("OrigDatablocksController", () => {
   });
 
   describe("updateDatasetSizeAndFiles", () => {
-    let controllerWithRealMethod: OrigDatablocksController;
-    let realOrigDatablocksService: OrigDatablocksServiceMock;
-    let realDatasetsService: DatasetsServiceMock;
-
-    beforeEach(async () => {
-      const module: TestingModule = await Test.createTestingModule({
-        controllers: [OrigDatablocksController],
-        imports: [ConfigModule],
-        providers: [
-          {
-            provide: OrigDatablocksService,
-            useClass: OrigDatablocksServiceMock,
-          },
-          { provide: DatasetsService, useClass: DatasetsServiceMock },
-          { provide: CaslAbilityFactory, useClass: CaslAbilityFactoryMock },
-        ],
-      }).compile();
-
-      controllerWithRealMethod = module.get<OrigDatablocksController>(
-        OrigDatablocksController,
-      );
-      realOrigDatablocksService = module.get<OrigDatablocksService>(
-        OrigDatablocksService,
-      ) as unknown as OrigDatablocksServiceMock;
-      realDatasetsService = module.get<DatasetsService>(
-        DatasetsService,
-      ) as unknown as DatasetsServiceMock;
-    });
-
     it("should use aggregateSizeAndFileCount and update the dataset", async () => {
-      realOrigDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
+      origDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
         size: 2000,
         numberOfFiles: 5,
       });
 
-      await controllerWithRealMethod["updateDatasetSizeAndFiles"]("testPid");
+      await controller["updateDatasetSizeAndFiles"]("testPid");
 
       expect(
-        realOrigDatablocksService.aggregateSizeAndFileCount,
+        origDatablocksService.aggregateSizeAndFileCount,
       ).toHaveBeenCalledWith("testPid");
-      expect(realDatasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
+      expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
         "testPid",
-        { size: 2000, numberOfFiles: 5 },
+        {
+          size: 2000,
+          numberOfFiles: 5,
+        },
       );
     });
 
     it("should propagate zero totals when no origdatablocks exist", async () => {
-      realOrigDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
+      origDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
         size: 0,
         numberOfFiles: 0,
       });
 
-      await controllerWithRealMethod["updateDatasetSizeAndFiles"]("emptyPid");
+      await controller["updateDatasetSizeAndFiles"]("emptyPid");
 
-      expect(realDatasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
+      expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
         "emptyPid",
         { size: 0, numberOfFiles: 0 },
       );

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -10,9 +10,12 @@ import { Request } from "express";
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
   findByIdAndUpdate = jest.fn();
+  aggregateSizeAndFileCount = jest.fn();
 }
 
-class DatasetsServiceMock {}
+class DatasetsServiceMock {
+  findByIdAndUpdate = jest.fn();
+}
 
 class CaslAbilityFactoryMock {}
 
@@ -36,7 +39,7 @@ describe("OrigDatablocksController", () => {
       OrigDatablocksService,
     );
 
-    // Mock internal methods
+    // Mock internal methods to isolate the handler under test
     controller["updateDatasetSizeAndFiles"] = jest.fn();
   });
 
@@ -158,6 +161,68 @@ describe("OrigDatablocksController", () => {
           "ds1",
         );
       });
+    });
+  });
+
+  describe("updateDatasetSizeAndFiles", () => {
+    let controllerWithRealMethod: OrigDatablocksController;
+    let realOrigDatablocksService: OrigDatablocksServiceMock;
+    let realDatasetsService: DatasetsServiceMock;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [OrigDatablocksController],
+        imports: [ConfigModule],
+        providers: [
+          {
+            provide: OrigDatablocksService,
+            useClass: OrigDatablocksServiceMock,
+          },
+          { provide: DatasetsService, useClass: DatasetsServiceMock },
+          { provide: CaslAbilityFactory, useClass: CaslAbilityFactoryMock },
+        ],
+      }).compile();
+
+      controllerWithRealMethod = module.get<OrigDatablocksController>(
+        OrigDatablocksController,
+      );
+      realOrigDatablocksService = module.get<OrigDatablocksService>(
+        OrigDatablocksService,
+      ) as unknown as OrigDatablocksServiceMock;
+      realDatasetsService = module.get<DatasetsService>(
+        DatasetsService,
+      ) as unknown as DatasetsServiceMock;
+    });
+
+    it("should use aggregateSizeAndFileCount and update the dataset", async () => {
+      realOrigDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
+        size: 2000,
+        numberOfFiles: 5,
+      });
+
+      await controllerWithRealMethod["updateDatasetSizeAndFiles"]("testPid");
+
+      expect(
+        realOrigDatablocksService.aggregateSizeAndFileCount,
+      ).toHaveBeenCalledWith("testPid");
+      expect(realDatasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
+        "testPid",
+        { size: 2000, numberOfFiles: 5 },
+      );
+    });
+
+    it("should propagate zero totals when no origdatablocks exist", async () => {
+      realOrigDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
+        size: 0,
+        numberOfFiles: 0,
+      });
+
+      await controllerWithRealMethod["updateDatasetSizeAndFiles"]("emptyPid");
+
+      expect(realDatasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
+        "emptyPid",
+        { size: 0, numberOfFiles: 0 },
+      );
     });
   });
 });

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -40,7 +40,6 @@ import { IOrigDatablockFields } from "./interfaces/origdatablocks.interface";
 import { plainToInstance } from "class-transformer";
 import { validate, ValidationError } from "class-validator";
 import { DatasetsService } from "src/datasets/datasets.service";
-import { PartialUpdateDatasetDto } from "src/datasets/dto/update-dataset.dto";
 import { filterDescription, filterExample, parseDate } from "src/common/utils";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
@@ -213,22 +212,10 @@ export class OrigDatablocksController {
   }
 
   async updateDatasetSizeAndFiles(pid: string) {
-    // updates datasets size
-    const parsedFilters: IFilters<OrigDatablockDocument, IOrigDatablockFields> =
-      { where: { datasetId: pid } };
-    const datasetOrigdatablocks =
-      await this.origDatablocksService.findAll(parsedFilters);
+    const { size, numberOfFiles } =
+      await this.origDatablocksService.aggregateSizeAndFileCount(pid);
 
-    const updateDatasetDto: PartialUpdateDatasetDto = {
-      size: datasetOrigdatablocks
-        .map((od) => od.size)
-        .reduce((ps, a) => ps + a, 0),
-      numberOfFiles: datasetOrigdatablocks
-        .map((od) => od.dataFileList.length)
-        .reduce((ps, a) => ps + a, 0),
-    };
-
-    await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto);
+    await this.datasetsService.findByIdAndUpdate(pid, { size, numberOfFiles });
   }
 
   @UseGuards(PoliciesGuard)

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -41,7 +41,6 @@ import { IOrigDatablockFields } from "./interfaces/origdatablocks.interface";
 import { plainToInstance } from "class-transformer";
 import { validate, ValidationError } from "class-validator";
 import { DatasetsService } from "src/datasets/datasets.service";
-import { PartialUpdateDatasetDto } from "src/datasets/dto/update-dataset.dto";
 import { filterDescription, filterExample, parseDate } from "src/common/utils";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
@@ -216,22 +215,10 @@ export class OrigDatablocksController {
   }
 
   async updateDatasetSizeAndFiles(pid: string) {
-    // updates datasets size
-    const parsedFilters: IFilters<OrigDatablockDocument, IOrigDatablockFields> =
-      { where: { datasetId: pid } };
-    const datasetOrigdatablocks =
-      await this.origDatablocksService.findAll(parsedFilters);
+    const { size, numberOfFiles } =
+      await this.origDatablocksService.aggregateSizeAndFileCount(pid);
 
-    const updateDatasetDto: PartialUpdateDatasetDto = {
-      size: datasetOrigdatablocks
-        .map((od) => od.size)
-        .reduce((ps, a) => ps + a, 0),
-      numberOfFiles: datasetOrigdatablocks
-        .map((od) => od.dataFileList.length)
-        .reduce((ps, a) => ps + a, 0),
-    };
-
-    await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto);
+    await this.datasetsService.findByIdAndUpdate(pid, { size, numberOfFiles });
   }
 
   @UseGuards(PoliciesGuard)

--- a/src/origdatablocks/origdatablocks.service.spec.ts
+++ b/src/origdatablocks/origdatablocks.service.spec.ts
@@ -47,6 +47,7 @@ describe("OrigdatablocksService", () => {
             find: jest.fn(),
             create: jest.fn(),
             exec: jest.fn(),
+            aggregate: jest.fn(),
           },
         },
       ],
@@ -60,5 +61,45 @@ describe("OrigdatablocksService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("aggregateSizeAndFileCount", () => {
+    it("should return summed size and file count from origdatablocks", async () => {
+      (model.aggregate as jest.Mock).mockReturnValue({
+        exec: jest
+          .fn()
+          .mockResolvedValue([{ _id: null, size: 5000, numberOfFiles: 3 }]),
+      });
+
+      const result = await service.aggregateSizeAndFileCount("testPid");
+
+      expect(result).toEqual({ size: 5000, numberOfFiles: 3 });
+    });
+
+    it("should return zeros when no origdatablocks exist for the dataset", async () => {
+      (model.aggregate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.aggregateSizeAndFileCount("emptyPid");
+
+      expect(result).toEqual({ size: 0, numberOfFiles: 0 });
+    });
+
+    it("should match on the given datasetId", async () => {
+      (model.aggregate as jest.Mock).mockReturnValue({
+        exec: jest
+          .fn()
+          .mockResolvedValue([{ _id: null, size: 0, numberOfFiles: 0 }]),
+      });
+
+      await service.aggregateSizeAndFileCount("ds123");
+
+      expect(model.aggregate).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ $match: { datasetId: "ds123" } }),
+        ]),
+      );
+    });
   });
 });

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -393,7 +393,9 @@ export class OrigDatablocksService {
           $group: {
             _id: null,
             size: { $sum: "$size" },
-            numberOfFiles: { $sum: { $size: "$dataFileList" } },
+            numberOfFiles: {
+              $sum: { $size: { $ifNull: ["$dataFileList", []] } },
+            },
           },
         },
       ])

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -398,6 +398,8 @@ export class OrigDatablocksService {
         },
       ])
       .exec();
-    return result ?? { size: 0, numberOfFiles: 0 };
+    return result
+      ? { size: result.size, numberOfFiles: result.numberOfFiles }
+      : { size: 0, numberOfFiles: 0 };
   }
 }

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -382,4 +382,22 @@ export class OrigDatablocksService {
       .exec();
     return { count };
   }
+
+  async aggregateSizeAndFileCount(
+    datasetId: string,
+  ): Promise<{ size: number; numberOfFiles: number }> {
+    const [result] = await this.origDatablockModel
+      .aggregate<{ size: number; numberOfFiles: number }>([
+        { $match: { datasetId } },
+        {
+          $group: {
+            _id: null,
+            size: { $sum: "$size" },
+            numberOfFiles: { $sum: { $size: "$dataFileList" } },
+          },
+        },
+      ])
+      .exec();
+    return result ?? { size: 0, numberOfFiles: 0 };
+  }
 }


### PR DESCRIPTION
## Description

Replaces the `updateDatasetSizeAndFiles` helper in `OrigDatablocksController` with a single MongoDB `$group` aggregation.

## Motivation

### Correctness

The previous implementation called `findAll` with no `limits`, which caused `parseLimitFilters` to apply its default of `limit: 100`. For any dataset backed by more than 100 origdatablocks, only the first 100 were included in the sum, silently understating `size` and `numberOfFiles` on the dataset record. This bug is triggered on every origdatablock create, update, and delete.

The aggregation has no such cap -- it processes every matching document.

### Performance

Beyond correctness, the previous approach fetched full origdatablock documents into application memory, including their complete `dataFileList` arrays, and computed the totals in JavaScript. The replacement pushes both calculations to the database using `$sum` and returns only the two scalars needed.

Related upstream issues: #2250 (double-counting of size/files when creating datablocks) and #1688 (size reset to 0 after dataset PATCH) both involve the same size-tracking logic.

## Changes:

* `src/origdatablocks/origdatablocks.service.ts` -- new `aggregateSizeAndFileCount(datasetId)` method using `$match` + `$group`; `dataFileList` wrapped in `$ifNull` so documents with a missing or null field return 0 rather than erroring; returns `{ size, numberOfFiles }`, stripping the internal `_id: null` field from the `$group` result
* `src/origdatablocks/origdatablocks.controller.ts` -- `updateDatasetSizeAndFiles` reduced to a single call to the new service method; unused `PartialUpdateDatasetDto` import removed

## Tests included

- [x] Included for each change/fix?
- [x] Passing?

Three new service-level tests for `aggregateSizeAndFileCount`:
* returns summed totals when origdatablocks exist
* returns `{ size: 0, numberOfFiles: 0 }` when none exist for the dataset
* passes the correct `datasetId` to the `$match` stage

Two new controller-level tests for `updateDatasetSizeAndFiles`:
* verifies the aggregation result flows through to `datasetsService.findByIdAndUpdate`
* verifies zero totals are propagated correctly

## Documentation
- [x] swagger documentation updated (required for API changes) -- n/a, no API change
- [x] official documentation updated -- n/a, internal implementation change only

## Summary by Sourcery

Replace dataset size and file count recalculation for origdatablocks with a MongoDB aggregation-based implementation to ensure correct totals for all datasets.

Bug Fixes:
- Fix dataset size and numberOfFiles being understated when more than 100 origdatablocks exist by eliminating the implicit query limit during recalculation.

Enhancements:
- Introduce an aggregateSizeAndFileCount service method that computes dataset size and file count in MongoDB using a $group aggregation and handles missing dataFileList fields.
- Simplify OrigDatablocksController.updateDatasetSizeAndFiles to delegate to the new aggregation-based service method and update the dataset in a single step.

Tests:
- Add unit tests for aggregateSizeAndFileCount covering normal aggregation, empty results, and correct datasetId matching in the aggregation pipeline.
- Add controller tests to verify updateDatasetSizeAndFiles uses the aggregation results to update datasets, including propagation of zero totals.