### PR TITLE
fix: stop patches from resetting dataset size fields to 0

### DIFF
--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -105,7 +105,7 @@ export class UpdateDatasetDto extends OwnableDto {
   })
   @IsOptional()
   @IsInt()
-  readonly size?: number = 0;
+  readonly size?: number;
 
   @ApiProperty({
     type: Number,
@@ -116,7 +116,7 @@ export class UpdateDatasetDto extends OwnableDto {
   })
   @IsOptional()
   @IsInt()
-  readonly packedSize?: number = 0;
+  readonly packedSize?: number;
 
   @ApiProperty({
     type: Number,
@@ -127,7 +127,7 @@ export class UpdateDatasetDto extends OwnableDto {
   })
   @IsOptional()
   @IsInt()
-  readonly numberOfFiles?: number = 0;
+  readonly numberOfFiles?: number;
 
   @ApiProperty({
     type: Number,

--- a/test/DatasetCustom.js
+++ b/test/DatasetCustom.js
@@ -600,6 +600,32 @@ describe("2400: CustomDataset: Custom Type Datasets", () => {
   describe("Datasets v3 custom dataset size fields should survive unrelated patches", () => {
     let sizeFieldsPid = null;
 
+    it("0895: adds a new custom dataset without size, packedSize, numberOfFiles or numberOfFilesArchived and defaults them to 0", async () => {
+      const { size, numberOfFiles, ...customDatasetWithoutSizeFields } =
+        TestData.CustomDatasetCorrect;
+
+      return request(appUrl)
+        .post("/api/v3/Datasets")
+        .send(customDatasetWithoutSizeFields)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then(async (res) => {
+          res.body.should.have.property("pid").and.be.a("string");
+          res.body.should.have.property("size").and.equal(0);
+          res.body.should.have.property("packedSize").and.equal(0);
+          res.body.should.have.property("numberOfFiles").and.equal(0);
+          res.body.should.have.property("numberOfFilesArchived").and.equal(0);
+
+          await request(appUrl)
+            .delete("/api/v3/Datasets/" + encodeURIComponent(res.body.pid))
+            .set("Accept", "application/json")
+            .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+            .expect(TestData.SuccessfulDeleteStatusCode);
+        });
+    });
+
     it("0900: adds a new custom dataset with explicit size and numberOfFiles", async () => {
       const customDatasetWithSize = {
         ...TestData.CustomDatasetCorrect,

--- a/test/DatasetCustom.js
+++ b/test/DatasetCustom.js
@@ -596,4 +596,88 @@ describe("2400: CustomDataset: Custom Type Datasets", () => {
         });
     });
   });
+
+  describe("Datasets v3 custom dataset size fields should survive unrelated patches", () => {
+    let sizeFieldsPid = null;
+
+    it("0900: adds a new custom dataset with explicit size and numberOfFiles", async () => {
+      const customDatasetWithSize = {
+        ...TestData.CustomDatasetCorrect,
+        size: 12345,
+        numberOfFiles: 6,
+      };
+
+      return request(appUrl)
+        .post("/api/v3/Datasets")
+        .send(customDatasetWithSize)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("pid").and.be.a("string");
+          res.body.should.have.property("size").and.equal(12345);
+          res.body.should.have.property("numberOfFiles").and.equal(6);
+          sizeFieldsPid = res.body["pid"];
+        });
+    });
+
+    it("0910: explicitly sets packedSize and numberOfFilesArchived", async () => {
+      return request(appUrl)
+        .patch(`/api/v3/Datasets/${encodeURIComponent(sizeFieldsPid)}`)
+        .send({ packedSize: 6789, numberOfFilesArchived: 3 })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulPatchStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("packedSize").and.equal(6789);
+          res.body.should.have.property("numberOfFilesArchived").and.equal(3);
+        });
+    });
+
+    it("0915: patches only size and preserves packedSize, numberOfFiles and numberOfFilesArchived", async () => {
+      return request(appUrl)
+        .patch(`/api/v3/Datasets/${encodeURIComponent(sizeFieldsPid)}`)
+        .send({ size: 54321 })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulPatchStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("size").and.equal(54321);
+          res.body.should.have.property("packedSize").and.equal(6789);
+          res.body.should.have.property("numberOfFiles").and.equal(6);
+          res.body.should.have.property("numberOfFilesArchived").and.equal(3);
+        });
+    });
+
+    it("0920: preserves size, packedSize, numberOfFiles and numberOfFilesArchived when patching an unrelated field", async () => {
+      return request(appUrl)
+        .patch(`/api/v3/Datasets/${encodeURIComponent(sizeFieldsPid)}`)
+        .send({ datasetName: "Updated custom dataset name" })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulPatchStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have
+            .property("datasetName")
+            .and.equal("Updated custom dataset name");
+          res.body.should.have.property("size").and.equal(54321);
+          res.body.should.have.property("packedSize").and.equal(6789);
+          res.body.should.have.property("numberOfFiles").and.equal(6);
+          res.body.should.have.property("numberOfFilesArchived").and.equal(3);
+        });
+    });
+
+    it("0930: should delete the size fields test dataset", async () => {
+      return request(appUrl)
+        .delete("/api/v3/Datasets/" + encodeURIComponent(sizeFieldsPid))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+        .expect(TestData.SuccessfulDeleteStatusCode)
+        .expect("Content-Type", /json/);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Having explicit defaults makes plainToInstance attach fields with 0s even when missing in the patch payload. This then updates the document's values in mongo to 0 even when missing in the payload

Raw and derived datasets have dedicated DTOs so this fixes the bug for other types

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Prevent dataset size-related fields from being unintentionally reset when applying partial updates to v3 custom datasets.

Bug Fixes:
- Ensure size, packedSize, numberOfFiles, and numberOfFilesArchived are not defaulted to 0 when omitted from update payloads.

Tests:
- Add regression tests verifying dataset size-related fields are preserved across unrelated PATCH operations on v3 custom datasets.