### PR TITLE
fix(Jobs): correct aggregation pipeline stage order for text search with access filters

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -13,7 +13,7 @@ import { ScientificRelation } from "./scientific-relation.enum";
 import { DatasetType } from "src/datasets/types/dataset-type.enum";
 import { isPlainObject, mapValues, omit, pickBy, some } from "lodash";
 import { MetadataSourceDoc } from "src/metadata-keys/metadatakeys.service";
-import { IJobFields } from "src/jobs/interfaces/job-filters.interface";
+import type { IJobFields } from "src/jobs/interfaces/job-filters.interface";
 
 // add Å to mathjs accepted units as equivalent to angstrom
 const isAlphaOriginal = Unit.isValidAlpha;
@@ -1382,7 +1382,7 @@ export function addAccessMatchToPipeline<T>(
   access: FilterQuery<T>,
   fields: IJobFields,
 ) {
-  if (fields["text"]) {
+  if ("text" in fields) {
     pipeline.splice(1, 0, {
       $match: access,
     });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -13,6 +13,7 @@ import { ScientificRelation } from "./scientific-relation.enum";
 import { DatasetType } from "src/datasets/types/dataset-type.enum";
 import { isPlainObject, mapValues, omit, pickBy, some } from "lodash";
 import { MetadataSourceDoc } from "src/metadata-keys/metadatakeys.service";
+import { IJobFields } from "src/jobs/interfaces/job-filters.interface";
 
 // add Å to mathjs accepted units as equivalent to angstrom
 const isAlphaOriginal = Unit.isValidAlpha;
@@ -1374,4 +1375,20 @@ export function createMetadataKeysInstance(
       doc.sampleCharacteristics ??
       {},
   };
+}
+
+export function addAccessMatchToPipeline<T>(
+  pipeline: PipelineStage[],
+  access: FilterQuery<T>,
+  fields: IJobFields,
+) {
+  if (fields["text"]) {
+    pipeline.splice(1, 0, {
+      $match: access,
+    });
+  } else {
+    pipeline.unshift({
+      $match: access,
+    });
+  }
 }

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -10,7 +10,11 @@ import {
   ILimitsFilter,
 } from "src/common/interfaces/common.interface";
 import { JobLookupKeysEnum, JOB_LOOKUP_FIELDS } from "./types/job-lookup";
-import { parsePipelineProjection, parsePipelineSort } from "src/common/utils";
+import {
+  parsePipelineProjection,
+  parsePipelineSort,
+  addAccessMatchToPipeline,
+} from "src/common/utils";
 import {
   addCreatedByFields,
   addUpdatedByField,
@@ -200,9 +204,7 @@ export class JobsService {
       JobDocument,
       IJobFields
     >(this.jobModel, "id", fields, facets);
-    pipeline.unshift({
-      $match: access,
-    });
+    addAccessMatchToPipeline(pipeline, access, fields);
     return await this.jobModel.aggregate(pipeline).exec();
   }
 

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -1114,6 +1114,22 @@ describe("1191: Jobs: Test Backwards Compatibility", () => {
       });
   });
 
+  it("0318: Fullfacet via /api/v3 jobs with text search and access filters as user5.1", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .query("fields=" + encodeURIComponent(JSON.stringify({ text: "owner_access" })))
+      .query("facets=" + encodeURIComponent(JSON.stringify([])))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be
+          .an("array")
+          .that.deep.contains({ all: [{ totalSets: 6 }] });
+      });
+  });
+
   it("0320: Delete via /api/v3 a job created by admin, as a user from ADMIN_GROUPS", async () => {
     return request(appUrl)
       .delete("/api/v3/Jobs/" + encodedJobOwnedByAdmin)


### PR DESCRIPTION
## Description
This PR fixes an issue in the jobs fullfacet endpoint where text search queries combined with access control filters were failing. 

Before this fix, when searching with text queries, the pipeline would place the access filter at the first stage and push the text search to the second stage. So the pipeline structure would like this:
``` 
[
  {
    "$match": {
      "$or": [
        {
          "ownerUser": "user5.2",
          "type": "acquisition_script"
        },
        {
          "ownerGroup": {
            "$in": [
              "group5"
            ]
          },
          "type": "acquisition_script"
        },
        {
          "ownerUser": "user5.2",
          "type": "visualization"
        },
        {
          "ownerGroup": {
            "$in": [
              "group5"
            ]
          },
          "type": "visualization"
        },
        {
          "ownerUser": "user5.2",
          "type": "embargo_period"
        },
        {
          "ownerGroup": {
            "$in": [
              "group5"
            ]
          },
          "type": "embargo_period"
        }
      ]
    }
  },
  {
    "$match": {
      "$or": [
        {
          "$text": {
            "$search": "embargo_period"
          }
        }
      ]
    }
  },
  {
    "$facet": {
      "all": [
        {
          "$match": {}
        },
        {
          "$count": "totalSets"
        }
      ]
    }
  }
]
```

Which would throw this error: 

``` 
response: {
    status: 400,
    message: '$match with $text is only allowed as the first pipeline stage'
  }
```
According to MongoDB documentation on aggregation pipeline constraints: https://www.mongodb.com/docs/manual/tutorial/text-search-in-aggregation/, the $text operator must always be the first stage in an aggregation pipeline. No $match conditions can come before it

The fix introduces a utility function in `utils.ts` called `addAccessMatchToPipeline` that checks if a text search field exists in the request. If text search is present, the access filter is inserted at index 1 instead of being unshifted to index 0, keeping the text search as the first stage. If no text search exists, the access filter is unshifted normally to the beginning.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Fix the jobs aggregation pipeline so text search stages remain first while still applying access control filters.

Bug Fixes:
- Ensure jobs fullfacet aggregation pipelines with text search comply with MongoDB’s requirement that $text be the first $match stage to prevent query failures.

Enhancements:
- Introduce a shared utility to insert access control $match stages into aggregation pipelines while preserving correct stage ordering.