### PR TITLE
fix: use orig size computation consistently

### DIFF
--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -141,7 +141,7 @@ class DatablocksFilterNotFoundException extends NotFoundException {
   constructor(filter: FilterQuery<DatablockDocument>) {
     const errorMessage = filter._id
       ? `datablock: ${filter._id} not found`
-      : `datablock not found for filter: ${JSON.stringify(filter)}`;
+      : "datablock not found";
     super(errorMessage);
   }
 }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2266,7 +2266,7 @@ export class DatasetsController {
     @Param("pid") pid: string,
     @Param("oid") oid: string,
     @Body() updateOrigdatablockDto: UpdateOrigDatablockDto,
-  ): Promise<OrigDatablock | null> {
+  ): Promise<OrigDatablock> {
     await this.checkPermissionsForDatasetExtended(
       request,
       pid,

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -86,7 +86,6 @@ import { CreateDatasetDto } from "./dto/create-dataset.dto";
 import { CreateDerivedDatasetObsoleteDto } from "./dto/create-derived-dataset-obsolete.dto";
 import { CreateRawDatasetObsoleteDto } from "./dto/create-raw-dataset-obsolete.dto";
 import { OutputDatasetObsoleteDto } from "./dto/output-dataset-obsolete.dto";
-import { PartialUpdateDatasetObsoleteDto } from "./dto/update-dataset-obsolete.dto";
 import {
   PartialUpdateDatasetDto,
   PartialUpdateDatasetLifecycleDto,
@@ -2098,15 +2097,9 @@ export class DatasetsController {
       accessGroups: dataset.accessGroups,
       instrumentGroup: dataset.instrumentGroup,
     };
-    const datablock =
-      await this.origDatablocksService.create(createOrigDatablock);
-
-    const updateDatasetDto: PartialUpdateDatasetObsoleteDto = {
-      size: dataset.size + datablock.size,
-      numberOfFiles: dataset.numberOfFiles + datablock.dataFileList.length,
-    };
-    await this.datasetsService.findByIdAndUpdate(dataset.pid, updateDatasetDto);
-    return datablock;
+    return this.origDatablocksService.createAndUpdateDatasetSizeAndFileCount(
+      createOrigDatablock,
+    );
   }
 
   // POST /datasets/:id/origdatablocks/isValid
@@ -2274,30 +2267,15 @@ export class DatasetsController {
     @Param("oid") oid: string,
     @Body() updateOrigdatablockDto: UpdateOrigDatablockDto,
   ): Promise<OrigDatablock | null> {
-    const dataset = await this.checkPermissionsForDatasetExtended(
+    await this.checkPermissionsForDatasetExtended(
       request,
       pid,
       Action.DatasetOrigdatablockUpdate,
     );
-    const origDatablockBeforeUpdate = await this.origDatablocksService.findOne({
-      _id: oid,
-    });
-
-    if (!origDatablockBeforeUpdate)
-      throw new NotFoundException(`origDatablock: ${oid} not found`);
-
-    const origDatablock = (await this.origDatablocksService.update(
-      { _id: oid },
+    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
+      oid,
       updateOrigdatablockDto,
-    )) as OrigDatablock;
-    await this.datasetsService.findByIdAndUpdate(pid, {
-      size: dataset.size - origDatablockBeforeUpdate.size + origDatablock.size,
-      numberOfFiles:
-        dataset.numberOfFiles -
-        origDatablockBeforeUpdate.dataFileList.length +
-        origDatablock.dataFileList.length,
-    });
-    return origDatablock;
+    );
   }
 
   // DELETE /datasets/:id/origdatablocks
@@ -2377,24 +2355,16 @@ export class DatasetsController {
     @Param("pid") pid: string,
     @Param("oid") oid: string,
   ): Promise<unknown> {
-    const dataset = await this.checkPermissionsForDatasetExtended(
+    await this.checkPermissionsForDatasetExtended(
       request,
       pid,
       Action.DatasetOrigdatablockDelete,
     );
 
-    const odb = (await this.origDatablocksService.remove({
+    return this.origDatablocksService.removeAndUpdateDatasetSizeAndFileCount({
       _id: oid,
       datasetId: pid,
-    })) as OrigDatablock;
-    if (!odb) throw new NotFoundException(`origDatablock: ${oid} not found`);
-    // update dataset size and files number
-    const updateDatasetDto: PartialUpdateDatasetObsoleteDto = {
-      size: dataset.size - odb.size,
-      numberOfFiles: dataset.numberOfFiles - odb.dataFileList.length,
-    };
-    await this.datasetsService.findByIdAndUpdate(dataset.pid, updateDatasetDto);
-    return odb;
+    });
   }
 
   // POST /datasets/:id/datablocks

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -4,13 +4,12 @@ import { OrigDatablocksService } from "src/origdatablocks/origdatablocks.service
 import { DatasetsService } from "src/datasets/datasets.service";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { ConfigModule } from "@nestjs/config";
-import { NotFoundException, HttpException } from "@nestjs/common";
+import { NotFoundException, PreconditionFailedException } from "@nestjs/common";
 import { Request } from "express";
 
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
-  findByIdAndUpdate = jest.fn();
-  updateDatasetSizeAndFiles = jest.fn();
+  findByIdAndUpdateDatasetSizeAndFileCount = jest.fn();
 }
 
 class DatasetsServiceMock {
@@ -63,28 +62,28 @@ describe("OrigDatablocksController", () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it("should throw PreconditionFailed if header date <= updatedAt", async () => {
-      origDatablocksService.findOne.mockResolvedValue({
-        ...mockDatablock,
-        updatedAt: new Date(),
-      });
-
+    it("should propagate PreconditionFailedException if header date <= updatedAt", async () => {
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
         .mockResolvedValue(mockDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+        new PreconditionFailedException(
+          "OrigDatablock #123 has been modified on server",
+        ),
+      );
 
       await expect(
         controller.update(mockRequest, "123", mockDto),
-      ).rejects.toThrow(HttpException);
+      ).rejects.toThrow(PreconditionFailedException);
     });
 
     it("should throw NotFoundException if datablock not found after update", async () => {
-      origDatablocksService.findOne.mockResolvedValue(mockDatablock);
-      origDatablocksService.findByIdAndUpdate.mockResolvedValue(null);
-
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
         .mockResolvedValue(mockDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+        new NotFoundException("OrigDatablock #123 not found"),
+      );
 
       await expect(
         controller.update(mockRequest, "123", mockDto),
@@ -94,21 +93,23 @@ describe("OrigDatablocksController", () => {
     it("should return updated datablock on success", async () => {
       const updatedDatablock = { ...mockDatablock, name: "Updated Name" };
 
-      origDatablocksService.findOne.mockResolvedValue(mockDatablock);
-      origDatablocksService.findByIdAndUpdate.mockResolvedValue(
-        updatedDatablock,
-      );
-
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
-        .mockResolvedValue(updatedDatablock);
+        .mockResolvedValue(mockDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+        updatedDatablock,
+      );
 
       const result = await controller.update(mockRequest, "123", mockDto);
 
       expect(result).toEqual(updatedDatablock);
       expect(
-        origDatablocksService.updateDatasetSizeAndFiles,
-      ).toHaveBeenCalledWith("ds1");
+        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+      ).toHaveBeenCalledWith(
+        "123",
+        mockDto,
+        new Date(mockRequest.headers["if-unmodified-since"] as string),
+      );
     });
 
     describe("update", () => {
@@ -121,8 +122,10 @@ describe("OrigDatablocksController", () => {
       const updatedDatablock = { ...mockDatablock, name: "Updated Name" };
 
       beforeEach(() => {
-        origDatablocksService.findOne.mockResolvedValue(mockDatablock);
-        origDatablocksService.findByIdAndUpdate.mockResolvedValue(
+        jest
+          .spyOn(controller, "checkPermissionsForOrigDatablock")
+          .mockResolvedValue(mockDatablock);
+        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
           updatedDatablock,
         );
       });
@@ -130,16 +133,12 @@ describe("OrigDatablocksController", () => {
       it("should proceed with update if 'if-unmodified-since' header is missing", async () => {
         const mockRequest = { headers: {} } as Request; // No header
 
-        jest
-          .spyOn(controller, "checkPermissionsForOrigDatablock")
-          .mockResolvedValue(mockDatablock);
-
         const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
         expect(
-          origDatablocksService.updateDatasetSizeAndFiles,
-        ).toHaveBeenCalledWith("ds1");
+          origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+        ).toHaveBeenCalledWith("123", mockDto, undefined);
       });
 
       it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
@@ -147,16 +146,12 @@ describe("OrigDatablocksController", () => {
           headers: { "if-unmodified-since": "not-a-date" },
         } as Request; // Invalid date format
 
-        jest
-          .spyOn(controller, "checkPermissionsForOrigDatablock")
-          .mockResolvedValue(mockDatablock);
-
         const result = await controller.update(mockRequest, "123", mockDto);
 
         expect(result).toEqual(updatedDatablock);
         expect(
-          origDatablocksService.updateDatasetSizeAndFiles,
-        ).toHaveBeenCalledWith("ds1");
+          origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+        ).toHaveBeenCalledWith("123", mockDto, undefined);
       });
     });
   });

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -656,7 +656,7 @@ export class OrigDatablocksController {
   })
   @ApiResponse({
     status: 200,
-    description: "No value is returned",
+    description: "The deleted origdatablock",
   })
   async remove(@Param("id") id: string): Promise<OrigDatablock> {
     return this.origDatablocksService.removeAndUpdateDatasetSizeAndFileCount({

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -205,13 +205,9 @@ export class OrigDatablocksController {
       };
     }
 
-    const origdatablock = await this.origDatablocksService.create(
+    return this.origDatablocksService.createAndUpdateDatasetSizeAndFileCount(
       createOrigDatablockDto,
     );
-
-    await this.origDatablocksService.updateDatasetSizeAndFiles(dataset.pid);
-
-    return origdatablock;
   }
 
   @UseGuards(PoliciesGuard)
@@ -635,18 +631,11 @@ export class OrigDatablocksController {
       Action.OrigdatablockUpdate,
     );
     const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
-    const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
+    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
       id,
       updateOrigDatablockDto,
       unmodifiedSince,
     );
-    if (!origdatablock) {
-      throw new NotFoundException("Datablock not found");
-    }
-    await this.origDatablocksService.updateDatasetSizeAndFiles(
-      origdatablock.datasetId,
-    );
-    return origdatablock;
   }
 
   // DELETE /origdatablocks/:id
@@ -669,15 +658,9 @@ export class OrigDatablocksController {
     status: 200,
     description: "No value is returned",
   })
-  async remove(@Param("id") id: string): Promise<unknown> {
-    const origdatablock = (await this.origDatablocksService.remove({
+  async remove(@Param("id") id: string): Promise<OrigDatablock> {
+    return this.origDatablocksService.removeAndUpdateDatasetSizeAndFileCount({
       _id: id,
-    })) as OrigDatablock;
-
-    await this.origDatablocksService.updateDatasetSizeAndFiles(
-      origdatablock.datasetId,
-    );
-
-    return origdatablock;
+    });
   }
 }

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -445,7 +445,7 @@ class OrigDatablocksFilterNotFoundException extends NotFoundException {
   constructor(filter: FilterQuery<OrigDatablockDocument>) {
     const errorMessage = filter._id
       ? `origDatablock: ${filter._id} not found`
-      : `origDatablock not found for filter: ${JSON.stringify(filter)}`;
+      : "origDatablock not found";
     super(errorMessage);
   }
 }

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -332,7 +332,9 @@ export class OrigDatablocksService {
       .exec();
   }
 
-  async remove(filter: FilterQuery<OrigDatablockDocument>): Promise<unknown> {
+  async remove(
+    filter: FilterQuery<OrigDatablockDocument>,
+  ): Promise<OrigDatablock | null> {
     return this.origDatablockModel.findOneAndDelete(filter).exec();
   }
 
@@ -371,10 +373,6 @@ export class OrigDatablocksService {
     return patchedOrigDatablock;
   }
 
-  async findByIdAndDelete(id: string): Promise<OutputOrigDatablockDto | null> {
-    return await this.origDatablockModel.findOneAndDelete({ _id: id });
-  }
-
   async count(
     filter: IFilters<OrigDatablockDocument>,
   ): Promise<CountApiResponse> {
@@ -399,6 +397,40 @@ export class OrigDatablocksService {
     return { count: result?.count ?? 0 };
   }
 
+  async createAndUpdateDatasetSizeAndFileCount(
+    createDatablockDto: CreateOrigDatablockDto,
+  ): Promise<OrigDatablock> {
+    const origDatablock = await this.create(createDatablockDto);
+    if (origDatablock)
+      await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+    return origDatablock;
+  }
+
+  async findByIdAndUpdateDatasetSizeAndFileCount(
+    _id: string,
+    updateDatablockDto: PartialUpdateOrigDatablockDto,
+    unmodifiedSince?: Date,
+  ): Promise<OrigDatablock> {
+    const origDatablock = await this.findByIdAndUpdate(
+      _id,
+      updateDatablockDto,
+      unmodifiedSince,
+    );
+    if (!origDatablock)
+      throw new OrigDatablocksFilterNotFoundException({ _id });
+    await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+    return origDatablock;
+  }
+
+  async removeAndUpdateDatasetSizeAndFileCount(
+    filter: FilterQuery<OrigDatablockDocument>,
+  ): Promise<OrigDatablock> {
+    const origDatablock = await this.remove(filter);
+    if (!origDatablock) throw new OrigDatablocksFilterNotFoundException(filter);
+    await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+    return origDatablock;
+  }
+
   async updateDatasetSizeAndFiles(pid: string) {
     await this.datasetsService.updateDatasetSizeAndFiles(
       pid,
@@ -406,5 +438,14 @@ export class OrigDatablocksService {
       "size",
       "numberOfFiles",
     );
+  }
+}
+
+class OrigDatablocksFilterNotFoundException extends NotFoundException {
+  constructor(filter: FilterQuery<OrigDatablockDocument>) {
+    const errorMessage = filter._id
+      ? `origDatablock: ${filter._id} not found`
+      : `origDatablock not found for filter: ${JSON.stringify(filter)}`;
+    super(errorMessage);
   }
 }

--- a/src/origdatablocks/origdatablocks.v4.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.spec.ts
@@ -9,7 +9,7 @@ import { Request } from "express";
 
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
-  findByIdAndUpdate = jest.fn();
+  findByIdAndUpdateDatasetSizeAndFileCount = jest.fn();
   findOneComplete = jest.fn();
 }
 
@@ -60,12 +60,6 @@ describe("OrigDatablocksV4Controller", () => {
       name: "Updated Name",
     };
 
-    beforeEach(() => {
-      jest
-        .spyOn(controller, "updateDatasetSizeAndFiles")
-        .mockResolvedValue(undefined);
-    });
-
     it("should throw NotFoundException if datablock not found", async () => {
       jest.spyOn(origDatablocksService, "findOne").mockResolvedValue(null);
 
@@ -82,11 +76,7 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should throw HttpException if service throws exception (when header date is older than updatedAt)", async () => {
-      jest.spyOn(origDatablocksService, "findOne").mockResolvedValue({
-        ...mockDatablock,
-        updatedAt: new Date(),
-      });
-      origDatablocksService.findByIdAndUpdate.mockRejectedValue(
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
         new PreconditionFailedException("Resource has been modified on server"),
       );
 
@@ -104,7 +94,9 @@ describe("OrigDatablocksV4Controller", () => {
       await expect(
         controller.findByIdAndUpdate(mockRequest, "db123", mockUpdateDto),
       ).rejects.toThrow(PreconditionFailedException);
-      expect(origDatablocksService.findByIdAndUpdate).toHaveBeenCalledWith(
+      expect(
+        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+      ).toHaveBeenCalledWith(
         "db123",
         mockUpdateDto,
         new Date(mockRequest.headers["if-unmodified-since"] as string),
@@ -112,12 +104,13 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should throw NotFoundException if update returns null", async () => {
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+        new NotFoundException("OrigDatablock #db123 not found"),
+      );
+
       jest
-        .spyOn(origDatablocksService, "findOne")
-        .mockResolvedValue(mockDatablock);
-      jest
-        .spyOn(origDatablocksService, "findByIdAndUpdate")
-        .mockResolvedValue(null);
+        .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
+        .mockResolvedValue(updatedDatablock);
 
       const mockRequest = {
         user: { id: "user123" },
@@ -127,17 +120,14 @@ describe("OrigDatablocksV4Controller", () => {
       } as unknown as Request;
 
       await expect(
-        controller.findByIdAndUpdate(mockRequest, "db123", {}, mockUpdateDto),
+        controller.findByIdAndUpdate(mockRequest, "db123", mockUpdateDto),
       ).rejects.toThrow(NotFoundException);
     });
 
     it("should return updated datablock on success", async () => {
-      jest
-        .spyOn(origDatablocksService, "findOne")
-        .mockResolvedValue(mockDatablock);
-      jest
-        .spyOn(origDatablocksService, "findByIdAndUpdate")
-        .mockResolvedValue(updatedDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+        updatedDatablock,
+      );
 
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
@@ -157,12 +147,9 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should succeed if 'if-unmodified-since' header is missing", async () => {
-      jest
-        .spyOn(origDatablocksService, "findOne")
-        .mockResolvedValue(mockDatablock);
-      jest
-        .spyOn(origDatablocksService, "findByIdAndUpdate")
-        .mockResolvedValue(updatedDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+        updatedDatablock,
+      );
 
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablockWrite")
@@ -182,12 +169,9 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should succeed if 'if-unmodified-since' header is malformed", async () => {
-      jest
-        .spyOn(origDatablocksService, "findOne")
-        .mockResolvedValue(mockDatablock);
-      jest
-        .spyOn(origDatablocksService, "findByIdAndUpdate")
-        .mockResolvedValue(updatedDatablock);
+      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+        updatedDatablock,
+      );
 
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablockWrite")

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -41,7 +41,7 @@ import {
   OrigDatablock,
   OrigDatablockDocument,
 } from "./schemas/origdatablock.schema";
-import { IFacets, IFilters } from "src/common/interfaces/common.interface";
+import { IFacets } from "src/common/interfaces/common.interface";
 import {
   IOrigDatablockFields,
   IOrigDatablockFiltersV4,
@@ -49,7 +49,6 @@ import {
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { DatasetsService } from "src/datasets/datasets.service";
-import { PartialUpdateDatasetDto } from "src/datasets/dto/update-dataset.dto";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
 import { CreateDatasetDto } from "src/datasets/dto/create-dataset.dto";
@@ -365,26 +364,6 @@ export class OrigDatablocksV4Controller {
     return filter;
   }
 
-  async updateDatasetSizeAndFiles(pid: string) {
-    const parsedFilters: IFilters<OrigDatablockDocument, IOrigDatablockFields> =
-      { where: { datasetId: pid } };
-    const datasetOrigdatablocks =
-      (await this.origDatablocksService.findAllComplete(
-        parsedFilters,
-      )) as OutputOrigDatablockDto[];
-
-    const updateDatasetDto: PartialUpdateDatasetDto = {
-      size: datasetOrigdatablocks
-        .map((odb) => odb.size)
-        .reduce((ps, a) => ps + a, 0),
-      numberOfFiles: datasetOrigdatablocks
-        .map((odb) => odb.dataFileList.length)
-        .reduce((ps, a) => ps + a, 0),
-    };
-
-    await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto);
-  }
-
   // POST /origdatablocks
   @UseGuards(PoliciesGuard)
   @CheckPolicies("origdatablocks", (ability: AppAbility) =>
@@ -431,16 +410,9 @@ export class OrigDatablocksV4Controller {
       createOrigDatablockDto,
       Action.OrigdatablockCreate,
     );
-
-    const origdatablock = await this.origDatablocksService.create(
+    return this.origDatablocksService.createAndUpdateDatasetSizeAndFileCount(
       createOrigDatablockDto,
     );
-
-    if (origdatablock) {
-      await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
-    }
-
-    return origdatablock;
   }
 
   // POST /origdatablocks/isValid
@@ -839,17 +811,11 @@ export class OrigDatablocksV4Controller {
       Action.OrigdatablockUpdate,
     );
     const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
-    const origdatablock = await this.origDatablocksService.findByIdAndUpdate(
+    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
       id,
       updateOrigDatablockDto,
       unmodifiedSince,
     );
-
-    if (origdatablock) {
-      await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
-    }
-
-    return origdatablock;
   }
 
   // DELETE /origdatablocks/:id
@@ -869,26 +835,21 @@ export class OrigDatablocksV4Controller {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    type: OutputOrigDatablockDto,
+    type: OrigDatablock,
     description: "Removed origdatablock value is returned",
   })
   async findByIdAndDelete(
     @Req() request: Request,
     @Param("id") id: string,
-  ): Promise<OutputOrigDatablockDto | null> {
+  ): Promise<OrigDatablock | null> {
     await this.checkPermissionsForOrigDatablockWrite(
       request,
       id,
       Action.OrigdatablockDelete,
     );
 
-    const origdatablock =
-      await this.origDatablocksService.findByIdAndDelete(id);
-
-    if (origdatablock) {
-      await this.updateDatasetSizeAndFiles(origdatablock.datasetId);
-    }
-
-    return origdatablock;
+    return this.origDatablocksService.removeAndUpdateDatasetSizeAndFileCount({
+      _id: id,
+    });
   }
 }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR uses aggreagtion pipes for size computations when cud on origs. It makes sure the pipes is used everywhere 

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Centralize dataset size and file count recalculation for origdatablocks in the service layer and ensure it is consistently applied on create, update, and delete operations.

Bug Fixes:
- Ensure dataset size and file counts are recalculated using the shared aggregation-based helper whenever origdatablocks are created, updated, or deleted.

Enhancements:
- Introduce service helper methods that couple origdatablock create/update/delete operations with dataset size and file count updates, replacing duplicated controller logic.
- Add a dedicated NotFoundException for origdatablock lookups by filter to provide clearer error messages and consistent 404 handling.