### PR TITLE
feat(Dataset): add scientific query and SI unit support to FindAll V4

### DIFF
--- a/docs/developer-guide/findall-v4-scientific-query.md
+++ b/docs/developer-guide/findall-v4-scientific-query.md
@@ -1,0 +1,93 @@
+# SciCat FindAll V4: Scientific Query Search with Unit Handling and Strict Mode Plan
+
+FindAll V4 does not support scientific queries. Our goal is to add this, but not in the old Fullquery V3 style (lhs, rhs, relation, unit). Instead, we want a MongoDB friendly approach using direct MongoDB operators ($eq, $gt, $lt, etc.).
+We also want to support SI unit conversion for scientific fields, controlled by a new strictMode flag (default: false), which will be a top-level field in the query.
+
+
+### New V4 style
+
+```
+{
+  "where": {
+    "$and": [
+      {
+        "$and": [
+          { "scientificMetadata.distance.value": { "$eq": 1 } },
+          { "scientificMetadata.distance.unit": { "$eq": "km" } }
+        ]
+      },
+      {
+        "$and": [
+          { "scientificMetadata.temperature.value": { "$eq": 10 } },
+          { "scientificMetadata.temperature.unit": { "$eq": "celsius" } }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### If only one of the conditions should match
+
+```
+{
+  "where": {
+    "$or": [
+      {
+        "$and": [
+          { "scientificMetadata.distance.value": { "$eq": 1 } },
+          { "scientificMetadata.distance.unit": { "$eq": "km" } }
+        ]
+      },
+      {
+        "$and": [
+          { "scientificMetadata.temperature.value": { "$eq": 10 } },
+          { "scientificMetadata.temperature.unit": { "$eq": "celsius" } }
+        ]
+      }
+    ]
+  }
+} 
+```
+
+### Unit Handling & SI Conversion
+
+If strictMode is false (default), the backend will:
+
+ * Check if each $and array contains exactly two objects ending with value and unit.
+ * Check if both objects share the same scientificMetadata key.
+ 
+ If both checks pass, use the existing convertToSI utility to also match SI-equivalent values. But if checks fail, it should skip the SI conversion.
+ 
+ If strictMode is true, only exact value/unit matches are returned (SI conversion is skipped).
+
+### Final Query Example
+
+Before being sent to the aggregation pipeline, the query looks like this:
+
+```
+[
+  {
+    "$match": {
+      "$and": [
+        { "datasetName": { "$regex": "someName", "$options": "i" } },
+        {
+          "$and": [
+            { "scientificMetadata.distance.value": { "$eq": 1 } },
+            { "scientificMetadata.distance.unit": { "$eq": "km" } }
+          ]
+        },
+        {
+          "$and": [
+            { "scientificMetadata.temperature.value": { "$eq": 25 } },
+            { "scientificMetadata.testing_unit2.unit": { "$eq": "celcius" } }
+          ]
+        }
+      ]
+    }
+  },
+  { "$sort": { "createdAt": -1 } },
+  { "$skip": 0 },
+  { "$limit": 10 }
+]
+```

--- a/docs/developer-guide/findall-v4-scientific-query.md
+++ b/docs/developer-guide/findall-v4-scientific-query.md
@@ -8,6 +8,7 @@ We also want to support SI unit conversion for scientific fields, controlled by 
 
 ```
 {
+  "strictMode": "false",
   "where": {
     "$and": [
       {
@@ -31,6 +32,7 @@ We also want to support SI unit conversion for scientific fields, controlled by 
 
 ```
 {
+  "strictMode": "false",
   "where": {
     "$or": [
       {
@@ -81,6 +83,35 @@ Before being sent to the aggregation pipeline, the query looks like this:
           "$and": [
             { "scientificMetadata.temperature.value": { "$eq": 25 } },
             { "scientificMetadata.testing_unit2.unit": { "$eq": "celcius" } }
+          ]
+        }
+      ]
+    }
+  },
+  { "$sort": { "createdAt": -1 } },
+  { "$skip": 0 },
+  { "$limit": 10 }
+]
+```
+
+With SI conversion, the final query looks like this:
+
+```
+[
+  {
+    "$match": {
+      "$and": [
+        { "datasetName": { "$regex": "someName", "$options": "i" } },
+        {
+          "$and": [
+            { "scientificMetadata.distance.valueSI": { "$eq": 1000 } },
+            { "scientificMetadata.distance.unitSI": { "$eq": "m" } }
+          ]
+        },
+        {
+          "$and": [
+            { "scientificMetadata.temperature.valueSI": { "$eq": 77 } },
+            { "scientificMetadata.testing_unit2.unitSI": { "$eq": "fahrenheit" } }
           ]
         }
       ]

--- a/docs/developer-guide/findall-v4-scientific-query.md
+++ b/docs/developer-guide/findall-v4-scientific-query.md
@@ -110,8 +110,8 @@ With SI conversion, the final query looks like this:
         },
         {
           "$and": [
-            { "scientificMetadata.temperature.valueSI": { "$eq": 77 } },
-            { "scientificMetadata.testing_unit2.unitSI": { "$eq": "fahrenheit" } }
+            { "scientificMetadata.temperature.valueSI": { "$eq": 298,15 } },
+            { "scientificMetadata.testing_unit2.unitSI": { "$eq": "kelvin" } }
           ]
         }
       ]


### PR DESCRIPTION
## Description
Adds support for scientific queries in FindAll V4 using MongoDB operators and introduces SI unit conversion with a `strictMode` flag.

Currently, this PR only includes a documentation file describing the scientific query format and the planned approach for SI unit conversion.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Documentation:
- Add developer guide describing MongoDB-based scientific query format, SI unit conversion behavior, and strictMode semantics for FindAll V4.