### PR TITLE
perf: avoid recompute to optimize size updates

### DIFF
--- a/src/datablocks/datablocks.controller.ts
+++ b/src/datablocks/datablocks.controller.ts
@@ -273,7 +273,7 @@ export class DatablocksController {
         throw new ForbiddenException("Unauthorized to update this datablock");
       }
 
-      return await this.datablocksService.updateAndUpdateDatasetSizeAndFileCount(
+      return await this.datablocksService.updateOneAndUpdateDatasetSizeAndFileCount(
         { _id: id },
         updateDatablockDto,
       );

--- a/src/datablocks/datablocks.service.spec.ts
+++ b/src/datablocks/datablocks.service.spec.ts
@@ -127,8 +127,7 @@ describe("DatablocksService", () => {
       );
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockCreateDatablockDto.datasetId,
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         result,
         undefined,
       );
@@ -158,8 +157,7 @@ describe("DatablocksService", () => {
       expect(result).toEqual(mockDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockDatablock.datasetId,
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         mockDatablock,
         oldDatablock,
       );
@@ -211,8 +209,7 @@ describe("DatablocksService", () => {
       expect(result).toEqual(mockDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         "testPid",
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         undefined,
         mockDatablock,
       );

--- a/src/datablocks/datablocks.service.spec.ts
+++ b/src/datablocks/datablocks.service.spec.ts
@@ -114,19 +114,6 @@ describe("DatablocksService", () => {
     });
   });
 
-  describe("updateDatasetSizeAndFiles", () => {
-    it("should delegate to the datasets service using the datablock model and its packedSize/numberOfFilesArchived fields", async () => {
-      await service.updateDatasetSizeAndFiles("testPid");
-
-      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
-        "testPid",
-        model,
-        "packedSize",
-        "numberOfFilesArchived",
-      );
-    });
-  });
-
   describe("createAndUpdateDatasetSizeAndFileCount", () => {
     it("should create the datablock and then update the dataset size and file count", async () => {
       const result = await service.createAndUpdateDatasetSizeAndFileCount(
@@ -140,41 +127,70 @@ describe("DatablocksService", () => {
       );
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockCreateDatablockDto.datasetId,
-        model,
         "packedSize",
         "numberOfFilesArchived",
+        result,
+        undefined,
       );
     });
   });
 
-  describe("updateAndUpdateDatasetSizeAndFileCount", () => {
-    it("should update the datablock and then update the dataset size and file count", async () => {
+  describe("updateOneAndUpdateDatasetSizeAndFileCount", () => {
+    const oldDatablock: Datablock = {
+      ...mockDatablock,
+      packedSize: 800,
+      dataFileList: [],
+    };
+
+    it("should update the datablock and then update the dataset size and file count by the delta", async () => {
+      (model.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(oldDatablock),
+      });
       (model.findOneAndUpdate as jest.Mock).mockReturnValue({
         exec: jest.fn().mockResolvedValue(mockDatablock),
       });
 
-      const result = await service.updateAndUpdateDatasetSizeAndFileCount(
+      const result = await service.updateOneAndUpdateDatasetSizeAndFileCount(
         { _id: "testId" },
-        { size: 2000 },
+        { packedSize: mockDatablock.packedSize },
       );
 
       expect(result).toEqual(mockDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockDatablock.datasetId,
-        model,
         "packedSize",
         "numberOfFilesArchived",
+        mockDatablock,
+        oldDatablock,
       );
     });
 
-    it("should throw NotFoundException and not touch the dataset when the datablock does not exist", async () => {
+    it("should throw NotFoundException and not touch the dataset when the original datablock does not exist", async () => {
+      (model.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.updateOneAndUpdateDatasetSizeAndFileCount(
+          { _id: "missing" },
+          { size: 2000 },
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
+    });
+
+    it("should throw NotFoundException and not touch the dataset when the datablock disappears during update", async () => {
+      (model.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(oldDatablock),
+      });
       (model.findOneAndUpdate as jest.Mock).mockReturnValue({
         exec: jest.fn().mockResolvedValue(null),
       });
 
       await expect(
-        service.updateAndUpdateDatasetSizeAndFileCount(
-          { _id: "missing" },
+        service.updateOneAndUpdateDatasetSizeAndFileCount(
+          { _id: "testId" },
           { size: 2000 },
         ),
       ).rejects.toThrow(NotFoundException);
@@ -183,7 +199,7 @@ describe("DatablocksService", () => {
   });
 
   describe("removeAndUpdateDatasetSizeAndFileCount", () => {
-    it("should remove the datablock and then update the dataset size and file count", async () => {
+    it("should remove the datablock and then update the dataset size and file count with negated values", async () => {
       (model.findOneAndDelete as jest.Mock).mockReturnValue({
         exec: jest.fn().mockResolvedValue(mockDatablock),
       });
@@ -195,9 +211,10 @@ describe("DatablocksService", () => {
       expect(result).toEqual(mockDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         "testPid",
-        model,
         "packedSize",
         "numberOfFilesArchived",
+        undefined,
+        mockDatablock,
       );
     });
 

--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -148,8 +148,7 @@ export class DatablocksService {
   ): Promise<void> {
     await this.datasetsService.updateDatasetSizeAndFiles(
       pid,
-      "packedSize",
-      "numberOfFilesArchived",
+      { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
       newDocument,
       oldDocument,
     );

--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -104,17 +104,27 @@ export class DatablocksService {
     createDatablockDto: CreateDatablockDto,
   ): Promise<Datablock> {
     const datablock = await this.create(createDatablockDto);
-    if (datablock) await this.updateDatasetSizeAndFiles(datablock.datasetId);
+    if (datablock)
+      await this.updateDatasetSizeAndFiles(datablock.datasetId, datablock);
     return datablock;
   }
 
-  async updateAndUpdateDatasetSizeAndFileCount(
+  async updateOneAndUpdateDatasetSizeAndFileCount(
     filter: FilterQuery<DatablockDocument>,
     updateDatablockDto: PartialUpdateDatablockDto,
   ): Promise<Datablock> {
+    const oldDatablock = await this.findOne({
+      where: filter,
+      fields: { packedSize: 1, dataFileList: 1 },
+    });
+    if (!oldDatablock) throw new DatablocksFilterNotFoundException(filter);
     const datablock = await this.update(filter, updateDatablockDto);
     if (!datablock) throw new DatablocksFilterNotFoundException(filter);
-    await this.updateDatasetSizeAndFiles(datablock.datasetId);
+    await this.updateDatasetSizeAndFiles(
+      datablock.datasetId,
+      datablock,
+      oldDatablock,
+    );
     return datablock;
   }
 
@@ -123,16 +133,25 @@ export class DatablocksService {
   ): Promise<Datablock> {
     const datablock = await this.remove(filter);
     if (!datablock) throw new DatablocksFilterNotFoundException(filter);
-    await this.updateDatasetSizeAndFiles(datablock.datasetId);
+    await this.updateDatasetSizeAndFiles(
+      datablock.datasetId,
+      undefined,
+      datablock,
+    );
     return datablock;
   }
 
-  async updateDatasetSizeAndFiles(pid: string) {
+  private async updateDatasetSizeAndFiles(
+    pid: string,
+    newDocument?: Datablock,
+    oldDocument?: Datablock,
+  ): Promise<void> {
     await this.datasetsService.updateDatasetSizeAndFiles(
       pid,
-      this.datablockModel,
       "packedSize",
       "numberOfFilesArchived",
+      newDocument,
+      oldDocument,
     );
   }
 }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2270,8 +2270,8 @@ export class DatasetsController {
       pid,
       Action.DatasetOrigdatablockUpdate,
     );
-    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
-      oid,
+    return this.origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount(
+      { _id: oid, datasetId: pid },
       updateOrigdatablockDto,
     );
   }
@@ -2548,7 +2548,7 @@ export class DatasetsController {
     );
     if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
 
-    return this.datablocksService.updateAndUpdateDatasetSizeAndFileCount(
+    return this.datablocksService.updateOneAndUpdateDatasetSizeAndFileCount(
       { _id: did, datasetId: pid },
       updateDatablockDto,
     );

--- a/src/datasets/datasets.service.spec.ts
+++ b/src/datasets/datasets.service.spec.ts
@@ -16,6 +16,7 @@ import { MetadataKeysService } from "src/metadata-keys/metadatakeys.service";
 import { OpensearchService } from "src/opensearch/opensearch.service";
 import { REQUEST } from "@nestjs/core";
 import { NotFoundException, PreconditionFailedException } from "@nestjs/common";
+import { Datablock } from "src/datablocks/schemas/datablock.schema";
 
 class InitialDatasetsServiceMock {}
 
@@ -203,5 +204,76 @@ describe("DatasetsService", () => {
     await expect(
       service.findByIdAndUpdate("testId", updateDto, unmodifiedSince),
     ).rejects.toThrow(PreconditionFailedException);
+  });
+
+  describe("updateDatasetSizeAndFiles", () => {
+    beforeEach(() => {
+      model.updateOne = jest
+        .fn()
+        .mockReturnValue({ exec: jest.fn().mockResolvedValue(undefined) });
+    });
+
+    it("should $inc by the delta between the old and new document", async () => {
+      const oldDocument = {
+        packedSize: 800,
+        dataFileList: [],
+      } as unknown as Datablock;
+      const newDocument = {
+        packedSize: 1000,
+        dataFileList: [{}],
+      } as unknown as Datablock;
+
+      await service.updateDatasetSizeAndFiles(
+        "testPid",
+        "packedSize",
+        "numberOfFilesArchived",
+        newDocument,
+        oldDocument,
+      );
+
+      expect(model.updateOne).toHaveBeenCalledWith(
+        { _id: "testPid" },
+        { $inc: { packedSize: 200, numberOfFilesArchived: 1 } },
+      );
+    });
+
+    it("should treat a missing old document as zero, e.g. on create", async () => {
+      const newDocument = {
+        packedSize: 1000,
+        dataFileList: [{}, {}],
+      } as unknown as Datablock;
+
+      await service.updateDatasetSizeAndFiles(
+        "testPid",
+        "packedSize",
+        "numberOfFilesArchived",
+        newDocument,
+      );
+
+      expect(model.updateOne).toHaveBeenCalledWith(
+        { _id: "testPid" },
+        { $inc: { packedSize: 1000, numberOfFilesArchived: 2 } },
+      );
+    });
+
+    it("should treat a missing new document as zero, e.g. on remove", async () => {
+      const oldDocument = {
+        packedSize: 1000,
+        dataFileList: [{}, {}],
+      } as unknown as Datablock;
+
+      await service.updateDatasetSizeAndFiles(
+        "testPid",
+        "packedSize",
+        "numberOfFilesArchived",
+        undefined,
+        oldDocument,
+      );
+
+      expect(model.updateOne).toHaveBeenCalledWith(
+        { _id: "testPid" },
+        { $inc: { packedSize: -1000, numberOfFilesArchived: -2 } },
+      );
+    });
   });
 });

--- a/src/datasets/datasets.service.spec.ts
+++ b/src/datasets/datasets.service.spec.ts
@@ -225,8 +225,7 @@ describe("DatasetsService", () => {
 
       await service.updateDatasetSizeAndFiles(
         "testPid",
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         newDocument,
         oldDocument,
       );
@@ -245,8 +244,7 @@ describe("DatasetsService", () => {
 
       await service.updateDatasetSizeAndFiles(
         "testPid",
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         newDocument,
       );
 
@@ -264,8 +262,7 @@ describe("DatasetsService", () => {
 
       await service.updateDatasetSizeAndFiles(
         "testPid",
-        "packedSize",
-        "numberOfFilesArchived",
+        { size: "packedSize", numberOfFiles: "numberOfFilesArchived" },
         undefined,
         oldDocument,
       );

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -735,32 +735,24 @@ export class DatasetsService {
     }
   }
 
-  private async _updateDatasetSizeAndFiles(
-    pid: string,
-    sizesDelta:
-      | Pick<DatasetDocument, "size" | "numberOfFiles">
-      | Pick<DatasetDocument, "packedSize" | "numberOfFilesArchived">,
-  ): Promise<void> {
-    await this.datasetModel
-      .updateOne({ _id: pid }, { $inc: sizesDelta })
-      .exec();
-  }
-
   async updateDatasetSizeAndFiles<T extends Datablock | OrigDatablock>(
     pid: string,
-    sizeKey: Extract<keyof T, "size" | "packedSize">,
-    numberOfFilesKey: "numberOfFiles" | "numberOfFilesArchived",
+    sizeKeys:
+      | { size: "size"; numberOfFiles: "numberOfFiles" }
+      | { size: "packedSize"; numberOfFiles: "numberOfFilesArchived" },
     newDocument?: T,
     oldDocument?: T,
   ): Promise<void> {
-    const newSize = (newDocument?.[sizeKey] ?? 0) as number;
+    const newSize = (newDocument?.[sizeKeys.size as keyof T] ?? 0) as number;
     const newFiles = newDocument?.dataFileList?.length ?? 0;
-    const oldSize = (oldDocument?.[sizeKey] ?? 0) as number;
+    const oldSize = (oldDocument?.[sizeKeys.size as keyof T] ?? 0) as number;
     const oldFiles = oldDocument?.dataFileList?.length ?? 0;
 
-    await this._updateDatasetSizeAndFiles(pid, {
-      [sizeKey]: newSize - oldSize,
-      [numberOfFilesKey]: newFiles - oldFiles,
-    } as Parameters<typeof this._updateDatasetSizeAndFiles>[1]);
+    const delta = {
+      [sizeKeys.size]: newSize - oldSize,
+      [sizeKeys.numberOfFiles]: newFiles - oldFiles,
+    };
+
+    await this.datasetModel.updateOne({ _id: pid }, { $inc: delta }).exec();
   }
 }

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -72,8 +72,8 @@ import { DatasetOpenSearchDto } from "src/opensearch/dto/dataset-opensearch.dto"
 import { plainToInstance } from "class-transformer";
 import { DATASET_OPENSEARCH_PROJECTION } from "../opensearch/utils/dataset-opensearch.utils";
 import { withOCCFilter } from "./utils/occ-util";
-import { DatablockDocument } from "src/datablocks/schemas/datablock.schema";
-import { OrigDatablockDocument } from "src/origdatablocks/schemas/origdatablock.schema";
+import { Datablock } from "src/datablocks/schemas/datablock.schema";
+import { OrigDatablock } from "src/origdatablocks/schemas/origdatablock.schema";
 @Injectable({ scope: Scope.REQUEST })
 export class DatasetsService {
   private readonly osDefaultIndex: string;
@@ -735,44 +735,32 @@ export class DatasetsService {
     }
   }
 
-  async updateDatasetSizeAndFiles(
+  private async _updateDatasetSizeAndFiles(
     pid: string,
-    model: Model<DatablockDocument> | Model<OrigDatablockDocument>,
-    sizeField: string,
-    filesField: string,
+    sizesDelta:
+      | Pick<DatasetDocument, "size" | "numberOfFiles">
+      | Pick<DatasetDocument, "packedSize" | "numberOfFilesArchived">,
   ): Promise<void> {
-    const { numberOfFiles, size } = await this.aggregateSizeAndFileCount(
-      pid,
-      model,
-      sizeField,
-    );
-    await this.findByIdAndUpdate(pid, {
-      [sizeField]: size,
-      [filesField]: numberOfFiles,
-    });
+    await this.datasetModel
+      .updateOne({ _id: pid }, { $inc: sizesDelta })
+      .exec();
   }
 
-  async aggregateSizeAndFileCount(
-    datasetId: string,
-    model: Model<DatablockDocument> | Model<OrigDatablockDocument>,
-    sizeField: string,
-  ): Promise<{ numberOfFiles: number; size: number }> {
-    const [result] = await model
-      .aggregate<{ numberOfFiles: number; size: number }>([
-        { $match: { datasetId } },
-        {
-          $group: {
-            _id: null,
-            size: { $sum: `$${sizeField}` },
-            numberOfFiles: {
-              $sum: { $size: { $ifNull: ["$dataFileList", []] } },
-            },
-          },
-        },
-      ])
-      .exec();
-    return result
-      ? { numberOfFiles: result.numberOfFiles, size: result.size }
-      : { numberOfFiles: 0, size: 0 };
+  async updateDatasetSizeAndFiles<T extends Datablock | OrigDatablock>(
+    pid: string,
+    sizeKey: Extract<keyof T, "size" | "packedSize">,
+    numberOfFilesKey: "numberOfFiles" | "numberOfFilesArchived",
+    newDocument?: T,
+    oldDocument?: T,
+  ): Promise<void> {
+    const newSize = (newDocument?.[sizeKey] ?? 0) as number;
+    const newFiles = newDocument?.dataFileList?.length ?? 0;
+    const oldSize = (oldDocument?.[sizeKey] ?? 0) as number;
+    const oldFiles = oldDocument?.dataFileList?.length ?? 0;
+
+    await this._updateDatasetSizeAndFiles(pid, {
+      [sizeKey]: newSize - oldSize,
+      [numberOfFilesKey]: newFiles - oldFiles,
+    } as Parameters<typeof this._updateDatasetSizeAndFiles>[1]);
   }
 }

--- a/src/origdatablocks/origdatablocks.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.controller.spec.ts
@@ -9,7 +9,7 @@ import { Request } from "express";
 
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
-  findByIdAndUpdateDatasetSizeAndFileCount = jest.fn();
+  updateOneAndUpdateDatasetSizeAndFileCount = jest.fn();
 }
 
 class DatasetsServiceMock {
@@ -66,7 +66,7 @@ describe("OrigDatablocksController", () => {
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
         .mockResolvedValue(mockDatablock);
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
         new PreconditionFailedException(
           "OrigDatablock #123 has been modified on server",
         ),
@@ -81,7 +81,7 @@ describe("OrigDatablocksController", () => {
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
         .mockResolvedValue(mockDatablock);
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
         new NotFoundException("OrigDatablock #123 not found"),
       );
 
@@ -96,7 +96,7 @@ describe("OrigDatablocksController", () => {
       jest
         .spyOn(controller, "checkPermissionsForOrigDatablock")
         .mockResolvedValue(mockDatablock);
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
         updatedDatablock,
       );
 
@@ -104,9 +104,9 @@ describe("OrigDatablocksController", () => {
 
       expect(result).toEqual(updatedDatablock);
       expect(
-        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+        origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount,
       ).toHaveBeenCalledWith(
-        "123",
+        { _id: "123" },
         mockDto,
         new Date(mockRequest.headers["if-unmodified-since"] as string),
       );
@@ -125,7 +125,7 @@ describe("OrigDatablocksController", () => {
         jest
           .spyOn(controller, "checkPermissionsForOrigDatablock")
           .mockResolvedValue(mockDatablock);
-        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+        origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
           updatedDatablock,
         );
       });
@@ -137,8 +137,8 @@ describe("OrigDatablocksController", () => {
 
         expect(result).toEqual(updatedDatablock);
         expect(
-          origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
-        ).toHaveBeenCalledWith("123", mockDto, undefined);
+          origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount,
+        ).toHaveBeenCalledWith({ _id: "123" }, mockDto, undefined);
       });
 
       it("should proceed with update if 'if-unmodified-since' header is malformed", async () => {
@@ -150,8 +150,8 @@ describe("OrigDatablocksController", () => {
 
         expect(result).toEqual(updatedDatablock);
         expect(
-          origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
-        ).toHaveBeenCalledWith("123", mockDto, undefined);
+          origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount,
+        ).toHaveBeenCalledWith({ _id: "123" }, mockDto, undefined);
       });
     });
   });

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -79,31 +79,6 @@ export class OrigDatablocksController {
     return origDatablock;
   }
 
-  // async checkPermissionsForDataset(request: Request, id: string) {
-  //   const user: JWTUser = request.user as JWTUser;
-  //   const dataset = await this.datasetsService.findOne({
-  //     where: { pid: id },
-  //   });
-  //   if (dataset) {
-  //     // NOTE: We need DatasetClass instance because casl module
-  //     // can not recognize the type from dataset mongo database model.
-  //     // If other fields are needed can be added later.
-  //     const newDatasetClass = new DatasetClass();
-  //     newDatasetClass.ownerGroup = dataset.ownerGroup;
-
-  //     if (user) {
-  //       const ability = this.caslAbilityFactory.createOrigDatablockForUser(user);
-  //       const canUpdate = ability.can(Action.Update, newDatasetClass);
-  //       if (!canUpdate) {
-  //         throw new ForbiddenException("Unauthorized access");
-  //       }
-  //     }
-  //   } else {
-  //     throw new BadRequestException("Invalid datasetId");
-  //   }
-  //   return dataset;
-  // }
-
   async generateOrigDatablockInstanceInstanceForPermissions(
     dataset:
       | CreateRawDatasetObsoleteDto
@@ -631,8 +606,8 @@ export class OrigDatablocksController {
       Action.OrigdatablockUpdate,
     );
     const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
-    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
-      id,
+    return this.origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount(
+      { _id: id },
       updateOrigDatablockDto,
       unmodifiedSince,
     );

--- a/src/origdatablocks/origdatablocks.service.spec.ts
+++ b/src/origdatablocks/origdatablocks.service.spec.ts
@@ -1,9 +1,10 @@
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 import { getModelToken } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
-import { Model } from "mongoose";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { OrigDatablocksService } from "./origdatablocks.service";
+import { CreateOrigDatablockDto } from "./dto/create-origdatablock.dto";
 import { OrigDatablock } from "./schemas/origdatablock.schema";
 
 const mockOrigDatablock: OrigDatablock = {
@@ -32,30 +33,51 @@ const mockOrigDatablock: OrigDatablock = {
   ],
 };
 
+const mockCreateOrigDatablockDto: CreateOrigDatablockDto = {
+  datasetId: mockOrigDatablock.datasetId,
+  size: mockOrigDatablock.size,
+  ownerGroup: mockOrigDatablock.ownerGroup,
+  accessGroups: mockOrigDatablock.accessGroups,
+  instrumentGroup: mockOrigDatablock.instrumentGroup,
+  chkAlg: mockOrigDatablock.chkAlg,
+  dataFileList: mockOrigDatablock.dataFileList,
+};
+
 class DatasetsServiceMock {
   updateDatasetSizeAndFiles = jest.fn().mockResolvedValue(undefined);
 }
 
+function MockOrigDatablockModel(
+  this: Record<string, unknown>,
+  data: Record<string, unknown>,
+) {
+  Object.assign(this, data);
+  this.save = jest.fn().mockResolvedValue({ ...mockOrigDatablock, ...data });
+}
+MockOrigDatablockModel.find = jest.fn();
+MockOrigDatablockModel.findOne = jest.fn();
+MockOrigDatablockModel.findOneAndUpdate = jest.fn();
+MockOrigDatablockModel.findOneAndDelete = jest.fn();
+MockOrigDatablockModel.deleteMany = jest.fn();
+MockOrigDatablockModel.countDocuments = jest.fn();
+MockOrigDatablockModel.aggregate = jest.fn();
+MockOrigDatablockModel.schema = {
+  path: jest.fn().mockReturnValue({ instance: "String" }),
+};
+
 describe("OrigdatablocksService", () => {
   let service: OrigDatablocksService;
-
-  let model: Model<OrigDatablock>;
   let datasetsService: DatasetsServiceMock;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrigDatablocksService,
         {
           provide: getModelToken("OrigDatablock"),
-          useValue: {
-            new: jest.fn().mockResolvedValue(mockOrigDatablock),
-            constructors: jest.fn().mockResolvedValue(mockOrigDatablock),
-            find: jest.fn(),
-            create: jest.fn(),
-            exec: jest.fn(),
-            aggregate: jest.fn(),
-          },
+          useValue: MockOrigDatablockModel,
         },
         { provide: DatasetsService, useClass: DatasetsServiceMock },
         { provide: REQUEST, useValue: { user: { username: "testUser" } } },
@@ -65,7 +87,6 @@ describe("OrigdatablocksService", () => {
     service = await module.resolve<OrigDatablocksService>(
       OrigDatablocksService,
     );
-    model = module.get<Model<OrigDatablock>>(getModelToken("OrigDatablock"));
     datasetsService = module.get<DatasetsServiceMock>(DatasetsService);
   });
 
@@ -73,37 +94,117 @@ describe("OrigdatablocksService", () => {
     expect(service).toBeDefined();
   });
 
-  describe("updateDatasetSizeAndFiles", () => {
-    it("should delegate size and file count aggregation to the datasets service, keyed on the origdatablock model and its size/numberOfFiles fields", async () => {
-      await service.updateDatasetSizeAndFiles("testPid");
+  describe("createAndUpdateDatasetSizeAndFileCount", () => {
+    it("should create the origdatablock and then update the dataset size and file count", async () => {
+      const result = await service.createAndUpdateDatasetSizeAndFileCount(
+        mockCreateOrigDatablockDto,
+      );
 
+      expect(result).toEqual(
+        expect.objectContaining({
+          datasetId: mockCreateOrigDatablockDto.datasetId,
+        }),
+      );
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
-        "testPid",
-        model,
+        mockCreateOrigDatablockDto.datasetId,
         "size",
         "numberOfFiles",
+        result,
+        undefined,
+      );
+    });
+  });
+
+  describe("updateOneAndUpdateDatasetSizeAndFileCount", () => {
+    const oldOrigDatablock: OrigDatablock = {
+      ...mockOrigDatablock,
+      size: 800,
+      dataFileList: [],
+    };
+
+    it("should update the origdatablock and then update the dataset size and file count", async () => {
+      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(
+        oldOrigDatablock,
+      );
+      (MockOrigDatablockModel.findOneAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockOrigDatablock),
+      });
+
+      const result = await service.updateOneAndUpdateDatasetSizeAndFileCount(
+        { _id: "testId" },
+        { size: mockOrigDatablock.size },
+      );
+
+      expect(result).toEqual(mockOrigDatablock);
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        mockOrigDatablock.datasetId,
+        "size",
+        "numberOfFiles",
+        mockOrigDatablock,
+        oldOrigDatablock,
       );
     });
 
-    it("should forward the given datasetId unchanged", async () => {
-      await service.updateDatasetSizeAndFiles("ds123");
-
-      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
-        "ds123",
-        expect.anything(),
-        "size",
-        "numberOfFiles",
-      );
-    });
-
-    it("should propagate errors raised by the datasets service", async () => {
-      datasetsService.updateDatasetSizeAndFiles.mockRejectedValueOnce(
-        new Error("aggregation failed"),
-      );
+    it("should throw ForbiddenException and not touch the dataset when the original origdatablock does not exist", async () => {
+      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(null);
 
       await expect(
-        service.updateDatasetSizeAndFiles("testPid"),
-      ).rejects.toThrow("aggregation failed");
+        service.updateOneAndUpdateDatasetSizeAndFileCount(
+          { _id: "missing" },
+          { size: 2000 },
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(MockOrigDatablockModel.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
+    });
+
+    it("should throw NotFoundException and not touch the dataset when the origdatablock disappears during update", async () => {
+      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(
+        oldOrigDatablock,
+      );
+      (MockOrigDatablockModel.findOneAndUpdate as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.updateOneAndUpdateDatasetSizeAndFileCount(
+          { _id: "testId" },
+          { size: 2000 },
+        ),
+      ).rejects.toThrow(NotFoundException);
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeAndUpdateDatasetSizeAndFileCount", () => {
+    it("should remove the origdatablock and then update the dataset size and file count with negated values", async () => {
+      (MockOrigDatablockModel.findOneAndDelete as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockOrigDatablock),
+      });
+
+      const result = await service.removeAndUpdateDatasetSizeAndFileCount({
+        _id: "testId",
+      });
+
+      expect(result).toEqual(mockOrigDatablock);
+      expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
+        mockOrigDatablock.datasetId,
+        "size",
+        "numberOfFiles",
+        undefined,
+        mockOrigDatablock,
+      );
+    });
+
+    it("should throw NotFoundException and not touch the dataset when the origdatablock does not exist", async () => {
+      (MockOrigDatablockModel.findOneAndDelete as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        service.removeAndUpdateDatasetSizeAndFileCount({ _id: "missing" }),
+      ).rejects.toThrow(NotFoundException);
+      expect(datasetsService.updateDatasetSizeAndFiles).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/origdatablocks/origdatablocks.service.spec.ts
+++ b/src/origdatablocks/origdatablocks.service.spec.ts
@@ -47,30 +47,37 @@ class DatasetsServiceMock {
   updateDatasetSizeAndFiles = jest.fn().mockResolvedValue(undefined);
 }
 
-function MockOrigDatablockModel(
-  this: Record<string, unknown>,
-  data: Record<string, unknown>,
-) {
-  Object.assign(this, data);
-  this.save = jest.fn().mockResolvedValue({ ...mockOrigDatablock, ...data });
+interface MockOrigDatablockModelType {
+  (this: Record<string, unknown>, data: Record<string, unknown>): void;
+  findOne: jest.Mock;
+  findOneAndUpdate: jest.Mock;
+  findOneAndDelete: jest.Mock;
+  schema: { path: jest.Mock };
 }
-MockOrigDatablockModel.find = jest.fn();
-MockOrigDatablockModel.findOne = jest.fn();
-MockOrigDatablockModel.findOneAndUpdate = jest.fn();
-MockOrigDatablockModel.findOneAndDelete = jest.fn();
-MockOrigDatablockModel.deleteMany = jest.fn();
-MockOrigDatablockModel.countDocuments = jest.fn();
-MockOrigDatablockModel.aggregate = jest.fn();
-MockOrigDatablockModel.schema = {
-  path: jest.fn().mockReturnValue({ instance: "String" }),
-};
 
 describe("OrigdatablocksService", () => {
   let service: OrigDatablocksService;
   let datasetsService: DatasetsServiceMock;
+  let MockOrigDatablockModel: MockOrigDatablockModelType;
 
   beforeEach(async () => {
-    jest.clearAllMocks();
+    MockOrigDatablockModel = function (
+      this: Record<string, unknown>,
+      data: Record<string, unknown>,
+    ) {
+      Object.assign(this, data);
+      this.save = jest
+        .fn()
+        .mockResolvedValue({ ...mockOrigDatablock, ...data });
+    } as MockOrigDatablockModelType;
+    MockOrigDatablockModel.findOne = jest.fn();
+    MockOrigDatablockModel.findOneAndUpdate = jest.fn();
+    MockOrigDatablockModel.findOneAndDelete = jest.fn();
+    // findOne() builds its filter via createFullqueryFilter, which
+    // inspects the schema for every filter key (e.g. "_id").
+    MockOrigDatablockModel.schema = {
+      path: jest.fn().mockReturnValue({ instance: "String" }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -107,8 +114,7 @@ describe("OrigdatablocksService", () => {
       );
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockCreateOrigDatablockDto.datasetId,
-        "size",
-        "numberOfFiles",
+        { size: "size", numberOfFiles: "numberOfFiles" },
         result,
         undefined,
       );
@@ -123,10 +129,8 @@ describe("OrigdatablocksService", () => {
     };
 
     it("should update the origdatablock and then update the dataset size and file count", async () => {
-      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(
-        oldOrigDatablock,
-      );
-      (MockOrigDatablockModel.findOneAndUpdate as jest.Mock).mockReturnValue({
+      MockOrigDatablockModel.findOne.mockResolvedValue(oldOrigDatablock);
+      MockOrigDatablockModel.findOneAndUpdate.mockReturnValue({
         exec: jest.fn().mockResolvedValue(mockOrigDatablock),
       });
 
@@ -138,15 +142,14 @@ describe("OrigdatablocksService", () => {
       expect(result).toEqual(mockOrigDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockOrigDatablock.datasetId,
-        "size",
-        "numberOfFiles",
+        { size: "size", numberOfFiles: "numberOfFiles" },
         mockOrigDatablock,
         oldOrigDatablock,
       );
     });
 
     it("should throw ForbiddenException and not touch the dataset when the original origdatablock does not exist", async () => {
-      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(null);
+      MockOrigDatablockModel.findOne.mockResolvedValue(null);
 
       await expect(
         service.updateOneAndUpdateDatasetSizeAndFileCount(
@@ -159,10 +162,8 @@ describe("OrigdatablocksService", () => {
     });
 
     it("should throw NotFoundException and not touch the dataset when the origdatablock disappears during update", async () => {
-      (MockOrigDatablockModel.findOne as jest.Mock).mockResolvedValue(
-        oldOrigDatablock,
-      );
-      (MockOrigDatablockModel.findOneAndUpdate as jest.Mock).mockReturnValue({
+      MockOrigDatablockModel.findOne.mockResolvedValue(oldOrigDatablock);
+      MockOrigDatablockModel.findOneAndUpdate.mockReturnValue({
         exec: jest.fn().mockResolvedValue(null),
       });
 
@@ -178,7 +179,7 @@ describe("OrigdatablocksService", () => {
 
   describe("removeAndUpdateDatasetSizeAndFileCount", () => {
     it("should remove the origdatablock and then update the dataset size and file count with negated values", async () => {
-      (MockOrigDatablockModel.findOneAndDelete as jest.Mock).mockReturnValue({
+      MockOrigDatablockModel.findOneAndDelete.mockReturnValue({
         exec: jest.fn().mockResolvedValue(mockOrigDatablock),
       });
 
@@ -189,15 +190,14 @@ describe("OrigdatablocksService", () => {
       expect(result).toEqual(mockOrigDatablock);
       expect(datasetsService.updateDatasetSizeAndFiles).toHaveBeenCalledWith(
         mockOrigDatablock.datasetId,
-        "size",
-        "numberOfFiles",
+        { size: "size", numberOfFiles: "numberOfFiles" },
         undefined,
         mockOrigDatablock,
       );
     });
 
     it("should throw NotFoundException and not touch the dataset when the origdatablock does not exist", async () => {
-      (MockOrigDatablockModel.findOneAndDelete as jest.Mock).mockReturnValue({
+      MockOrigDatablockModel.findOneAndDelete.mockReturnValue({
         exec: jest.fn().mockResolvedValue(null),
       });
 

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -451,8 +451,7 @@ export class OrigDatablocksService {
   ): Promise<void> {
     await this.datasetsService.updateDatasetSizeAndFiles(
       pid,
-      "size",
-      "numberOfFiles",
+      { size: "size", numberOfFiles: "numberOfFiles" },
       newDocument,
       oldDocument,
     );

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -402,23 +402,32 @@ export class OrigDatablocksService {
   ): Promise<OrigDatablock> {
     const origDatablock = await this.create(createDatablockDto);
     if (origDatablock)
-      await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+      await this.updateDatasetSizeAndFiles(
+        origDatablock.datasetId,
+        origDatablock,
+      );
     return origDatablock;
   }
 
-  async findByIdAndUpdateDatasetSizeAndFileCount(
-    _id: string,
+  async updateOneAndUpdateDatasetSizeAndFileCount(
+    filter: FilterQuery<OrigDatablockDocument>,
     updateDatablockDto: PartialUpdateOrigDatablockDto,
     unmodifiedSince?: Date,
   ): Promise<OrigDatablock> {
+    const oldOrigDatablock = await this.findOne(filter);
+    if (!oldOrigDatablock)
+      throw new OrigDatablocksFilterNotFoundException(filter);
     const origDatablock = await this.findByIdAndUpdate(
-      _id,
+      filter._id as string,
       updateDatablockDto,
       unmodifiedSince,
     );
-    if (!origDatablock)
-      throw new OrigDatablocksFilterNotFoundException({ _id });
-    await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+    if (!origDatablock) throw new OrigDatablocksFilterNotFoundException(filter);
+    await this.updateDatasetSizeAndFiles(
+      origDatablock.datasetId,
+      origDatablock,
+      oldOrigDatablock,
+    );
     return origDatablock;
   }
 
@@ -427,16 +436,25 @@ export class OrigDatablocksService {
   ): Promise<OrigDatablock> {
     const origDatablock = await this.remove(filter);
     if (!origDatablock) throw new OrigDatablocksFilterNotFoundException(filter);
-    await this.updateDatasetSizeAndFiles(origDatablock.datasetId);
+    await this.updateDatasetSizeAndFiles(
+      origDatablock.datasetId,
+      undefined,
+      origDatablock,
+    );
     return origDatablock;
   }
 
-  async updateDatasetSizeAndFiles(pid: string) {
+  private async updateDatasetSizeAndFiles(
+    pid: string,
+    newDocument?: OrigDatablock,
+    oldDocument?: OrigDatablock,
+  ): Promise<void> {
     await this.datasetsService.updateDatasetSizeAndFiles(
       pid,
-      this.origDatablockModel,
       "size",
       "numberOfFiles",
+      newDocument,
+      oldDocument,
     );
   }
 }

--- a/src/origdatablocks/origdatablocks.v4.controller.spec.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.spec.ts
@@ -9,7 +9,7 @@ import { Request } from "express";
 
 class OrigDatablocksServiceMock {
   findOne = jest.fn();
-  findByIdAndUpdateDatasetSizeAndFileCount = jest.fn();
+  updateOneAndUpdateDatasetSizeAndFileCount = jest.fn();
   findOneComplete = jest.fn();
 }
 
@@ -76,7 +76,7 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should throw HttpException if service throws exception (when header date is older than updatedAt)", async () => {
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
         new PreconditionFailedException("Resource has been modified on server"),
       );
 
@@ -95,16 +95,16 @@ describe("OrigDatablocksV4Controller", () => {
         controller.findByIdAndUpdate(mockRequest, "db123", mockUpdateDto),
       ).rejects.toThrow(PreconditionFailedException);
       expect(
-        origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount,
+        origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount,
       ).toHaveBeenCalledWith(
-        "db123",
+        { _id: "db123" },
         mockUpdateDto,
         new Date(mockRequest.headers["if-unmodified-since"] as string),
       );
     });
 
     it("should throw NotFoundException if update returns null", async () => {
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockRejectedValue(
         new NotFoundException("OrigDatablock #db123 not found"),
       );
 
@@ -125,7 +125,7 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should return updated datablock on success", async () => {
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
         updatedDatablock,
       );
 
@@ -147,7 +147,7 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should succeed if 'if-unmodified-since' header is missing", async () => {
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
         updatedDatablock,
       );
 
@@ -169,7 +169,7 @@ describe("OrigDatablocksV4Controller", () => {
     });
 
     it("should succeed if 'if-unmodified-since' header is malformed", async () => {
-      origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
+      origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount.mockResolvedValue(
         updatedDatablock,
       );
 

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -809,8 +809,8 @@ export class OrigDatablocksV4Controller {
       Action.OrigdatablockUpdate,
     );
     const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
-    return this.origDatablocksService.findByIdAndUpdateDatasetSizeAndFileCount(
-      id,
+    return this.origDatablocksService.updateOneAndUpdateDatasetSizeAndFileCount(
+      { _id: id },
       updateOrigDatablockDto,
       unmodifiedSince,
     );

--- a/test/Datablock.js
+++ b/test/Datablock.js
@@ -209,6 +209,49 @@ describe("Datablocks", () => {
     });
   });
 
+  it("0067: should update the packedSize and dataFileList of the first datablock and remove the old contribution while adding the new one", async () => {
+    const updatedPackedSize = TestData.DataBlockCorrect.packedSize + 999;
+    const updatedDataFileList = [TestData.DataBlockCorrect.dataFileList[0]];
+
+    await request(appUrl)
+      .patch(`/api/v3/datablocks/${datablockId}`)
+      .send({
+        packedSize: updatedPackedSize,
+        dataFileList: updatedDataFileList,
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("packedSize")
+          .and.equal(updatedPackedSize);
+        res.body.should.have
+          .property("dataFileList")
+          .and.be.instanceof(Array)
+          .and.to.have.length(updatedDataFileList.length);
+      });
+
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodeURIComponent(datasetId))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("packedSize")
+          .and.equal(updatedPackedSize + TestData.DataBlockCorrect.packedSize);
+        res.body.should.have
+          .property("numberOfFilesArchived")
+          .and.equal(
+            updatedDataFileList.length +
+              TestData.DataBlockCorrect.dataFileList.length,
+          );
+      });
+  });
+
   it("0070: should delete first datablock", async () => {
     return request(appUrl)
       .delete(`/api/v3/datablocks/${datablockId}`)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The size and number of files was computed in a way that required the full datablocks scan by datasetId. The new implementation increments the sizes by simply adding the new entries. This is much more efficient

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Optimize dataset size and file count maintenance by incrementally applying changes from datablocks and origdatablocks instead of recomputing aggregates.

New Features:
- Support incremental dataset size and file count updates when creating, updating, or deleting datablocks and origdatablocks.
- Expose new service and controller methods that operate on filters and pass old/new datablock documents for size update calculations.

Bug Fixes:
- Prevent dataset size/file updates when the targeted datablock or origdatablock is missing or disappears during update, returning appropriate HTTP exceptions instead.
- Ensure origdatablock and datablock update endpoints respect optimistic concurrency and permission checks while avoiding unintended dataset mutations.

Enhancements:
- Refine DatasetsService to compute and apply size and file count deltas directly on the dataset model using $inc operations.
- Improve service APIs for datablocks and origdatablocks to more clearly express combined update-plus-dataset-size maintenance flows.
- Strengthen mocking in origdatablocks unit tests to better cover create, update, and delete behaviors tied to dataset size updates.

Tests:
- Add unit tests for DatasetsService.updateDatasetSizeAndFiles to validate delta calculations for create, update, and delete scenarios.
- Extend datablocks and origdatablocks service and controller tests to cover incremental size updates and error handling when documents are missing.
- Introduce an integration test verifying dataset packedSize and numberOfFilesArchived stay consistent when a datablock is modified.