### PR TITLE
feat(jwt-auth): throw 401 session expired error for expired token

### DIFF
--- a/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,86 @@
+import { ExecutionContext, UnauthorizedException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Request } from "express";
+import { JwtAuthGuard } from "./jwt-auth.guard";
+
+describe("JwtAuthGuard", () => {
+  let jwtAuthGuard: JwtAuthGuard;
+
+  const createExecutionContext = (request: Request): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    }) as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JwtAuthGuard, Reflector],
+    }).compile();
+
+    jwtAuthGuard = module.get(JwtAuthGuard);
+  });
+
+  it("should be defined", () => {
+    expect(jwtAuthGuard).toBeDefined();
+  });
+
+  it("should set authorization header from access token query param (getRequest)", () => {
+    const mockRequest: Request = {
+      query: { access_token: "Bearer query-token" },
+      headers: {},
+    } as unknown as Request;
+
+    const mockExecutionContext = createExecutionContext(mockRequest);
+    const request = jwtAuthGuard.getRequest(mockExecutionContext);
+
+    expect(request).toBe(mockRequest);
+    expect(mockRequest.headers.authorization).toBe("Bearer query-token");
+  });
+
+  it("should preserve existing authorization header over access token query param", () => {
+    const mockRequest: Request = {
+      query: { access_token: "Bearer query-token" },
+      headers: { authorization: "Bearer header-token" },
+    } as unknown as Request;
+
+    const mockExecutionContext = createExecutionContext(mockRequest);
+    jwtAuthGuard.getRequest(mockExecutionContext);
+
+    expect(mockRequest.headers.authorization).toBe("Bearer header-token");
+  });
+
+  it("should not set authorization header if access token query param is missing", () => {
+    const mockRequest: Request = {
+      query: {},
+      headers: {},
+    } as unknown as Request;
+
+    const mockExecutionContext = createExecutionContext(mockRequest);
+    jwtAuthGuard.getRequest(mockExecutionContext);
+
+    expect(mockRequest.headers.authorization).toBeUndefined();
+  });
+
+  it("should return user if user is authenticated", () => {
+    const mockUser = { username: "test-user" };
+    const user = jwtAuthGuard.handleRequest(null, mockUser, null);
+
+    expect(user).toBe(mockUser);
+  });
+
+  it("should throw unauthorized exception if token has expired", () => {
+    expect(() =>
+      jwtAuthGuard.handleRequest(null, null, { name: "TokenExpiredError" }),
+    ).toThrow(UnauthorizedException);
+    expect(() =>
+      jwtAuthGuard.handleRequest(null, null, { name: "TokenExpiredError" }),
+    ).toThrow("SESSION_EXPIRED");
+  });
+
+  it("should return null if user is not authenticated, without attempting with expired token", () => {
+    const user = jwtAuthGuard.handleRequest(null, null, null);
+    expect(user).toBeNull();
+  });
+});

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,4 +1,8 @@
-import { ExecutionContext, Injectable } from "@nestjs/common";
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { AuthGuard } from "@nestjs/passport";
 
@@ -22,6 +26,8 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
     err: unknown,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     user: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,
+    info: any,
   ) {
     // const allowAny = this.reflector.get<string[]>(
     //   "allow-any",
@@ -30,6 +36,10 @@ export class JwtAuthGuard extends AuthGuard("jwt") {
 
     if (user) {
       return user;
+    }
+
+    if (!err && info?.name === "TokenExpiredError") {
+      throw new UnauthorizedException("SESSION_EXPIRED");
     }
     // if (allowAny) {
     //   return null;

--- a/test/Users.js
+++ b/test/Users.js
@@ -6,7 +6,8 @@ let accessTokenAdminIngestor = null,
   userIdUser1 = null,
   accessTokenUser1 = null,
   userIdUser2 = null,
-  accessTokenUser2 = null;
+  accessTokenUser2 = null,
+  adminIngestorUserId = null;
 
 describe("2350: Users: Login with functional accounts", () => {
   it("0010: Admin ingestor login fails with incorrect credentials", async () => {
@@ -34,6 +35,7 @@ describe("2350: Users: Login with functional accounts", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("user").and.be.instanceof(Object);
+        adminIngestorUserId = res.body.userId;
       });
   });
 });
@@ -259,6 +261,27 @@ describe("2370: Change password", () => {
           "message",
           "Only local users passwords can be changed by admin",
         );
+      });
+  });
+
+  it("0080: Request with expired token should return SESSION_EXPIRED", async () => {
+    const response = await request(appUrl)
+      .post(`/api/v3/users/${adminIngestorUserId}/jwt`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .send({ expiresIn: "-5" });
+
+    const expiredAccessToken = response.body.jwt;
+    return request(appUrl)
+      .post("/api/v3/datasets")
+      .set("Accept", "application/json")
+      .set({
+        Authorization: `Bearer ${expiredAccessToken}`,
+      })
+      .send({})
+      .expect(401)
+      .then((res) => {
+        res.body.message.should.equal("SESSION_EXPIRED");
       });
   });
 });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Throw a `401` status HTTP error with `SESSION_EXPIRED` message, for jwt authentication with an expired token.

## Motivation
Separate the session expired errors, from the `403` unauthorized errors, to inform the user of session expiration instead of silently failing.

## Changes:
- updated the `jwt-auth.guard.ts` making use of the `info` field in case of Token Expired.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Bug Fixes:
- Return a 401 SESSION_EXPIRED unauthorized error when JWT authentication fails due to an expired token, instead of treating it as a generic unauthorized failure.