### PR TITLE
fix: add datablock size updates with aggregation on cud

### DIFF
--- a/src/datablocks/datablocks.controller.ts
+++ b/src/datablocks/datablocks.controller.ts
@@ -312,10 +312,9 @@ export class DatablocksController {
     if (!dataset)
       throw new NotFoundException(`dataset: ${datablock.datasetId} not found`);
 
-    return this.datablocksService.removeAndUpdateDatasetSizeAndFileCount(
-      { _id: id },
-      datablock.datasetId,
-    );
+    return this.datablocksService.removeAndUpdateDatasetSizeAndFileCount({
+      _id: id,
+    });
   }
 }
 

--- a/src/datablocks/datablocks.controller.ts
+++ b/src/datablocks/datablocks.controller.ts
@@ -34,7 +34,6 @@ import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { IFilters } from "src/common/interfaces/common.interface";
 import { CountApiResponse } from "src/common/types";
 import { DatasetsService } from "src/datasets/datasets.service";
-import { PartialUpdateDatasetObsoleteDto } from "src/datasets/dto/update-dataset-obsolete.dto";
 import { DatablocksService } from "./datablocks.service";
 import { CreateDatablockDto } from "./dto/create-datablock.dto";
 import { PartialUpdateDatablockDto } from "./dto/update-datablock.dto";
@@ -100,20 +99,15 @@ export class DatablocksController {
           pid: createDatablockDto.datasetId,
         },
       });
-      const datablock = await this.datablocksService.create({
+      const datablock = {
         ...createDatablockDto,
         ownerGroup: createDatablockDto.ownerGroup || dataset?.ownerGroup || "",
         accessGroups:
           createDatablockDto.accessGroups || dataset?.accessGroups || [],
-      });
-      if (dataset) {
-        await this.datasetsService.findByIdAndUpdate(datablock.datasetId, {
-          packedSize: (dataset.packedSize ?? 0) + datablock.packedSize,
-          numberOfFilesArchived:
-            dataset.numberOfFilesArchived + datablock.dataFileList.length,
-        });
-      }
-      return datablock;
+      };
+      return await this.datablocksService.createAndUpdateDatasetSizeAndFileCount(
+        datablock,
+      );
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
@@ -279,11 +273,10 @@ export class DatablocksController {
         throw new ForbiddenException("Unauthorized to update this datablock");
       }
 
-      const datablock = await this.datablocksService.update(
+      return await this.datablocksService.updateAndUpdateDatasetSizeAndFileCount(
         { _id: id },
         updateDatablockDto,
       );
-      return datablock;
     } catch (error) {
       if ((error as MongoError).code === 11000) {
         throw new ConflictException(
@@ -304,6 +297,11 @@ export class DatablocksController {
     @Req() request: Request,
     @Param("id") id: string,
   ): Promise<unknown> {
+    const user: JWTUser = request.user as JWTUser;
+    const ability = this.caslAbilityFactory.datablockInstanceAccess(user);
+    if (ability.cannot(Action.DatablockDeleteAny, Datablock)) {
+      throw new ForbiddenException("Unauthorized to delete this datablock");
+    }
     const datablock = await this.datablocksService.findOne({
       where: { _id: id },
     });
@@ -314,21 +312,10 @@ export class DatablocksController {
     if (!dataset)
       throw new NotFoundException(`dataset: ${datablock.datasetId} not found`);
 
-    const user: JWTUser = request.user as JWTUser;
-    const ability = this.caslAbilityFactory.datablockInstanceAccess(user);
-    if (ability.cannot(Action.DatablockDeleteAny, Datablock)) {
-      throw new ForbiddenException("Unauthorized to delete this datablock");
-    }
-
-    const res = (await this.datablocksService.remove({ _id: id })) as Datablock;
-    const updateDatasetDto: PartialUpdateDatasetObsoleteDto = {
-      packedSize: (dataset.packedSize ?? 0) - res.packedSize,
-      numberOfFilesArchived:
-        dataset.numberOfFilesArchived - res.dataFileList.length,
-    };
-    await this.datasetsService.findByIdAndUpdate(dataset.pid, updateDatasetDto);
-
-    return res;
+    return this.datablocksService.removeAndUpdateDatasetSizeAndFileCount(
+      { _id: id },
+      datablock.datasetId,
+    );
   }
 }
 

--- a/src/datablocks/datablocks.service.spec.ts
+++ b/src/datablocks/datablocks.service.spec.ts
@@ -188,10 +188,9 @@ describe("DatablocksService", () => {
         exec: jest.fn().mockResolvedValue(mockDatablock),
       });
 
-      const result = await service.removeAndUpdateDatasetSizeAndFileCount(
-        { _id: "testId" },
-        "testPid",
-      );
+      const result = await service.removeAndUpdateDatasetSizeAndFileCount({
+        _id: "testId",
+      });
 
       expect(result).toEqual(mockDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
@@ -208,10 +207,7 @@ describe("DatablocksService", () => {
       });
 
       await expect(
-        service.removeAndUpdateDatasetSizeAndFileCount(
-          { _id: "missing" },
-          "testPid",
-        ),
+        service.removeAndUpdateDatasetSizeAndFileCount({ _id: "missing" }),
       ).rejects.toThrow(NotFoundException);
       expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
     });

--- a/src/datablocks/datablocks.service.spec.ts
+++ b/src/datablocks/datablocks.service.spec.ts
@@ -1,7 +1,11 @@
+import { NotFoundException } from "@nestjs/common";
+import { REQUEST } from "@nestjs/core";
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Model } from "mongoose";
+import { DatasetsService } from "src/datasets/datasets.service";
 import { DatablocksService } from "./datablocks.service";
+import { CreateDatablockDto } from "./dto/create-datablock.dto";
 import { Datablock } from "./schemas/datablock.schema";
 
 const mockDatablock: Datablock = {
@@ -36,33 +40,180 @@ const mockDatablock: Datablock = {
   ],
 };
 
+const mockCreateDatablockDto: CreateDatablockDto = {
+  datasetId: mockDatablock.datasetId,
+  archiveId: mockDatablock.archiveId,
+  size: mockDatablock.size,
+  packedSize: mockDatablock.packedSize,
+  chkAlg: mockDatablock.chkAlg,
+  version: mockDatablock.version,
+  ownerGroup: mockDatablock.ownerGroup,
+  accessGroups: mockDatablock.accessGroups,
+  instrumentGroup: mockDatablock.instrumentGroup,
+  dataFileList: mockDatablock.dataFileList,
+};
+
+class DatasetsServiceMock {
+  updateDatasetSizeAndFiles = jest.fn().mockResolvedValue(undefined);
+}
+
+function MockDatablockModel(
+  this: Record<string, unknown>,
+  data: Record<string, unknown>,
+) {
+  Object.assign(this, data);
+  this.save = jest.fn().mockResolvedValue({ ...mockDatablock, ...data });
+}
+MockDatablockModel.find = jest.fn();
+MockDatablockModel.findOne = jest.fn();
+MockDatablockModel.findOneAndUpdate = jest.fn();
+MockDatablockModel.findOneAndDelete = jest.fn();
+MockDatablockModel.deleteMany = jest.fn();
+MockDatablockModel.countDocuments = jest.fn();
+
 describe("DatablocksService", () => {
   let service: DatablocksService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let model: Model<Datablock>;
+  let datasetsService: DatasetsServiceMock;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DatablocksService,
         {
           provide: getModelToken("Datablock"),
-          useValue: {
-            new: jest.fn().mockResolvedValue(mockDatablock),
-            constructor: jest.fn().mockResolvedValue(mockDatablock),
-            find: jest.fn(),
-            create: jest.fn(),
-            exec: jest.fn(),
-          },
+          useValue: MockDatablockModel,
         },
+        { provide: DatasetsService, useClass: DatasetsServiceMock },
+        { provide: REQUEST, useValue: { user: { username: "testUser" } } },
       ],
     }).compile();
 
     service = await module.resolve<DatablocksService>(DatablocksService);
     model = module.get<Model<Datablock>>(getModelToken("Datablock"));
+    datasetsService = module.get<DatasetsServiceMock>(DatasetsService);
   });
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("create", () => {
+    it("should save a datablock stamped with the requesting user", async () => {
+      const result = await service.create(mockCreateDatablockDto);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          createdBy: "testUser",
+          updatedBy: "testUser",
+          datasetId: mockCreateDatablockDto.datasetId,
+        }),
+      );
+    });
+  });
+
+  describe("updateDatasetSizeAndFiles", () => {
+    it("should delegate to the datasets service using the datablock model and its packedSize/numberOfFilesArchived fields", async () => {
+      await service.updateDatasetSizeAndFiles("testPid");
+
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        "testPid",
+        model,
+        "packedSize",
+        "numberOfFilesArchived",
+      );
+    });
+  });
+
+  describe("createAndUpdateDatasetSizeAndFileCount", () => {
+    it("should create the datablock and then update the dataset size and file count", async () => {
+      const result = await service.createAndUpdateDatasetSizeAndFileCount(
+        mockCreateDatablockDto,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          datasetId: mockCreateDatablockDto.datasetId,
+        }),
+      );
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        mockCreateDatablockDto.datasetId,
+        model,
+        "packedSize",
+        "numberOfFilesArchived",
+      );
+    });
+  });
+
+  describe("updateAndUpdateDatasetSizeAndFileCount", () => {
+    it("should update the datablock and then update the dataset size and file count", async () => {
+      (model.findOneAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockDatablock),
+      });
+
+      const result = await service.updateAndUpdateDatasetSizeAndFileCount(
+        { _id: "testId" },
+        { size: 2000 },
+      );
+
+      expect(result).toEqual(mockDatablock);
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        mockDatablock.datasetId,
+        model,
+        "packedSize",
+        "numberOfFilesArchived",
+      );
+    });
+
+    it("should throw NotFoundException and not touch the dataset when the datablock does not exist", async () => {
+      (model.findOneAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.updateAndUpdateDatasetSizeAndFileCount(
+          { _id: "missing" },
+          { size: 2000 },
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeAndUpdateDatasetSizeAndFileCount", () => {
+    it("should remove the datablock and then update the dataset size and file count", async () => {
+      (model.findOneAndDelete as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockDatablock),
+      });
+
+      const result = await service.removeAndUpdateDatasetSizeAndFileCount(
+        { _id: "testId" },
+        "testPid",
+      );
+
+      expect(result).toEqual(mockDatablock);
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        "testPid",
+        model,
+        "packedSize",
+        "numberOfFilesArchived",
+      );
+    });
+
+    it("should throw NotFoundException and not touch the dataset when the datablock does not exist", async () => {
+      (model.findOneAndDelete as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.removeAndUpdateDatasetSizeAndFileCount(
+          { _id: "missing" },
+          "testPid",
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -80,7 +80,9 @@ export class DatablocksService {
    * @param filter - The filter to find the document to remove.
    * @returns The removed document or null if not found.
    */
-  async remove(filter: FilterQuery<DatablockDocument>): Promise<unknown> {
+  async remove(
+    filter: FilterQuery<DatablockDocument>,
+  ): Promise<Datablock | null> {
     return await this.datablockModel.findOneAndDelete(filter).exec();
   }
 
@@ -109,7 +111,7 @@ export class DatablocksService {
   async updateAndUpdateDatasetSizeAndFileCount(
     filter: FilterQuery<DatablockDocument>,
     updateDatablockDto: PartialUpdateDatablockDto,
-  ): Promise<Datablock | null> {
+  ): Promise<Datablock> {
     const datablock = await this.update(filter, updateDatablockDto);
     if (!datablock) throw new DatablocksFilterNotFoundException(filter);
     await this.updateDatasetSizeAndFiles(datablock.datasetId);
@@ -118,11 +120,10 @@ export class DatablocksService {
 
   async removeAndUpdateDatasetSizeAndFileCount(
     filter: FilterQuery<DatablockDocument>,
-    datasetId: string,
-  ): Promise<unknown> {
+  ): Promise<Datablock> {
     const datablock = await this.remove(filter);
     if (!datablock) throw new DatablocksFilterNotFoundException(filter);
-    await this.updateDatasetSizeAndFiles(datasetId);
+    await this.updateDatasetSizeAndFiles(datablock.datasetId);
     return datablock;
   }
 

--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -1,6 +1,7 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 import { InjectModel } from "@nestjs/mongoose";
+import { DatasetsService } from "src/datasets/datasets.service";
 import { Request } from "express";
 import { DeleteResult, FilterQuery, Model } from "mongoose";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
@@ -16,6 +17,7 @@ export class DatablocksService {
   constructor(
     @InjectModel(Datablock.name)
     private datablockModel: Model<DatablockDocument>,
+    private readonly datasetsService: DatasetsService,
     @Inject(REQUEST) private request: Request,
   ) {}
 
@@ -94,5 +96,51 @@ export class DatablocksService {
     const count = await this.datablockModel.countDocuments(whereFilter).exec();
 
     return { count };
+  }
+
+  async createAndUpdateDatasetSizeAndFileCount(
+    createDatablockDto: CreateDatablockDto,
+  ): Promise<Datablock> {
+    const datablock = await this.create(createDatablockDto);
+    if (datablock) await this.updateDatasetSizeAndFiles(datablock.datasetId);
+    return datablock;
+  }
+
+  async updateAndUpdateDatasetSizeAndFileCount(
+    filter: FilterQuery<DatablockDocument>,
+    updateDatablockDto: PartialUpdateDatablockDto,
+  ): Promise<Datablock | null> {
+    const datablock = await this.update(filter, updateDatablockDto);
+    if (!datablock) throw new DatablocksFilterNotFoundException(filter);
+    await this.updateDatasetSizeAndFiles(datablock.datasetId);
+    return datablock;
+  }
+
+  async removeAndUpdateDatasetSizeAndFileCount(
+    filter: FilterQuery<DatablockDocument>,
+    datasetId: string,
+  ): Promise<unknown> {
+    const datablock = await this.remove(filter);
+    if (!datablock) throw new DatablocksFilterNotFoundException(filter);
+    await this.updateDatasetSizeAndFiles(datasetId);
+    return datablock;
+  }
+
+  async updateDatasetSizeAndFiles(pid: string) {
+    await this.datasetsService.updateDatasetSizeAndFiles(
+      pid,
+      this.datablockModel,
+      "packedSize",
+      "numberOfFilesArchived",
+    );
+  }
+}
+
+class DatablocksFilterNotFoundException extends NotFoundException {
+  constructor(filter: FilterQuery<DatablockDocument>) {
+    const errorMessage = filter._id
+      ? `datablock: ${filter._id} not found`
+      : `datablock not found for filter: ${JSON.stringify(filter)}`;
+    super(errorMessage);
   }
 }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2382,6 +2382,7 @@ export class DatasetsController {
       pid,
       Action.DatasetOrigdatablockDelete,
     );
+
     const odb = (await this.origDatablocksService.remove({
       _id: oid,
       datasetId: pid,
@@ -2444,13 +2445,9 @@ export class DatasetsController {
       accessGroups: dataset.accessGroups,
       instrumentGroup: dataset.instrumentGroup,
     };
-    const datablock = await this.datablocksService.create(createDatablock);
-    await this.datasetsService.findByIdAndUpdate(pid, {
-      packedSize: (dataset.packedSize ?? 0) + datablock.packedSize,
-      numberOfFilesArchived:
-        dataset.numberOfFilesArchived + datablock.dataFileList.length,
-    });
-    return datablock;
+    return this.datablocksService.createAndUpdateDatasetSizeAndFileCount(
+      createDatablock,
+    );
   }
 
   // GET /datasets/:id/datablocks
@@ -2583,27 +2580,10 @@ export class DatasetsController {
     );
     if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
 
-    const datablockBeforeUpdate = await this.datablocksService.findOne({
-      where: { _id: did },
-    });
-    if (!datablockBeforeUpdate)
-      throw new NotFoundException(`datablock: ${did} not found`);
-
-    const datablock = (await this.datablocksService.update(
-      { _id: did },
+    return this.datablocksService.updateAndUpdateDatasetSizeAndFileCount(
+      { _id: did, datasetId: pid },
       updateDatablockDto,
-    )) as Datablock;
-    await this.datasetsService.findByIdAndUpdate(pid, {
-      packedSize:
-        (dataset.packedSize ?? 0) -
-        datablockBeforeUpdate.packedSize +
-        datablock.packedSize,
-      numberOfFilesArchived:
-        dataset.numberOfFilesArchived -
-        datablockBeforeUpdate.dataFileList.length +
-        datablock.dataFileList.length,
-    });
-    return datablock;
+    );
   }
 
   // DELETE /datasets/:id/datablocks/:fk
@@ -2646,19 +2626,13 @@ export class DatasetsController {
     if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
 
     // remove datablock
-    const datablock = (await this.datablocksService.remove({
-      _id: did,
-      datasetId: pid,
-    })) as Datablock;
-
-    if (!datablock) throw new NotFoundException(`datablock: ${did} not found`);
-    // update dataset size and files number
-    const updateDatasetDto: PartialUpdateDatasetObsoleteDto = {
-      packedSize: (dataset.packedSize ?? 0) - datablock.packedSize,
-      numberOfFilesArchived:
-        dataset.numberOfFilesArchived - datablock.dataFileList.length,
-    };
-    await this.datasetsService.findByIdAndUpdate(dataset.pid, updateDatasetDto);
+    await this.datablocksService.removeAndUpdateDatasetSizeAndFileCount(
+      {
+        _id: did,
+        datasetId: pid,
+      },
+      pid,
+    );
   }
 
   // DELETE /datasets/:id/datablocks

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2626,13 +2626,10 @@ export class DatasetsController {
     if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
 
     // remove datablock
-    await this.datablocksService.removeAndUpdateDatasetSizeAndFileCount(
-      {
-        _id: did,
-        datasetId: pid,
-      },
-      pid,
-    );
+    await this.datablocksService.removeAndUpdateDatasetSizeAndFileCount({
+      _id: did,
+      datasetId: pid,
+    });
   }
 
   // DELETE /datasets/:id/datablocks

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -72,6 +72,8 @@ import { DatasetOpenSearchDto } from "src/opensearch/dto/dataset-opensearch.dto"
 import { plainToInstance } from "class-transformer";
 import { DATASET_OPENSEARCH_PROJECTION } from "../opensearch/utils/dataset-opensearch.utils";
 import { withOCCFilter } from "./utils/occ-util";
+import { DatablockDocument } from "src/datablocks/schemas/datablock.schema";
+import { OrigDatablockDocument } from "src/origdatablocks/schemas/origdatablock.schema";
 @Injectable({ scope: Scope.REQUEST })
 export class DatasetsService {
   private readonly osDefaultIndex: string;
@@ -733,5 +735,46 @@ export class DatasetsService {
       Logger.error(`Sync failed: ${errorMessage}`, "OpensearchSync");
       throw error;
     }
+  }
+
+  async updateDatasetSizeAndFiles(
+    pid: string,
+    model: Model<DatablockDocument> | Model<OrigDatablockDocument>,
+    sizeField: string,
+    filesField: string,
+  ): Promise<void> {
+    const { numberOfFiles, size } = await this.aggregateSizeAndFileCount(
+      pid,
+      model,
+      sizeField,
+    );
+    await this.findByIdAndUpdate(pid, {
+      [sizeField]: size,
+      [filesField]: numberOfFiles,
+    });
+  }
+
+  async aggregateSizeAndFileCount(
+    datasetId: string,
+    model: Model<DatablockDocument> | Model<OrigDatablockDocument>,
+    sizeField: string,
+  ): Promise<{ numberOfFiles: number; size: number }> {
+    const [result] = await model
+      .aggregate<{ numberOfFiles: number; size: number }>([
+        { $match: { datasetId } },
+        {
+          $group: {
+            _id: null,
+            size: { $sum: `$${sizeField}` },
+            numberOfFiles: {
+              $sum: { $size: { $ifNull: ["$dataFileList", []] } },
+            },
+          },
+        },
+      ])
+      .exec();
+    return result
+      ? { numberOfFiles: result.numberOfFiles, size: result.size }
+      : { numberOfFiles: 0, size: 0 };
   }
 }

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -10,7 +10,7 @@ import { Request } from "express";
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
   findByIdAndUpdate = jest.fn();
-  aggregateSizeAndFileCount = jest.fn();
+  updateDatasetSizeAndFiles = jest.fn();
 }
 
 class DatasetsServiceMock {
@@ -22,7 +22,6 @@ class CaslAbilityFactoryMock {}
 describe("OrigDatablocksController", () => {
   let controller: OrigDatablocksController;
   let origDatablocksService: OrigDatablocksServiceMock;
-  let datasetsService: DatasetsServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -39,9 +38,6 @@ describe("OrigDatablocksController", () => {
     origDatablocksService = module.get<OrigDatablocksService>(
       OrigDatablocksService,
     ) as unknown as OrigDatablocksServiceMock;
-    datasetsService = module.get<DatasetsService>(
-      DatasetsService,
-    ) as unknown as DatasetsServiceMock;
   });
 
   it("should be defined", () => {
@@ -58,11 +54,6 @@ describe("OrigDatablocksController", () => {
       updatedAt: new Date(Date.now() - 1000),
       datasetId: "ds1",
     };
-
-    beforeEach(() => {
-      // Isolate the update handler from the side-effect helper
-      controller["updateDatasetSizeAndFiles"] = jest.fn();
-    });
 
     it("should throw NotFoundException if datablock not found before update", async () => {
       origDatablocksService.findOne.mockResolvedValue(null);
@@ -115,9 +106,9 @@ describe("OrigDatablocksController", () => {
       const result = await controller.update(mockRequest, "123", mockDto);
 
       expect(result).toEqual(updatedDatablock);
-      expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
-        "ds1",
-      );
+      expect(
+        origDatablocksService.updateDatasetSizeAndFiles,
+      ).toHaveBeenCalledWith("ds1");
     });
 
     describe("update", () => {
@@ -146,9 +137,9 @@ describe("OrigDatablocksController", () => {
         const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
-        expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
-          "ds1",
-        );
+        expect(
+          origDatablocksService.updateDatasetSizeAndFiles,
+        ).toHaveBeenCalledWith("ds1");
       });
 
       it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
@@ -163,46 +154,10 @@ describe("OrigDatablocksController", () => {
         const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
-        expect(controller["updateDatasetSizeAndFiles"]).toHaveBeenCalledWith(
-          "ds1",
-        );
+        expect(
+          origDatablocksService.updateDatasetSizeAndFiles,
+        ).toHaveBeenCalledWith("ds1");
       });
-    });
-  });
-
-  describe("updateDatasetSizeAndFiles", () => {
-    it("should use aggregateSizeAndFileCount and update the dataset", async () => {
-      origDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
-        size: 2000,
-        numberOfFiles: 5,
-      });
-
-      await controller["updateDatasetSizeAndFiles"]("testPid");
-
-      expect(
-        origDatablocksService.aggregateSizeAndFileCount,
-      ).toHaveBeenCalledWith("testPid");
-      expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
-        "testPid",
-        {
-          size: 2000,
-          numberOfFiles: 5,
-        },
-      );
-    });
-
-    it("should propagate zero totals when no origdatablocks exist", async () => {
-      origDatablocksService.aggregateSizeAndFileCount.mockResolvedValue({
-        size: 0,
-        numberOfFiles: 0,
-      });
-
-      await controller["updateDatasetSizeAndFiles"]("emptyPid");
-
-      expect(datasetsService.findByIdAndUpdate).toHaveBeenCalledWith(
-        "emptyPid",
-        { size: 0, numberOfFiles: 0 },
-      );
     });
   });
 });

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -209,16 +209,9 @@ export class OrigDatablocksController {
       createOrigDatablockDto,
     );
 
-    await this.updateDatasetSizeAndFiles(dataset.pid);
+    await this.origDatablocksService.updateDatasetSizeAndFiles(dataset.pid);
 
     return origdatablock;
-  }
-
-  async updateDatasetSizeAndFiles(pid: string) {
-    const { size, numberOfFiles } =
-      await this.origDatablocksService.aggregateSizeAndFileCount(pid);
-
-    await this.datasetsService.findByIdAndUpdate(pid, { size, numberOfFiles });
   }
 
   @UseGuards(PoliciesGuard)
@@ -650,7 +643,9 @@ export class OrigDatablocksController {
     if (!origdatablock) {
       throw new NotFoundException("Datablock not found");
     }
-    await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
+    await this.origDatablocksService.updateDatasetSizeAndFiles(
+      origdatablock.datasetId,
+    );
     return origdatablock;
   }
 
@@ -679,7 +674,9 @@ export class OrigDatablocksController {
       _id: id,
     })) as OrigDatablock;
 
-    await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
+    await this.origDatablocksService.updateDatasetSizeAndFiles(
+      origdatablock.datasetId,
+    );
 
     return origdatablock;
   }

--- a/src/origdatablocks/origdatablocks.service.spec.ts
+++ b/src/origdatablocks/origdatablocks.service.spec.ts
@@ -1,6 +1,8 @@
+import { REQUEST } from "@nestjs/core";
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Model } from "mongoose";
+import { DatasetsService } from "src/datasets/datasets.service";
 import { OrigDatablocksService } from "./origdatablocks.service";
 import { OrigDatablock } from "./schemas/origdatablock.schema";
 
@@ -30,10 +32,15 @@ const mockOrigDatablock: OrigDatablock = {
   ],
 };
 
+class DatasetsServiceMock {
+  updateDatasetSizeAndFiles = jest.fn().mockResolvedValue(undefined);
+}
+
 describe("OrigdatablocksService", () => {
   let service: OrigDatablocksService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   let model: Model<OrigDatablock>;
+  let datasetsService: DatasetsServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -50,6 +57,8 @@ describe("OrigdatablocksService", () => {
             aggregate: jest.fn(),
           },
         },
+        { provide: DatasetsService, useClass: DatasetsServiceMock },
+        { provide: REQUEST, useValue: { user: { username: "testUser" } } },
       ],
     }).compile();
 
@@ -57,49 +66,44 @@ describe("OrigdatablocksService", () => {
       OrigDatablocksService,
     );
     model = module.get<Model<OrigDatablock>>(getModelToken("OrigDatablock"));
+    datasetsService = module.get<DatasetsServiceMock>(DatasetsService);
   });
 
   it("should be defined", () => {
     expect(service).toBeDefined();
   });
 
-  describe("aggregateSizeAndFileCount", () => {
-    it("should return summed size and file count from origdatablocks", async () => {
-      (model.aggregate as jest.Mock).mockReturnValue({
-        exec: jest
-          .fn()
-          .mockResolvedValue([{ _id: null, size: 5000, numberOfFiles: 3 }]),
-      });
+  describe("updateDatasetSizeAndFiles", () => {
+    it("should delegate size and file count aggregation to the datasets service, keyed on the origdatablock model and its size/numberOfFiles fields", async () => {
+      await service.updateDatasetSizeAndFiles("testPid");
 
-      const result = await service.aggregateSizeAndFileCount("testPid");
-
-      expect(result).toEqual({ size: 5000, numberOfFiles: 3 });
-    });
-
-    it("should return zeros when no origdatablocks exist for the dataset", async () => {
-      (model.aggregate as jest.Mock).mockReturnValue({
-        exec: jest.fn().mockResolvedValue([]),
-      });
-
-      const result = await service.aggregateSizeAndFileCount("emptyPid");
-
-      expect(result).toEqual({ size: 0, numberOfFiles: 0 });
-    });
-
-    it("should match on the given datasetId", async () => {
-      (model.aggregate as jest.Mock).mockReturnValue({
-        exec: jest
-          .fn()
-          .mockResolvedValue([{ _id: null, size: 0, numberOfFiles: 0 }]),
-      });
-
-      await service.aggregateSizeAndFileCount("ds123");
-
-      expect(model.aggregate).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ $match: { datasetId: "ds123" } }),
-        ]),
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        "testPid",
+        model,
+        "size",
+        "numberOfFiles",
       );
+    });
+
+    it("should forward the given datasetId unchanged", async () => {
+      await service.updateDatasetSizeAndFiles("ds123");
+
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        "ds123",
+        expect.anything(),
+        "size",
+        "numberOfFiles",
+      );
+    });
+
+    it("should propagate errors raised by the datasets service", async () => {
+      datasetsService.updateDatasetSizeAndFiles.mockRejectedValueOnce(
+        new Error("aggregation failed"),
+      );
+
+      await expect(
+        service.updateDatasetSizeAndFiles("testPid"),
+      ).rejects.toThrow("aggregation failed");
     });
   });
 });

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -8,6 +8,7 @@ import {
 } from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 import { Request } from "express";
+import { DatasetsService } from "src/datasets/datasets.service";
 import { InjectModel } from "@nestjs/mongoose";
 import {
   FilterQuery,
@@ -53,6 +54,7 @@ export class OrigDatablocksService {
   constructor(
     @InjectModel(OrigDatablock.name)
     private origDatablockModel: Model<OrigDatablockDocument>,
+    private readonly datasetsService: DatasetsService,
     @Inject(REQUEST) private request: Request,
   ) {}
 
@@ -397,25 +399,12 @@ export class OrigDatablocksService {
     return { count: result?.count ?? 0 };
   }
 
-  async aggregateSizeAndFileCount(
-    datasetId: string,
-  ): Promise<{ size: number; numberOfFiles: number }> {
-    const [result] = await this.origDatablockModel
-      .aggregate<{ size: number; numberOfFiles: number }>([
-        { $match: { datasetId } },
-        {
-          $group: {
-            _id: null,
-            size: { $sum: "$size" },
-            numberOfFiles: {
-              $sum: { $size: { $ifNull: ["$dataFileList", []] } },
-            },
-          },
-        },
-      ])
-      .exec();
-    return result
-      ? { size: result.size, numberOfFiles: result.numberOfFiles }
-      : { size: 0, numberOfFiles: 0 };
+  async updateDatasetSizeAndFiles(pid: string) {
+    await this.datasetsService.updateDatasetSizeAndFiles(
+      pid,
+      this.origDatablockModel,
+      "size",
+      "numberOfFiles",
+    );
   }
 }

--- a/test/Datablock.js
+++ b/test/Datablock.js
@@ -296,6 +296,7 @@ describe("Datablocks", () => {
         datasetId: historyDatasetId, // Override with our specific values
         ownerGroup: historyOwnerGroup,
         size: originalSize,
+        packedSize: originalSize,
         archiveId: "original-archive-id",
       };
 
@@ -312,10 +313,26 @@ describe("Datablocks", () => {
         });
     });
 
+    it("1005: should update the dataset packedSize and numberOfFilesArchived after creating the datablock", async () => {
+      return request(appUrl)
+        .get("/api/v3/Datasets/" + encodeURIComponent(historyDatasetId))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("packedSize").and.equal(originalSize);
+          res.body.should.have
+            .property("numberOfFilesArchived")
+            .and.equal(TestData.DataBlockCorrect.dataFileList.length);
+        });
+    });
+
     it("1010: should update datablock with new archiveId and size", async () => {
       const updatePayload = {
         archiveId: "994394",
         size: 737243,
+        packedSize: 737243,
       };
 
       return request(appUrl)
@@ -332,6 +349,9 @@ describe("Datablocks", () => {
             .property("archiveId")
             .equal(updatePayload.archiveId);
           res.body.should.have.property("size").equal(updatePayload.size);
+          res.body.should.have
+            .property("packedSize")
+            .equal(updatePayload.packedSize);
         });
     });
 
@@ -346,6 +366,21 @@ describe("Datablocks", () => {
           res.body.should.be.a("object");
           res.body.should.have.property("archiveId").equal("994394");
           res.body.should.have.property("size").equal(737243);
+        });
+    });
+
+    it("1025: should update the dataset packedSize after the datablock size was updated", async () => {
+      return request(appUrl)
+        .get("/api/v3/Datasets/" + encodeURIComponent(historyDatasetId))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("packedSize").and.equal(737243);
+          res.body.should.have
+            .property("numberOfFilesArchived")
+            .and.equal(TestData.DataBlockCorrect.dataFileList.length);
         });
     });
 
@@ -396,6 +431,25 @@ describe("Datablocks", () => {
           // After should have the updated values
           updateHistory.after.should.have.property("archiveId").equal("994394");
           updateHistory.after.should.have.property("size").equal(737243);
+        });
+    });
+
+    it("1035: should reset the dataset packedSize and numberOfFilesArchived after deleting the datablock", async () => {
+      await request(appUrl)
+        .delete(`/api/v3/datablocks/${historyDatablockId}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+        .expect(TestData.SuccessfulDeleteStatusCode);
+
+      return request(appUrl)
+        .get("/api/v3/Datasets/" + encodeURIComponent(historyDatasetId))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("packedSize").and.equal(0);
+          res.body.should.have.property("numberOfFilesArchived").and.equal(0);
         });
     });
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
It uses size and files aggregation pipe for all datablock related information. It includes a small refactor to reuse the origdatablocks aggregation pipeline (following commits allows to see the refactor first and then the feat) 

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Centralize dataset size and file count aggregation for datablocks and origdatablocks, and ensure dataset metadata stays consistent on create, update, and delete operations.

New Features:
- Add service methods to create, update, and delete datablocks while automatically recalculating and persisting dataset packed size and archived file count.
- Introduce a reusable dataset aggregation helper that computes size and file totals from datablock and origdatablock collections.

Enhancements:
- Refactor datablocks and origdatablocks controllers and services to delegate size/file aggregation to the datasets service instead of performing local calculations.
- Stamp newly created datablocks with the requesting user for auditing.
- Align origdatablocks with the shared aggregation mechanism used by datablocks for dataset size and file updates.

Tests:
- Extend unit and integration tests to cover dataset size and file count updates across datablock lifecycle operations, including not-found cases and error propagation from aggregation.