### PR TITLE
fix: apply dataset types check

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import { merge } from "lodash";
 import { boolean } from "mathjs";
-import { DatasetType } from "src/datasets/types/dataset-type.enum";
 import { DEFAULT_PROPOSAL_TYPE } from "src/proposals/schemas/proposal.schema";
 import localconfiguration from "./localconfiguration";
 
@@ -141,11 +140,6 @@ const configuration = () => {
     }
   });
 
-  // NOTE: Add the default dataset types here
-  Object.assign(jsonConfigMap.datasetTypes, {
-    Raw: DatasetType.Raw,
-    Derived: DatasetType.Derived,
-  });
   // NOTE: Add the default proposal type here
   Object.assign(jsonConfigMap.proposalTypes, {
     DefaultProposal: DEFAULT_PROPOSAL_TYPE,
@@ -455,7 +449,7 @@ const configuration = () => {
       policyPublicationShiftInYears: process.env.POLICY_PUBLICATION_SHIFT ?? 3,
       policyRetentionShiftInYears: process.env.POLICY_RETENTION_SHIFT ?? -1,
     },
-    datasetTypes: jsonConfigMap.datasetTypes,
+    customDatasetTypes: jsonConfigMap.datasetTypes,
     proposalTypes: jsonConfigMap.proposalTypes,
     frontendConfig: jsonConfigMap.frontendConfig,
     frontendTheme: jsonConfigMap.frontendTheme,

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -152,12 +152,16 @@ export class DatasetsController {
     this.datasetCreationValidationRegex = this.configService.get<string>(
       "datasetCreationValidationRegex",
     );
-    this.datasetTypes = this.configService.get<string>("datasetTypes");
+    const customDatasetTypes =
+      this.configService.get<Record<string, string>>("customDatasetTypes");
+    this.customDatasetTypes = customDatasetTypes
+      ? Object.values(customDatasetTypes)
+      : [];
   }
   private accessGroups;
   private datasetCreationValidationEnabled;
   private datasetCreationValidationRegex;
-  private datasetTypes;
+  private customDatasetTypes;
 
   updateMergedFiltersForList(
     request: Request,
@@ -664,23 +668,17 @@ export class DatasetsController {
     const outputDatasetDto = plainToInstance(dto, inputDatasetDto);
 
     if (
-      outputDatasetDto instanceof
-      (CreateRawDatasetObsoleteDto ||
-        CreateDerivedDatasetObsoleteDto ||
-        CreateDatasetDto)
+      this.customDatasetTypes.length > 0 &&
+      outputDatasetDto instanceof CreateDatasetDto &&
+      !this.customDatasetTypes.includes(outputDatasetDto.type)
     ) {
-      if (
-        this.datasetTypes &&
-        !Object.values(this.datasetTypes).includes(outputDatasetDto.type)
-      ) {
-        throw new HttpException(
-          {
-            status: HttpStatus.BAD_REQUEST,
-            message: "Invalid dataset type!",
-          },
-          HttpStatus.BAD_REQUEST,
-        );
-      }
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: "Invalid dataset type!",
+        },
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const errors = await validate(outputDatasetDto, validateOptions);

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -670,6 +670,9 @@ export class DatasetsController {
     if (
       this.customDatasetTypes.length > 0 &&
       outputDatasetDto instanceof CreateDatasetDto &&
+      !Object.values(DatasetType).includes(
+        outputDatasetDto.type as DatasetType,
+      ) &&
       !this.customDatasetTypes.includes(outputDatasetDto.type)
     ) {
       throw new HttpException(

--- a/test/DatasetCustom.js
+++ b/test/DatasetCustom.js
@@ -257,6 +257,95 @@ describe("2400: CustomDataset: Custom Type Datasets", () => {
       });
   });
 
+  it("0176: should be able to update a custom dataset without providing its type", async () => {
+    const createRes = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send({
+        ...TestData.CustomDatasetCorrect,
+        pid: TestData.PidPrefix + "/" + uuidv4(),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode);
+
+    const createdPid = createRes.body.pid;
+
+    await request(appUrl)
+      .patch(`/api/v3/Datasets/${encodeURIComponent(createdPid)}`)
+      .send({ datasetName: "Updated without type field" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("datasetName")
+          .and.equal("Updated without type field");
+      });
+
+    await request(appUrl)
+      .delete("/api/v3/Datasets/" + encodeURIComponent(createdPid))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+  });
+
+  it("0177: should be able to add a raw dataset even though datasetTypes.json only lists custom types", async () => {
+    const rawDataset = {
+      ...TestData.RawCorrectMin,
+      pid: TestData.PidPrefix + "/" + uuidv4(),
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(rawDataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then(async (res) => {
+        res.body.should.have.property("type").and.equal("raw");
+        res.body.should.have.property("pid").and.equal(rawDataset.pid);
+
+        await request(appUrl)
+          .delete("/api/v3/Datasets/" + encodeURIComponent(res.body.pid))
+          .set("Accept", "application/json")
+          .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+          .expect(TestData.SuccessfulDeleteStatusCode);
+      });
+  });
+
+  it("0178: should not be able to patch a dataset's type", async () => {
+    const createRes = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send({
+        ...TestData.CustomDatasetCorrect,
+        pid: TestData.PidPrefix + "/" + uuidv4(),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode);
+
+    const createdPid = createRes.body.pid;
+
+    await request(appUrl)
+      .patch(`/api/v3/Datasets/${encodeURIComponent(createdPid)}`)
+      .send({ type: "custom" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("message").and.match(/should not exist/);
+      });
+
+    await request(appUrl)
+      .delete("/api/v3/Datasets/" + encodeURIComponent(createdPid))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+  });
+
   it("0180: should fetch several custom datasets", async () => {
     const filter = {
       where: {

--- a/test/DatasetCustom.js
+++ b/test/DatasetCustom.js
@@ -237,6 +237,26 @@ describe("2400: CustomDataset: Custom Type Datasets", () => {
       });
   });
 
+  it("0175: should not be able to add a dataset with a type not supported in datasetTypes.json", async () => {
+    const customDatasetWithUnsupportedType = {
+      ...TestData.CustomDatasetCorrect,
+      pid: TestData.PidPrefix + "/" + uuidv4(),
+      type: "unsupportedType",
+    };
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(customDatasetWithUnsupportedType)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.BadRequestStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("message")
+          .and.equal("Invalid dataset type!");
+      });
+  });
+
   it("0180: should fetch several custom datasets", async () => {
     const filter = {
       where: {

--- a/test/config/.env
+++ b/test/config/.env
@@ -9,6 +9,7 @@ UPDATE_JOB_PRIVILEGED_GROUPS=group3
 UPDATE_DATASET_LIFECYCLE_GROUPS=archivemanager
 DATASET_CREATION_VALIDATION_ENABLED=true
 DATASET_CREATION_VALIDATION_REGEX=^scicat_testing/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$$
+DATASET_TYPES_FILE=test/config/datasetTypes.json
 DELETE_GROUPS=archivemanager
 DELETE_JOB_GROUPS=archivemanager,admin
 EXPRESS_SESSION_SECRET=a_scicat_secret

--- a/test/config/datasetTypes.json
+++ b/test/config/datasetTypes.json
@@ -1,0 +1,3 @@
+{
+  "Custom": "custom"
+}


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The datasetTypes check was skipped due to a wrong type comparison. This PR should fix it together with simplifying the variables creation.

Since the check was never enforced, it's a bit hard to know what the expected behaviour should be when the datasetTypes.json file is missing. 

1. should all custom types be allowed (as assumed by the tests)?
2. or should no custom types be allowed (as assumed by the controller, even if buggy)?

This version implements the 1 , but I am happy to change it.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* dataset type comparison wrong check

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Validate dataset creation against configured custom dataset types and adjust configuration accordingly.

Bug Fixes:
- Correct dataset type validation to ensure unsupported custom types are rejected during dataset creation.

Enhancements:
- Rename and streamline configuration and controller handling from generic datasetTypes to customDatasetTypes for clearer semantics.

Tests:
- Add an integration test verifying that datasets with unsupported types are rejected with a bad request error.