### PR TITLE
fix(Jobs): fix jobs fullfacet access with text

### DIFF
--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -195,9 +195,16 @@ export class JobsService {
       JobDocument,
       IJobFields
     >(this.jobModel, "id", fields, facets);
-    pipeline.unshift({
-      $match: access,
-    });
+
+    const firstStage = pipeline[0] as { $match: Record<string, unknown> };
+
+    if (fields["text"]) {
+      pipeline.splice(0, 1, { $match: { $and: [access, firstStage.$match] } });
+    } else {
+      pipeline.unshift({
+        $match: access,
+      });
+    }
     return await this.jobModel.aggregate(pipeline).exec();
   }
 


### PR DESCRIPTION
## Description
This PR places a check if the pipeline contains a text and merges access to the text match so MongoDB accepts the pipeline and access is still enforced.

## Motivation
When searching in Jobs table, the fullfacet endpoint throws an error: 

"{status: 400, message: "$match with $text is only allowed as the first pipeline stage"}
message
: 
"$match with $text is only allowed as the first pipeline stage"
status
: 
400"

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Bug Fixes:
- Fix jobs fullfacet aggregation error when combining access filtering with $text search by correctly positioning and merging the $match stage.