### PR TITLE
fix: add job owner when submitting with CREATE_JOB_PRIVILEGED

### DIFF
--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -384,9 +384,11 @@ export class JobsControllerUtils {
         pid: { $in: datasetList.map((x) => x.pid) },
       },
     };
-    const requestUserGroups = this.isJobCreationPrivilegedUser(user)
+    const isPrivilegedUser = this.isPrivilegedUser(user);
+    const baseGroups = isPrivilegedUser
       ? (jobUser?.currentGroups ?? [])
       : (user?.currentGroups ?? []);
+    const requestUserGroups = [...baseGroups];
     if (jobConfiguration.create.auth === CreateJobAuth.DatasetPublic)
       datasetsWhere.where.isPublished = true;
     else if (jobConfiguration.create.auth === CreateJobAuth.DatasetAccess) {
@@ -400,6 +402,8 @@ export class JobsControllerUtils {
         ];
     } else if (jobConfiguration.create.auth === CreateJobAuth.DatasetOwner) {
       if (!user) throw new UnauthorizedException("User not authenticated");
+      if (isPrivilegedUser)
+        requestUserGroups.push(jobCreateDto.ownerGroup as string);
       if (requestUserGroups.length === 0)
         throw new ForbiddenException(
           "User does not belong to any group, cannot create job with #datasetOwner authorization.",

--- a/test/JobsDatasetOwner.js
+++ b/test/JobsDatasetOwner.js
@@ -603,6 +603,31 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       });
   });
 
+  it("0195: Add a new job as a user from CREATE_JOB_PRIVILEGED_GROUPS for another ownerGroup in '#datasetOwner' configuration, where the ownerGroup is owner of these datasets", async () => {
+    const newJob = {
+      ...jobDatasetOwner,
+      ownerGroup: "group3",
+      jobParams: {
+        datasetList: [{ pid: datasetPid2, files: [] }],
+      },
+    };
+
+     return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("group3");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+        jobId7 = res.body["id"];
+        encodedJobOwnedByUser3 = encodeURIComponent(jobId7);
+      });
+  });
+
   it("0200: Add a new job as a user from CREATE_JOB_PRIVILEGED_GROUPS for group1 and user3 in '#datasetOwner' configuration, which should be forbiiden", async () => {
     const newJob = {
       ...jobDatasetOwner,
@@ -651,7 +676,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.not.have.property("id");
         res.body.should.have
           .property("message")
-          .and.be.equal("User does not belong to any group, cannot create job with #datasetOwner authorization.");
+          .and.be.equal("User does not have access to all datasets, cannot create job.");
       });
   });
 
@@ -897,7 +922,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(13);
+        res.body.should.be.an("array").to.have.lengthOf(14);
         res.body
           .map((job) => job.id)
           .should.include.members([jobId2, jobId3, jobId12, jobId21, jobId7]);
@@ -923,7 +948,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(13);
+        res.body.should.be.an("array").to.have.lengthOf(14);
       });
   });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This fixes a regression introduced by #2713 which removed the permissions to submit jobs on behalf of users when logged in with CREATE_JOB_PRIVILEGED_GROUPS

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Allow privileged job creators to set the job owner group when using #datasetOwner authorization and update tests accordingly.

Bug Fixes:
- Restore ability for users in CREATE_JOB_PRIVILEGED_GROUPS to submit jobs on behalf of another owner group when they have dataset access.
- Adjust dataset owner authorization error messaging to reflect dataset access requirements rather than group membership.

Tests:
- Add coverage ensuring privileged users can create jobs for another owner group owning the datasets and update expected job listing counts.