### PR TITLE
fix: allow multiple sorts

### DIFF
--- a/src/common/utils.spec.ts
+++ b/src/common/utils.spec.ts
@@ -1,5 +1,5 @@
 // Currently only covers converToSI
-import { convertToSI, parseDate } from "./utils";
+import { convertToSI, parseDate, parseOrderLimits } from "./utils";
 
 describe("convertToSI", () => {
   it("should convert a known unit to SI successfully", () => {
@@ -63,5 +63,24 @@ describe("parseDate", () => {
   it("should return undefined for undefined input", () => {
     const result = parseDate(undefined);
     expect(result).toBeUndefined();
+  });
+
+  describe("parseOrderLimits", () => {
+    it("should parse a single sort field", () => {
+      const result = parseOrderLimits({
+        limit: 10,
+        order: "creationTime:desc",
+      });
+      expect(result.sort).toEqual({ creationTime: "desc" });
+      expect(result).not.toHaveProperty("order");
+    });
+
+    it("should parse multiple sort fields for stable pagination", () => {
+      const result = parseOrderLimits({
+        limit: 10,
+        order: "creationTime:desc,pid:asc",
+      });
+      expect(result.sort).toEqual({ creationTime: "desc", pid: "asc" });
+    });
   });
 });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -389,9 +389,10 @@ export const parseOrderLimits = (
   const limitFilters: ILimitsFilterV4 = structuredClone(limits);
   if (!limits.order) return limitFilters;
   const sort: Record<string, "asc" | "desc"> = {};
-  for (const part of limits.order.split(",")) {
-    const [field, direction] = part.split(":");
-    if (direction === "asc" || direction === "desc") sort[field] = direction;
+  for (const order of limits.order.split(",")) {
+    const [field, direction] = order.split(":");
+    if (direction === "asc" || direction === "desc")
+      sort[field.trim()] = direction;
   }
   limitFilters.sort = sort;
   return omit(limitFilters, "order");

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -389,8 +389,10 @@ export const parseOrderLimits = (
   const limitFilters: ILimitsFilterV4 = structuredClone(limits);
   if (!limits.order) return limitFilters;
   const sort: Record<string, "asc" | "desc"> = {};
-  const [field, direction] = limits.order.split(":");
-  if (direction === "asc" || direction === "desc") sort[field] = direction;
+  for (const part of limits.order.split(",")) {
+    const [field, direction] = part.split(":");
+    if (direction === "asc" || direction === "desc") sort[field] = direction;
+  }
   limitFilters.sort = sort;
   return omit(limitFilters, "order");
 };


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
parseOrderLimits only parsed one field:direction and dropped the rest. It now splits on commas, so creationTime:desc,pid:asc works.
when rows share the same creationTime (common with batch ingestion), sorting by creationTime alone leaves their order undefined. MongoDB can arrange tied rows differently per request, so the same dataset appears on two pages and others get skipped. Adding a unique field (e.g, pid) as the last sort key fixes their position.


Backward compatible: a single key with no comma parses as before.
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Support comma-separated sort fields in order parsing to ensure stable pagination and avoid duplicate/omitted rows across pages.

Bug Fixes:
- Fix parseOrderLimits dropping additional sort fields by correctly handling comma-separated field:direction pairs.

Tests:
- Add unit tests covering single and multiple sort fields in parseOrderLimits for stable pagination behavior.