### PR TITLE
fix(Dataset): allow public dataset access in v4 findById endpoint for unauthenticated users

### DIFF
--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -675,8 +675,11 @@ export class DatasetsV4Controller {
   // GET /datasets/:id
   //@UseGuards(PoliciesGuard)
   @UseGuards(PoliciesGuard)
-  @CheckPolicies("datasets", (ability: AppAbility) =>
-    ability.can(Action.DatasetRead, DatasetClass),
+  @CheckPolicies(
+    "datasets",
+    (ability: AppAbility) =>
+      ability.can(Action.DatasetRead, DatasetClass) ||
+      ability.can(Action.DatasetReadOnePublic, DatasetClass),
   )
   @Get("/:pid")
   @ApiParam({


### PR DESCRIPTION
## Description
This PR allows unauthenticated users to access published datasets through the V4 `findById` endpoint. The `@CheckPolicies `decorator now checks for both DatasetRead and DatasetReadOnePublic permissions just like in the V3 `findById` .

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Bug Fixes:
- Fix v4 dataset findById authorization to permit access to publicly published datasets without authentication, consistent with v3 behavior.