### PR TITLE
feat(OrigDatablock): file count endpoints with isPublished backfill

### DIFF
--- a/migrations/20260606152800-backfill-legacy-origdatablock-ispublished-from-dataset.js
+++ b/migrations/20260606152800-backfill-legacy-origdatablock-ispublished-from-dataset.js
@@ -1,0 +1,47 @@
+module.exports = {
+  async up(db) {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      console.log(
+        `Running backfill-legacy-origdatablock-ispublished-from-dataset... ${Math.floor((Date.now() - start) / 1000)}s`,
+      );
+    }, 1000);
+
+    try {
+      await db
+        .collection("OrigDatablock")
+        .aggregate([
+          { $match: { isPublished: { $exists: false } } },
+          {
+            $lookup: {
+              from: "Dataset",
+              localField: "datasetId",
+              foreignField: "pid",
+              as: "dataset",
+            },
+          },
+          {
+            $set: {
+              isPublished: {
+                $ifNull: [{ $arrayElemAt: ["$dataset.isPublished", 0] }, false],
+              },
+            },
+          },
+          { $unset: "dataset" },
+          {
+            $merge: { into: "OrigDatablock", on: "_id", whenMatched: "merge" },
+          },
+        ])
+        .next();
+    } finally {
+      clearInterval(timer);
+      console.log(
+        `Done backfill-legacy-origdatablock-ispublished-from-dataset in ${((Date.now() - start) / 1000).toFixed(1)}s`,
+      );
+    }
+  },
+
+  async down(db, client) {
+    // no path backward
+  },
+};

--- a/src/origdatablocks/origdatablocks-public.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks-public.v4.controller.ts
@@ -14,7 +14,11 @@ import {
   IOrigDatablockFields,
   IOrigDatablockFiltersV4,
 } from "./interfaces/origdatablocks.interface";
-import { FullFacetFilters, FullFacetResponse } from "src/common/types";
+import {
+  FullFacetFilters,
+  FullFacetResponse,
+  CountApiResponse,
+} from "src/common/types";
 import { getSwaggerOrigDatablockFilterContent } from "./types/origdatablock-filter-content";
 import {
   OrigDatablockLookupKeysEnum,
@@ -236,5 +240,53 @@ export class OrigDatablocksPublicV4Controller {
     });
 
     return origdatablock;
+  }
+
+  // GET /origdatablocks/public/files/count
+  @AllowAny()
+  @Get("/files/count")
+  @ApiOperation({
+    summary: "It returns the count of public files",
+    description:
+      "It returns the total number of public files across all origdatablocks matching the provided filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving count of public files",
+    required: false,
+    type: String,
+    content: getSwaggerOrigDatablockFilterContent({
+      where: true,
+      include: false,
+      fields: false,
+      limits: false,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: CountApiResponse,
+    description:
+      "Return the number of public files in the following format: { count: integer }",
+  })
+  async countFilesPublic(
+    @Query(
+      "filter",
+      new FilterValidationPipe(
+        ALLOWED_ORIGDATABLOCK_KEYS,
+        ALLOWED_ORIGDATABLOCK_FILTER_KEYS,
+        {
+          where: true,
+          include: false,
+          fields: false,
+          limits: false,
+        },
+      ),
+    )
+    queryFilter: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+
+    return this.origDatablocksService.countFiles(parsedFilter);
   }
 }

--- a/src/origdatablocks/origdatablocks-public.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks-public.v4.controller.ts
@@ -283,7 +283,7 @@ export class OrigDatablocksPublicV4Controller {
         },
       ),
     )
-    queryFilter: string,
+    queryFilter?: string,
   ) {
     const parsedFilter = JSON.parse(queryFilter ?? "{}");
 

--- a/src/origdatablocks/origdatablocks-public.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks-public.v4.controller.ts
@@ -287,6 +287,8 @@ export class OrigDatablocksPublicV4Controller {
   ) {
     const parsedFilter = JSON.parse(queryFilter ?? "{}");
 
+    this.addPublicFilter(parsedFilter);
+
     return this.origDatablocksService.countFiles(parsedFilter);
   }
 }

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -168,6 +168,23 @@ export class OrigDatablocksService {
       pipeline.push({ $project: projection });
     }
 
+    pipeline.push({
+      $lookup: {
+        from: "Dataset",
+        as: "dataset_temp",
+        let: { datasetId: "$datasetId" },
+        pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
+      },
+    });
+
+    pipeline.push({
+      $addFields: {
+        datasetExist: { $gt: [{ $size: "$dataset_temp" }, 0] },
+      },
+    });
+
+    pipeline.push({ $unset: "dataset_temp" });
+
     pipeline.push({ $unwind: "$dataFileList" });
 
     if (!isEmpty(limits.sort)) {
@@ -264,6 +281,20 @@ export class OrigDatablocksService {
 
     const pipelineStages: PipelineStage[] = [
       { $match: filterQuery },
+      {
+        $lookup: {
+          from: "Dataset",
+          as: "dataset_temp",
+          let: { datasetId: "$datasetId" },
+          pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
+        },
+      },
+      {
+        $addFields: {
+          datasetExist: { $gt: [{ $size: "$dataset_temp" }, 0] },
+        },
+      },
+      { $unset: "dataset_temp" },
       { $unwind: "$dataFileList" },
       ...modifiers,
     ];

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -383,6 +383,48 @@ export class OrigDatablocksService {
     return { count };
   }
 
+  async countFiles(
+    filter: FilterQuery<OrigDatablockDocument>,
+  ): Promise<CountApiResponse> {
+    const whereFilter: FilterQuery<OrigDatablockDocument> = filter.where ?? {};
+    const fieldsProjection: string[] = filter.fields ?? {};
+
+    const pipeline: PipelineStage[] = [{ $match: whereFilter }];
+    this.addLookupFields(pipeline, filter.include);
+
+    if (!isEmpty(fieldsProjection)) {
+      const projection = parsePipelineProjection(fieldsProjection);
+      pipeline.push({ $project: projection });
+    }
+
+    pipeline.push({
+      $lookup: {
+        from: "Dataset",
+        as: "dataset_temp",
+        let: { datasetId: "$datasetId" },
+        pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
+      },
+    });
+
+    pipeline.push({
+      $addFields: {
+        datasetExist: { $gt: [{ $size: "$dataset_temp" }, 0] },
+      },
+    });
+
+    pipeline.push({ $unset: "dataset_temp" });
+
+    pipeline.push({ $unwind: "$dataFileList" });
+
+    pipeline.push({ $count: "count" });
+
+    const [result] = await this.origDatablockModel
+      .aggregate<{ count: number }>(pipeline)
+      .exec();
+
+    return { count: result.count ?? 0 };
+  }
+
   async aggregateSizeAndFileCount(
     datasetId: string,
   ): Promise<{ size: number; numberOfFiles: number }> {

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -168,23 +168,6 @@ export class OrigDatablocksService {
       pipeline.push({ $project: projection });
     }
 
-    pipeline.push({
-      $lookup: {
-        from: "Dataset",
-        as: "dataset_temp",
-        let: { datasetId: "$datasetId" },
-        pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
-      },
-    });
-
-    pipeline.push({
-      $addFields: {
-        datasetExist: { $gt: [{ $size: "$dataset_temp" }, 0] },
-      },
-    });
-
-    pipeline.push({ $unset: "dataset_temp" });
-
     pipeline.push({ $unwind: "$dataFileList" });
 
     if (!isEmpty(limits.sort)) {
@@ -281,20 +264,6 @@ export class OrigDatablocksService {
 
     const pipelineStages: PipelineStage[] = [
       { $match: filterQuery },
-      {
-        $lookup: {
-          from: "Dataset",
-          as: "Dataset",
-          let: { datasetId: "$datasetId" },
-          pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
-        },
-      },
-      {
-        $addFields: {
-          datasetExist: { $gt: [{ $size: "$Dataset" }, 0] },
-        },
-      },
-      { $unset: "Dataset" },
       { $unwind: "$dataFileList" },
       ...modifiers,
     ];
@@ -386,42 +355,14 @@ export class OrigDatablocksService {
   async countFiles(
     filter: FilterQuery<OrigDatablockDocument>,
   ): Promise<CountApiResponse> {
-    const whereFilter: FilterQuery<OrigDatablockDocument> = filter.where ?? {};
-    const fieldsProjection: string[] = filter.fields ?? [];
-
-    const pipeline: PipelineStage[] = [{ $match: whereFilter }];
-    this.addLookupFields(pipeline, filter.include);
-
-    if (!isEmpty(fieldsProjection)) {
-      const projection = parsePipelineProjection(fieldsProjection);
-      pipeline.push({ $project: projection });
-    }
-
-    pipeline.push({
-      $lookup: {
-        from: "Dataset",
-        as: "dataset_temp",
-        let: { datasetId: "$datasetId" },
-        pipeline: [{ $match: { $expr: { $eq: ["$pid", "$$datasetId"] } } }],
-      },
-    });
-
-    pipeline.push({
-      $addFields: {
-        datasetExist: { $gt: [{ $size: "$dataset_temp" }, 0] },
-      },
-    });
-
-    pipeline.push({ $unset: "dataset_temp" });
-
-    pipeline.push({ $unwind: "$dataFileList" });
-
-    pipeline.push({ $count: "count" });
-
+    const pipeline: PipelineStage[] = [
+      { $match: filter.where ?? {} },
+      { $unwind: "$dataFileList" },
+      { $count: "count" },
+    ];
     const [result] = await this.origDatablockModel
       .aggregate<{ count: number }>(pipeline)
       .exec();
-
     return { count: result?.count ?? 0 };
   }
 

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -387,7 +387,7 @@ export class OrigDatablocksService {
     filter: FilterQuery<OrigDatablockDocument>,
   ): Promise<CountApiResponse> {
     const whereFilter: FilterQuery<OrigDatablockDocument> = filter.where ?? {};
-    const fieldsProjection: string[] = filter.fields ?? {};
+    const fieldsProjection: string[] = filter.fields ?? [];
 
     const pipeline: PipelineStage[] = [{ $match: whereFilter }];
     this.addLookupFields(pipeline, filter.include);
@@ -422,7 +422,7 @@ export class OrigDatablocksService {
       .aggregate<{ count: number }>(pipeline)
       .exec();
 
-    return { count: result.count ?? 0 };
+    return { count: result?.count ?? 0 };
   }
 
   async aggregateSizeAndFileCount(

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -722,7 +722,7 @@ export class OrigDatablocksV4Controller {
   @ApiResponse({
     status: HttpStatus.OK,
     type: CountApiResponse,
-    description: 
+    description:
       "Return the number of files in the following format: { count: integer }",
   })
   async countFiles(
@@ -738,9 +738,9 @@ export class OrigDatablocksV4Controller {
           fields: false,
           limits: false,
         },
-    ),
-  )
-  queryFilter?: string,
+      ),
+    )
+    queryFilter?: string,
   ) {
     const parsedFilter = JSON.parse(queryFilter ?? "{}");
     const mergedFilter = this.addAccessBasedFilters(

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -58,6 +58,7 @@ import {
   IsValidResponse,
   FullFacetFilters,
   FullFacetResponse,
+  CountApiResponse,
 } from "src/common/types";
 import { getSwaggerOrigDatablockFilterContent } from "./types/origdatablock-filter-content";
 import {
@@ -695,6 +696,60 @@ export class OrigDatablocksV4Controller {
     );
   }
 
+  // GET /origdatablocks/files/count
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("origdatablocks", (ability: AppAbility) =>
+    ability.can(Action.OrigdatablockRead, OrigDatablock),
+  )
+  @Get("/files/count")
+  @ApiOperation({
+    summary: "It returns the count of files",
+    description:
+      "It returns the total number of files across all origdatablocks matching the provided filter.",
+  })
+  @ApiQuery({
+    name: "filter",
+    description: "Database filters to apply when retrieving count for files",
+    required: false,
+    type: String,
+    content: getSwaggerOrigDatablockFilterContent({
+      where: true,
+      include: false,
+      fields: false,
+      limits: false,
+    }),
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: CountApiResponse,
+    description: 
+      "Return the number of files in the following format: { count: integer }",
+  })
+  async countFiles(
+    @Req() request: Request,
+    @Query(
+      "filter",
+      new FilterValidationPipe(
+        ALLOWED_ORIGDATABLOCK_KEYS,
+        ALLOWED_ORIGDATABLOCK_FILTER_KEYS,
+        {
+          where: true,
+          include: false,
+          fields: false,
+          limits: false,
+        },
+    ),
+  )
+  queryFilter?: string,
+  ) {
+    const parsedFilter = JSON.parse(queryFilter ?? "{}");
+    const mergedFilter = this.addAccessBasedFilters(
+      request.user as JWTUser,
+      parsedFilter,
+    );
+
+    return this.origDatablocksService.countFiles(mergedFilter);
+  }
   // GET /origdatablocks/:id
   @UseGuards(PoliciesGuard)
   @CheckPolicies("origdatablocks", (ability: AppAbility) =>

--- a/test/OrigDatablockV4.js
+++ b/test/OrigDatablockV4.js
@@ -10,7 +10,6 @@ let accessTokenAdminIngestor = null,
   accessTokenUser2 = null,
   accessTokenUser3 = null,
   accessTokenUser4 = null,
-
   datasetPid = null,
   datasetPidWrong = null,
   origDatablockMinPid = null,
@@ -53,7 +52,11 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     await request(appUrl)
       .post("/api/v4/datasets")
-      .send({...TestData.RawCorrectMinV4, ownerGroup: "group1", accessGroups: [ "group3" ]})
+      .send({
+        ...TestData.RawCorrectMinV4,
+        ownerGroup: "group1",
+        accessGroups: ["group3"],
+      })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
@@ -64,16 +67,26 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     await request(appUrl)
       .post("/api/v4/origdatablocks")
-      .send({...TestData.OrigDatablockV4MinCorrect, datasetId: datasetPid, ownerGroup: "group1", accessGroups: [ "group3" ]})
+      .send({
+        ...TestData.OrigDatablockV4MinCorrect,
+        datasetId: datasetPid,
+        ownerGroup: "group1",
+        accessGroups: ["group3"],
+      })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
         origDatablockMinPid = res.body._id;
       });
-    
+
     await request(appUrl)
       .post("/api/v4/origdatablocks")
-      .send({...TestData.OrigDatablockV4Correct, datasetId: datasetPid, ownerGroup: "group1", accessGroups: [ "group3" ]})
+      .send({
+        ...TestData.OrigDatablockV4Correct,
+        datasetId: datasetPid,
+        ownerGroup: "group1",
+        accessGroups: ["group3"],
+      })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
@@ -104,7 +117,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
       await deleteDataset(item);
     }
   }
-  
+
   async function processOrigDatablockArray(array) {
     for (const item of array) {
       await deleteOrigDatablock(item);
@@ -383,7 +396,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
           res.body.should.have.property("ownerGroup").and.be.a("string");
         });
     });
-    
+
     it("0251: should not be able to add new origdatablock with user that is not in create dataset list", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
@@ -583,7 +596,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
             odb.dataset.should.have.length(1);
             const [dataset] = odb.dataset;
             dataset.should.have.property("pid");
-          });          
+          });
         });
     });
 
@@ -680,9 +693,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0351: should fetch origdatablocks and relation fields with correct data included with ownerGroup rights", async () => {
       const filter = {
-        include: [
-          "dataset",
-        ],
+        include: ["dataset"],
       };
 
       return request(appUrl)
@@ -707,9 +718,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0352: should fetch origdatablocks and relation fields with correct data included with accessGroup rights", async () => {
       const filter = {
-        include: [
-          "dataset",
-        ],
+        include: ["dataset"],
       };
 
       return request(appUrl)
@@ -737,14 +746,18 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
   describe("OrigDatablocks v4 findById tests", () => {
     it("0400: should not be able to fetch origdatablock by id if not logged in", () => {
       return request(appUrl)
-        .get(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockMinPid)}`)
+        .get(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockMinPid)}`,
+        )
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
     });
 
     it("0401: should fetch origdatablock by id", () => {
       return request(appUrl)
-        .get(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockMinPid)}`)
+        .get(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockMinPid)}`,
+        )
         .auth(accessTokenAdminIngestor, { type: "bearer" })
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
@@ -797,9 +810,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0450: should not be able to fetch origdatablock without the correct access rights", () => {
       return request(appUrl)
-        .get(
-          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
-        )
+        .get(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
         .auth(accessTokenUser2, { type: "bearer" })
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
@@ -807,7 +818,9 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0451: should fetch origdatablocks and relation fields with correct data included with ownerGroup rights", () => {
       return request(appUrl)
-        .get(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}?include=dataset`)
+        .get(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}?include=dataset`,
+        )
         .auth(accessTokenUser1, { type: "bearer" })
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
@@ -825,7 +838,9 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0452: should fetch origdatablocks and relation fields with correct data included with accessGroup rights", () => {
       return request(appUrl)
-        .get(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}?include=dataset`)
+        .get(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}?include=dataset`,
+        )
         .auth(accessTokenUser3, { type: "bearer" })
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
@@ -870,7 +885,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
           res.body.should.be.a("object");
           res.body.should.have.property("_id").and.be.a("string");
           res.body.should.have.property("datasetId").and.be.a("string");
-          res.body.should.have.property("size")
+          res.body.should.have.property("size");
           res.body.size.should.be.eq(updatedOrigDatablock.size);
         });
     });
@@ -954,14 +969,18 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
   describe("OrigDatablocks v4 delete tests", () => {
     it("0700: should not be able to delete origdatablock if not logged in", () => {
       return request(appUrl)
-        .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
     });
 
     it("0701: should not be able to delete origdatablock as owner", () => {
       return request(appUrl)
-        .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
         .auth(accessTokenUser1, { type: "bearer" })
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
@@ -969,7 +988,9 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0702: should not be able to delete origdatablock as adminIngestor", () => {
       return request(appUrl)
-        .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
         .auth(accessTokenAdminIngestor, { type: "bearer" })
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
@@ -977,7 +998,9 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
 
     it("0703: should be able to delete origdatablock as archivemanager", () => {
       return request(appUrl)
-        .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
         .auth(accessTokenArchiveManager, { type: "bearer" })
         .expect(TestData.SuccessfulDeleteStatusCode)
         .expect("Content-Type", /json/)

--- a/test/OrigDatablockV4.js
+++ b/test/OrigDatablockV4.js
@@ -909,15 +909,57 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     });
   });
 
+  describe("OrigDatablocks v4 count tests", () => {
+    it("0600: should not be able to fetch the count of origdatablocks files if not logged in", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .expect(TestData.AccessForbiddenStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("0601: should be able to fetch the count of origdatablocks files", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.greaterThan(0);
+        });
+    });
+  });
+
   describe("OrigDatablocks v4 delete tests", () => {
-    it("0600: should not be able to delete origdatablock if not logged in", () => {
+    it("0700: should not be able to delete origdatablock if not logged in", () => {
       return request(appUrl)
         .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
     });
 
-    it("0601: should not be able to delete origdatablock as owner", () => {
+    it("0701: should not be able to delete origdatablock as owner", () => {
       return request(appUrl)
         .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
         .auth(accessTokenUser1, { type: "bearer" })
@@ -925,7 +967,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
         .expect("Content-Type", /json/);
     });
 
-    it("0602: should not be able to delete origdatablock as adminIngestor", () => {
+    it("0702: should not be able to delete origdatablock as adminIngestor", () => {
       return request(appUrl)
         .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
         .auth(accessTokenAdminIngestor, { type: "bearer" })
@@ -933,7 +975,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
         .expect("Content-Type", /json/);
     });
 
-    it("0603: should be able to delete origdatablock as archivemanager", () => {
+    it("0703: should be able to delete origdatablock as archivemanager", () => {
       return request(appUrl)
         .delete(`/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`)
         .auth(accessTokenArchiveManager, { type: "bearer" })

--- a/test/OrigDatablockV4.js
+++ b/test/OrigDatablockV4.js
@@ -10,7 +10,8 @@ let accessTokenAdminIngestor = null,
   accessTokenUser2 = null,
   accessTokenUser3 = null,
   accessTokenUser4 = null,
-  datasetPid = null,
+  datasetPid1 = null,
+  datasetPid2 = null,
   datasetPidWrong = null,
   origDatablockMinPid = null,
   origDatablockPid = null;
@@ -60,7 +61,20 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
-        datasetPid = res.body.pid;
+        datasetPid1 = res.body.pid;
+      });
+
+    await request(appUrl)
+      .post("/api/v4/datasets")
+      .send({
+        ...TestData.RawCorrectV4,
+        ownerGroup: "group2",
+        accessGroups: ["group2"],
+      })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.EntryCreatedStatusCode)
+      .then((res) => {
+        datasetPid2 = res.body.pid;
       });
 
     datasetPidWrong = TestData.PidPrefix + "/" + uuidv4();
@@ -69,7 +83,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
       .post("/api/v4/origdatablocks")
       .send({
         ...TestData.OrigDatablockV4MinCorrect,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
         ownerGroup: "group1",
         accessGroups: ["group3"],
       })
@@ -82,8 +96,19 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     await request(appUrl)
       .post("/api/v4/origdatablocks")
       .send({
+        ...TestData.OrigDatablockV4MinCorrect,
+        datasetId: datasetPid2,
+        ownerGroup: "group2",
+        accessGroups: ["group2"],
+      })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.EntryCreatedStatusCode);
+
+    await request(appUrl)
+      .post("/api/v4/origdatablocks")
+      .send({
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
         ownerGroup: "group1",
         accessGroups: ["group3"],
       })
@@ -128,7 +153,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0100: should not be able to validate origdatablock if not logged in", async () => {
       const odb = {
         ...TestData.OrigDatablockV4MinCorrect,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -140,7 +165,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0101: check if minimal origdatablock is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4MinCorrect,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -156,7 +181,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0102: check if average origdatablock is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -172,7 +197,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0103: check if origdatablock with wrong field type is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4WrongType,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -188,7 +213,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0104: check if origdatablock with missing field is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4MissingField,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -204,7 +229,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0105: check if origdatablock with empty dataFileList is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4EmptyDataFiles,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -220,7 +245,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0106: check if origdatablock with wrong chkAlg is valid", async () => {
       const odb = {
         ...TestData.OrigDatablockV4EmptyChkAlg,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks/isValid")
@@ -254,7 +279,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0200: should not be able to create origdatablock if not logged in", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -266,7 +291,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0201: adds a new minimal origdatablock", async () => {
       const odb = {
         ...TestData.OrigDatablockV4MinCorrect,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -284,7 +309,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0202: adds a new origdatablock", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -302,7 +327,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0203: tries to add an origdatablock with wrong data type", async () => {
       const odb = {
         ...TestData.OrigDatablockV4WrongType,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -318,7 +343,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0204: tries to add an origdatablock with missing field", async () => {
       const odb = {
         ...TestData.OrigDatablockV4MissingField,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -334,7 +359,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0205: tries to add an origdatablock with empty dataFileList", async () => {
       const odb = {
         ...TestData.OrigDatablockV4EmptyDataFiles,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -350,7 +375,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0206: tries to add an origdatablock with wrong chkAlg", async () => {
       const odb = {
         ...TestData.OrigDatablockV4EmptyChkAlg,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -382,7 +407,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0250: should be able to add new origdatablock with access to datasetId", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -400,7 +425,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0251: should not be able to add new origdatablock with user that is not in create dataset list", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -413,7 +438,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0252: should not be able to add new origdatablock without access to datasetId", async () => {
       const odb = {
         ...TestData.OrigDatablockV4Correct,
-        datasetId: datasetPid,
+        datasetId: datasetPid1,
       };
       return request(appUrl)
         .post("/api/v4/origdatablocks")
@@ -603,7 +628,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0306: should be able to fetch the origdatablocks providing where filter", async () => {
       const filter = {
         where: {
-          datasetId: datasetPid,
+          datasetId: datasetPid1,
         },
       };
 
@@ -618,7 +643,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
           res.body.forEach((odb) => {
             odb.should.have.property("_id").and.be.a("string");
             odb.should.have.property("datasetId").and.be.a("string");
-            odb.datasetId.should.be.eq(datasetPid);
+            odb.datasetId.should.be.eq(datasetPid1);
           });
         });
     });
@@ -626,7 +651,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     it("0307: should be able to fetch the origdatablocks providing all allowed filters together", async () => {
       const filter = {
         where: {
-          datasetId: datasetPid,
+          datasetId: datasetPid1,
         },
         include: ["all"],
         fields: ["_id", "datasetId", "dataset"],
@@ -651,13 +676,13 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
           res.body.forEach((odb) => {
             odb.should.have.property("_id").and.be.a("string");
             odb.should.have.property("datasetId").and.be.a("string");
-            odb.datasetId.should.be.eq(datasetPid);
+            odb.datasetId.should.be.eq(datasetPid1);
             odb.should.have.property("dataset");
             odb.dataset.should.be.a("array");
             odb.dataset.should.have.length(1);
             const [dataset] = odb.dataset;
             dataset.should.have.property("pid");
-            dataset.pid.should.be.eq(datasetPid);
+            dataset.pid.should.be.eq(datasetPid1);
             odb.should.not.have.property("size");
             odb.should.not.have.property("chkAlg");
           });
@@ -683,7 +708,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
       return request(appUrl)
         .get("/api/v4/origdatablocks")
         .query({ filter: JSON.stringify(filter) })
-        .auth(accessTokenUser2, { type: "bearer" })
+        .auth(accessTokenUser4, { type: "bearer" })
         .expect(TestData.SuccessfulGetStatusCode)
         .then((res) => {
           res.body.should.be.a("array");
@@ -737,7 +762,7 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
             odb.dataset.should.have.length(1);
             const [dataset] = odb.dataset;
             dataset.should.have.property("pid");
-            dataset.pid.should.be.eq(datasetPid);
+            dataset.pid.should.be.eq(datasetPid1);
           });
         });
     });
@@ -925,11 +950,37 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
   });
 
   describe("OrigDatablocks v4 count tests", () => {
+    let expectedTotal,
+      expectedCorrectCountForUser1,
+      expectedCorrectCountForUser2;
+
+    before(async () => {
+      const countFiles = async (match) => {
+        const res = await db
+          .collection("OrigDatablock")
+          .aggregate([
+            { $match: match },
+            { $unwind: "$dataFileList" },
+            { $count: "count" },
+          ])
+          .toArray();
+
+        return res[0]?.count ?? 0;
+      };
+      expectedTotal = await countFiles({});
+      expectedCorrectCountForUser1 = await countFiles({
+        datasetId: datasetPid1,
+      });
+      expectedCorrectCountForUser2 = await countFiles({
+        datasetId: datasetPid2,
+      });
+    });
+
     it("0600: should not be able to fetch the count of origdatablocks files if not logged in", async () => {
       const filter = {
         where: {
           datasetId: {
-            $regex: datasetPid,
+            $regex: datasetPid1,
             $options: "i",
           },
         },
@@ -942,14 +993,9 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
         .expect("Content-Type", /json/);
     });
 
-    it("0601: should be able to fetch the count of origdatablocks files", async () => {
+    it("0610: should be able to fetch all the count of origdatablocks files as admin", async () => {
       const filter = {
-        where: {
-          datasetId: {
-            $regex: datasetPid,
-            $options: "i",
-          },
-        },
+        where: {},
       };
 
       return request(appUrl)
@@ -961,64 +1007,104 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
         .then((res) => {
           res.body.should.be.a("object");
           res.body.should.have.property("count");
-          res.body.count.should.be.greaterThan(0);
+          res.body.count.should.equal(expectedTotal);
         });
     });
-  });
 
-  describe("OrigDatablocks v4 delete tests", () => {
-    it("0700: should not be able to delete origdatablock if not logged in", () => {
-      return request(appUrl)
-        .delete(
-          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
-        )
-        .expect(TestData.AccessForbiddenStatusCode)
-        .expect("Content-Type", /json/);
-    });
+    it("0620: should be able to fetch correct count of origdatablocks files without filter as user1", async () => {
+      const filter = {
+        where: {},
+      };
 
-    it("0701: should not be able to delete origdatablock as owner", () => {
       return request(appUrl)
-        .delete(
-          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
-        )
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
         .auth(accessTokenUser1, { type: "bearer" })
-        .expect(TestData.AccessForbiddenStatusCode)
-        .expect("Content-Type", /json/);
-    });
-
-    it("0702: should not be able to delete origdatablock as adminIngestor", () => {
-      return request(appUrl)
-        .delete(
-          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
-        )
-        .auth(accessTokenAdminIngestor, { type: "bearer" })
-        .expect(TestData.AccessForbiddenStatusCode)
-        .expect("Content-Type", /json/);
-    });
-
-    it("0703: should be able to delete origdatablock as archivemanager", () => {
-      return request(appUrl)
-        .delete(
-          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
-        )
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.SuccessfulDeleteStatusCode)
+        .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
           res.body.should.be.a("object");
-          res.body.should.have.property("_id").and.be.a("string");
-          res.body.should.have.property("datasetId").and.be.a("string");
+          res.body.should.have.property("count");
+          res.body.count.should.equal(expectedCorrectCountForUser1);
+        });
+    });
+
+    it("0625: should be able to fetch correct count of origdatablocks files with filter as user2", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid2,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenUser2, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.equal(expectedCorrectCountForUser2);
+        });
+    });
+
+    it("0630: should not be able to fetch the count of origdatablock files for datasetPid2 as user1", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid2,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenUser1, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.equal(0);
+        });
+    });
+    it("0635: should not be able to fetch the count of origdatablock files for datasetPid1 as user2", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid1,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenUser2, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.equal(0);
         });
     });
   });
 
   describe("OrigDatablocks v4 optimistic concurrency control tests", () => {
-    it("0800: should fail one request with HTTP 412 when two requests try to update the same origdatablock", async () => {
+    it("0700: should fail one request with HTTP 412 when two requests try to update the same origdatablock", async () => {
       const res = await request(appUrl)
         .post("/api/v4/origdatablocks")
         .send({
           ...TestData.OrigDatablockV4MinCorrect,
-          datasetId: datasetPid,
+          datasetId: datasetPid1,
         })
         .auth(accessTokenAdminIngestor, { type: "bearer" })
         .expect(TestData.EntryCreatedStatusCode);
@@ -1050,27 +1136,61 @@ describe("2800: OrigDatablock v4 endpoint tests", () => {
     });
   });
 
-  describe("Cleanup after the tests", () => {
-    it("0900: delete all origdatablocks as archivemanager", async () => {
-      return await request(appUrl)
-        .get("/api/v4/origdatablocks")
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          return processOrigDatablockArray(res.body);
-        });
+  describe("OrigDatablocks v4 delete tests", () => {
+    it("0800: should not be able to delete origdatablock if not logged in", () => {
+      return request(appUrl)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
+        .expect(TestData.AccessForbiddenStatusCode)
+        .expect("Content-Type", /json/);
     });
 
-    it("0901: delete all datasets as archivemanager", async () => {
-      return await request(appUrl)
-        .get("/api/v4/datasets")
+    it("0801: should not be able to delete origdatablock as owner", () => {
+      return request(appUrl)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
+        .auth(accessTokenUser1, { type: "bearer" })
+        .expect(TestData.AccessForbiddenStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("0802: should not be able to delete origdatablock as adminIngestor", () => {
+      return request(appUrl)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.AccessForbiddenStatusCode)
+        .expect("Content-Type", /json/);
+    });
+
+    it("0803: should be able to delete origdatablock as archivemanager", () => {
+      return request(appUrl)
+        .delete(
+          `/api/v4/origdatablocks/${encodeURIComponent(origDatablockPid)}`,
+        )
         .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
+        .expect(TestData.SuccessfulDeleteStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          return processDatasetArray(res.body);
+          res.body.should.be.a("object");
+          res.body.should.have.property("_id").and.be.a("string");
+          res.body.should.have.property("datasetId").and.be.a("string");
         });
     });
+  });
+
+  after(async () => {
+    const odbs = await request(appUrl)
+      .get("/api/v4/origdatablocks")
+      .auth(accessTokenArchiveManager, { type: "bearer" });
+    await processOrigDatablockArray(odbs.body);
+
+    const datasets = await request(appUrl)
+      .get("/api/v4/datasets")
+      .auth(accessTokenArchiveManager, { type: "bearer" });
+    await processDatasetArray(datasets.body);
   });
 });

--- a/test/OrigDatablockV4Public.js
+++ b/test/OrigDatablockV4Public.js
@@ -373,8 +373,33 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
     });
   });
 
+  describe("OrigDatablocks v4 public count tests", () => {
+    it("0300: should be able to fetch the count of origdatablocks files providing where filter", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/public/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.a("number");
+          res.body.count.should.be.greaterThan(0);
+        });
+    });
+  });
+
   describe("Cleanup after the tests", () => {
-    it("0300: delete all origdatablocks as archivemanager", async () => {
+    it("0400: delete all origdatablocks as archivemanager", async () => {
       return await request(appUrl)
         .get("/api/v4/origdatablocks")
         .auth(accessTokenArchiveManager, { type: "bearer" })
@@ -385,7 +410,7 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
         });
     });
 
-    it("0301: delete all datasets as archivemanager", async () => {
+    it("0401: delete all datasets as archivemanager", async () => {
       return await request(appUrl)
         .get("/api/v4/datasets")
         .auth(accessTokenArchiveManager, { type: "bearer" })

--- a/test/OrigDatablockV4Public.js
+++ b/test/OrigDatablockV4Public.js
@@ -4,7 +4,6 @@ const { TestData } = require("./TestData");
 
 let accessTokenArchiveManager = null,
   accessTokenAdminIngestor = null,
-
   datasetPid = null,
   origDatablockMinPid = null,
   origDatablockPid = null;
@@ -26,25 +25,33 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
 
     await request(appUrl)
       .post("/api/v4/datasets")
-      .send({...TestData.RawCorrectMinV4, isPublished: true})
+      .send({ ...TestData.RawCorrectMinV4, isPublished: true })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
         datasetPid = res.body.pid;
       });
-    
+
     await request(appUrl)
       .post("/api/v4/origdatablocks")
-      .send({...TestData.OrigDatablockV4MinCorrect, datasetId: datasetPid, isPublished: true})
+      .send({
+        ...TestData.OrigDatablockV4MinCorrect,
+        datasetId: datasetPid,
+        isPublished: true,
+      })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
         origDatablockMinPid = res.body._id;
       });
-    
+
     await request(appUrl)
       .post("/api/v4/origdatablocks")
-      .send({...TestData.OrigDatablockV4Correct, datasetId: datasetPid, isPublished: true})
+      .send({
+        ...TestData.OrigDatablockV4Correct,
+        datasetId: datasetPid,
+        isPublished: true,
+      })
       .auth(accessTokenAdminIngestor, { type: "bearer" })
       .expect(TestData.EntryCreatedStatusCode)
       .then((res) => {
@@ -75,7 +82,7 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
       await deleteDataset(item);
     }
   }
-  
+
   async function processOrigDatablockArray(array) {
     for (const item of array) {
       await deleteOrigDatablock(item);
@@ -321,7 +328,9 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
   describe("OrigDatablocks v4 public findById tests", () => {
     it("0200: should fetch origdatablock by id", () => {
       return request(appUrl)
-        .get(`/api/v4/origdatablocks/public/${encodeURIComponent(origDatablockMinPid)}`)
+        .get(
+          `/api/v4/origdatablocks/public/${encodeURIComponent(origDatablockMinPid)}`,
+        )
         .auth(accessTokenAdminIngestor, { type: "bearer" })
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)

--- a/test/OrigDatablockV4Public.js
+++ b/test/OrigDatablockV4Public.js
@@ -5,6 +5,7 @@ const { TestData } = require("./TestData");
 let accessTokenArchiveManager = null,
   accessTokenAdminIngestor = null,
   datasetPid = null,
+  datasetPid2 = null,
   origDatablockMinPid = null,
   origDatablockPid = null;
 
@@ -33,6 +34,15 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
       });
 
     await request(appUrl)
+      .post("/api/v4/datasets")
+      .send({ ...TestData.RawCorrectMinV4 })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.EntryCreatedStatusCode)
+      .then((res) => {
+        datasetPid2 = res.body.pid;
+      });
+
+    await request(appUrl)
       .post("/api/v4/origdatablocks")
       .send({
         ...TestData.OrigDatablockV4MinCorrect,
@@ -44,6 +54,15 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
       .then((res) => {
         origDatablockMinPid = res.body._id;
       });
+
+    await request(appUrl)
+      .post("/api/v4/origdatablocks")
+      .send({
+        ...TestData.OrigDatablockV4MinCorrect,
+        datasetId: datasetPid2,
+      })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.EntryCreatedStatusCode);
 
     await request(appUrl)
       .post("/api/v4/origdatablocks")
@@ -383,7 +402,56 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
   });
 
   describe("OrigDatablocks v4 public count tests", () => {
-    it("0300: should be able to fetch the count of origdatablocks files providing where filter", async () => {
+    let expectedTotal,
+      expectedTotalPublic,
+      expectedCountForPublicDatasetPid,
+      expectedCountForPublicDatasetPid2;
+
+    before(async () => {
+      const countFiles = async (match) => {
+        const res = await db
+          .collection("OrigDatablock")
+          .aggregate([
+            { $match: match },
+            { $unwind: "$dataFileList" },
+            { $count: "count" },
+          ])
+          .toArray();
+
+        return res[0]?.count ?? 0;
+      };
+
+      expectedTotal = await countFiles({});
+      expectedTotalPublic = await countFiles({ isPublished: true });
+      expectedCountForPublicDatasetPid = await countFiles({
+        datasetId: datasetPid,
+        isPublished: true,
+      });
+      expectedCountForPublicDatasetPid2 = await countFiles({
+        datasetId: datasetPid2,
+        isPublished: true,
+      });
+    });
+
+    it("0300: should be able to fetch the count of origdatablocks files without where filter", async () => {
+      const filter = {
+        where: {},
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/public/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.a("number");
+          res.body.count.should.equal(expectedTotalPublic);
+        });
+    });
+
+    it("0305: should be able to fetch the count of origdatablocks files for datasetPid", async () => {
       const filter = {
         where: {
           datasetId: {
@@ -402,32 +470,87 @@ describe("2900: OrigDatablock v4 public endpoint tests", () => {
           res.body.should.be.a("object");
           res.body.should.have.property("count");
           res.body.count.should.be.a("number");
-          res.body.count.should.be.greaterThan(0);
+          res.body.count.should.equal(expectedCountForPublicDatasetPid);
+        });
+    });
+
+    it("0310: should not fetch count of origdatablocks files for unpublished datasetPid2", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid2,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/public/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.a("number");
+          res.body.count.should.equal(expectedCountForPublicDatasetPid2);
+        });
+    });
+
+    it("0315: should return public count even when authenticated as admin", async () => {
+      const filter = {
+        where: {},
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/public/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.a("number");
+          res.body.count.should.not.equal(expectedTotal);
+          res.body.count.should.equal(expectedTotalPublic);
+        });
+    });
+
+    it("0320: should not fetch count of origdatablocks files for unpublished datasetPid2 as admin", async () => {
+      const filter = {
+        where: {
+          datasetId: {
+            $regex: datasetPid2,
+            $options: "i",
+          },
+        },
+      };
+
+      return request(appUrl)
+        .get("/api/v4/origdatablocks/public/files/count")
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("object");
+          res.body.should.have.property("count");
+          res.body.count.should.be.a("number");
+          res.body.count.should.equal(expectedCountForPublicDatasetPid2);
         });
     });
   });
 
-  describe("Cleanup after the tests", () => {
-    it("0400: delete all origdatablocks as archivemanager", async () => {
-      return await request(appUrl)
-        .get("/api/v4/origdatablocks")
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          return processOrigDatablockArray(res.body);
-        });
-    });
+  after(async () => {
+    const odbs = await request(appUrl)
+      .get("/api/v4/origdatablocks")
+      .auth(accessTokenArchiveManager, { type: "bearer" });
+    await processOrigDatablockArray(odbs.body);
 
-    it("0401: delete all datasets as archivemanager", async () => {
-      return await request(appUrl)
-        .get("/api/v4/datasets")
-        .auth(accessTokenArchiveManager, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          return processDatasetArray(res.body);
-        });
-    });
+    const datasets = await request(appUrl)
+      .get("/api/v4/datasets")
+      .auth(accessTokenArchiveManager, { type: "bearer" });
+    await processDatasetArray(datasets.body);
   });
 });


### PR DESCRIPTION
## Description
This PR adds new endpoints to count files across origdatablocks linked to a specific dataset. It also includes API tests for the public and private file count endpoints.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Add API support to count files across origdatablocks, including public and authenticated variants, and cover them with tests.

New Features:
- Expose a secured /api/v4/origdatablocks/files/count endpoint to return the number of files matching optional filters.
- Expose a public /api/v4/origdatablocks/public/files/count endpoint to return the number of public files matching optional filters.
- Add a service-layer aggregation to count files across origdatablocks with support for filters and projections.

Tests:
- Add authenticated and unauthenticated tests for the private origdatablocks files count endpoint.
- Add tests for the public origdatablocks files count endpoint and adjust existing test case numbering.