### PR TITLE
fix: apply security fix for security fix for GHSA-pxvj-88j3-82p8 to v5.2.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - master
-      - release-*
+      - release*
 
 jobs:
   install-and-cache:

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1038,6 +1038,7 @@ export class CaslAbilityFactory {
         can(Action.ProposalsAttachmentCreate, ProposalClass);
         can(Action.ProposalsAttachmentUpdate, ProposalClass);
         can(Action.ProposalsAttachmentDelete, ProposalClass);
+        can(Action.ProposalsDatasetRead, ProposalClass);
       } else if (
         user.currentGroups.some((g) => {
           return this.accessGroups?.proposal.includes(g);
@@ -1054,7 +1055,7 @@ export class CaslAbilityFactory {
         can(Action.ProposalsAttachmentCreate, ProposalClass);
         can(Action.ProposalsAttachmentUpdate, ProposalClass);
         can(Action.ProposalsAttachmentDelete, ProposalClass);
-        cannot(Action.ProposalsDatasetRead, ProposalClass);
+        can(Action.ProposalsDatasetRead, ProposalClass);
       } else if (user) {
         /**
          * authenticated users
@@ -1067,7 +1068,7 @@ export class CaslAbilityFactory {
         cannot(Action.ProposalsAttachmentCreate, ProposalClass);
         cannot(Action.ProposalsAttachmentUpdate, ProposalClass);
         cannot(Action.ProposalsAttachmentDelete, ProposalClass);
-        can(Action.ProposalsDatasetRead, ProposalClass);
+        cannot(Action.ProposalsDatasetRead, ProposalClass);
       }
 
       if (

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -983,8 +983,14 @@ export class ProposalsController {
     @Req() request: Request,
     @Param("pid") proposalId: string,
   ): Promise<DatasetClass[] | null> {
+    await this.checkPermissionsForProposal(
+      request,
+      proposalId,
+      Action.ProposalsRead,
+    );
+
     const user: JWTUser = request.user as JWTUser;
-    const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
+    const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
     const canViewAny = ability.can(Action.DatasetReadAny, DatasetClass);
     const fields: IDatasetFields = JSON.parse("{}");
 
@@ -993,16 +999,11 @@ export class ProposalsController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-
-      const canViewPublic = ability.can(
-        Action.DatasetReadManyPublic,
-        DatasetClass,
-      );
       if (canViewAccess) {
         fields.userGroups = user.currentGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
         // fields.sharedWith = user.email;
-      } else if (canViewPublic) {
+      } else {
         fields.isPublished = true;
       }
     }

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -995,8 +995,10 @@ export class SamplesController {
     @Req() request: Request,
     @Param("id") id: string,
   ): Promise<DatasetClass[] | null> {
+    await this.checkPermissionsForSample(request, id, Action.SampleRead);
+
     const user: JWTUser = request.user as JWTUser;
-    const ability = this.caslAbilityFactory.samplesInstanceAccess(user);
+    const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
     const canViewAny = ability.can(Action.DatasetReadAny, DatasetClass);
     const fields: IDatasetFields = JSON.parse("{}");
 
@@ -1005,15 +1007,11 @@ export class SamplesController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewPublic = ability.can(
-        Action.DatasetReadManyPublic,
-        DatasetClass,
-      );
       if (canViewAccess) {
         fields.userGroups = user.currentGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
         // fields.sharedWith = user.email;
-      } else if (canViewPublic) {
+      } else {
         fields.isPublished = true;
       }
     }

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -1114,21 +1114,14 @@ describe("2500: Datasets v4 tests", () => {
 
   describe("Datasets v4 count tests", () => {
     it("0400: should not be able to fetch datasets count if not logged in", async () => {
-      const filter = {
-        limits: {
-          skip: 0,
-          sort: {
-            datasetName: "asc",
-          },
-        },
-      };
+      const filter = {};
 
       return request(appUrl)
         .get("/api/v4/datasets/count")
         .query({ filter: JSON.stringify(filter) })
         .expect(TestData.AccessForbiddenStatusCode)
         .expect("Content-Type", /json/);
-    });
+    });        
 
     it("0401: should be able to fetch the datasets count providing where filter", async () => {
       const filter = {

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -7,10 +7,13 @@ const { TestData } = require("./TestData");
 let accessTokenProposalIngestor = null,
   accessTokenAdminIngestor = null,
   accessTokenArchiveManager = null,
+  accessTokenUser1 = null,
 
   defaultProposalId = null,
   minimalProposalId = null,
   proposalId = null,
+  datasetId = null,
+  datasetId2 = null,
   proposalWithParentId = null,
   attachmentId = null;
 
@@ -31,6 +34,11 @@ describe("1500: Proposal: Simple Proposal", () => {
     accessTokenArchiveManager = await utils.getToken(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
     });
   });
 
@@ -132,6 +140,94 @@ describe("1500: Proposal: Simple Proposal", () => {
         defaultProposalId = res.body["proposalId"];
         proposalId = encodeURIComponent(res.body["proposalId"]);
       });
+  });
+
+  it("0061: should return no datasets", async () => {
+    return request(appUrl)
+      .get("/api/v3/Proposals/" + proposalId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.instanceof(Array);
+        res.body.length.should.be.equal(0);
+      });
+  });
+
+  it("0062: insert dataset using this proposal with proposalingestor owner", async () => {
+    let dataset = { ...TestData.RawCorrect };
+    dataset.proposalId = proposalId;
+    dataset.ownerGroup = "proposalingestor";
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("owner").and.be.string;
+        res.body.should.have.property("type").and.equal("raw");
+        res.body.should.have.property("pid").and.be.string;
+        datasetId = encodeURIComponent(res.body["pid"]);
+      });
+  });
+
+  it("0063: insert dataset using this proposal with adminingestor owner", async () => {
+    let dataset = { ...TestData.RawCorrect };
+    dataset.proposalId = proposalId;
+    dataset.ownerGroup = "adminingestor";
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("owner").and.be.string;
+        res.body.should.have.property("type").and.equal("raw");
+        res.body.should.have.property("pid").and.be.string;
+        datasetId2 = encodeURIComponent(res.body["pid"]);
+      });
+  });
+
+  it("0063: should retrieve one dataset for proposal as proposalingestor", async () => {
+    return request(appUrl)
+      .get("/api/v3/Proposals/" + proposalId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.instanceof(Array);
+        res.body.length.should.be.equal(1);
+        res.body[0].pid.should.be.equal(decodeURIComponent(datasetId));
+      });
+  });
+
+  it("0064: should retrieve two datasets for proposal as adminingestor", async () => {
+    return request(appUrl)
+      .get("/api/v3/Proposals/" + proposalId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.instanceof(Array);
+        res.body.length.should.be.equal(2);
+        res.body[0].pid.should.be.equal(decodeURIComponent(datasetId));
+        res.body[1].pid.should.be.equal(decodeURIComponent(datasetId2));
+      });
+  });
+
+  it("0065: should deny access as user1", async () => {
+    return request(appUrl)
+      .get("/api/v3/Proposals/" + proposalId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode);
   });
 
   // check if proposal with additional field is valid

--- a/test/Sample.js
+++ b/test/Sample.js
@@ -5,9 +5,13 @@ const { TestData } = require("./TestData");
 
 let accessTokenAdminIngestor = null,
   accessTokenArchiveManager = null,
+  accessTokenUser1 = null,
+  accessTokenUser2 = null,
+
   sampleId = null,
   attachmentId = null,
   datasetId = null,
+  datasetId2 = null,
   sampleIdSpecial = null,
   sampleIdNested = null;
 
@@ -67,12 +71,22 @@ describe("2200: Sample: Simple Sample", () => {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
     });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
   });
 
   it("0010: adds a new sample", async () => {
     return request(appUrl)
       .post("/api/v3/Samples")
-      .send(TestData.SampleCorrect)
+      .send({ ...TestData.SampleCorrect, accessGroups: ["group1"] })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
@@ -207,9 +221,10 @@ describe("2200: Sample: Simple Sample", () => {
       });
   });
 
-  it("0080: insert dataset using this sample", async () => {
+  it("0080: insert dataset using this sample with group1 owner", async () => {
     let dataset = { ...TestData.RawCorrect };
     dataset.sampleId = sampleId;
+    dataset.ownerGroup = "group1";
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset)
@@ -225,7 +240,40 @@ describe("2200: Sample: Simple Sample", () => {
       });
   });
 
-  it("0090: should retrieve dataset for sample", async () => {
+  it("0081: insert dataset using this sample with adminingestor owner", async () => {
+    let dataset = { ...TestData.RawCorrect };
+    dataset.sampleId = sampleId;
+    dataset.ownerGroup = "adminingestor";
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("owner").and.be.string;
+        res.body.should.have.property("type").and.equal("raw");
+        res.body.should.have.property("pid").and.be.string;
+        datasetId2 = encodeURIComponent(res.body["pid"]);
+      });
+  });
+
+  it("0090: should retrieve one dataset for sample as user1", async () => {
+    return request(appUrl)
+      .get("/api/v3/Samples/" + sampleId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.instanceof(Array);
+        res.body.length.should.be.equal(1);
+        res.body[0].pid.should.be.equal(decodeURIComponent(datasetId));
+      });
+  });
+
+  it("0091: should retrieve two datasets for sample as adminIngestor", async () => {
     return request(appUrl)
       .get("/api/v3/Samples/" + sampleId + "/datasets")
       .set("Accept", "application/json")
@@ -234,9 +282,18 @@ describe("2200: Sample: Simple Sample", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.instanceof(Array);
-        res.body.length.should.be.equal(1);
+        res.body.length.should.be.equal(2);
         res.body[0].pid.should.be.equal(decodeURIComponent(datasetId));
+        res.body[1].pid.should.be.equal(decodeURIComponent(datasetId2));
       });
+  });
+
+  it("0092: should deny access as user2", async () => {
+    return request(appUrl)
+      .get("/api/v3/Samples/" + sampleId + "/datasets")
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .expect(TestData.AccessForbiddenStatusCode);
   });
 
   it("0100: should delete the dataset linked to sample", function (done) {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Close vulnerabilities in /proposals/:id/datasets and /samples/:id/datasets endpoints that may expose datasets to unauthorized authenticated users. Add test coverage for the /proposals/:id/datasets endpoint.

This applies the security fix for security fix for GHSA-pxvj-88j3-82p8 (https://github.com/SciCatProject/backend-ghsa-pxvj-88j3-82p8/pull/5) to the release branch.

This will PR will modify the release branch in order to create release v5.2.1

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* https://github.com/SciCatProject/backend/security/advisories/GHSA-pxvj-88j3-82p8
   

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

- Restrict casl endpoint access permissions for basic authenticated users on proposals
- Add instance read authentification on the /proposals/:id/datasets and /samples/:id/datasets endpoints
- Fix instance authentification on dataset in both endpoints
- Add fallback case requiring public records in both endpoints, ensuring access control

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->
    - [x] `npm run test`
    - [x] `npm run test:api:mocha`

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Apply security hardening to proposal- and sample-linked dataset endpoints to prevent unauthorized dataset access and align permissions with v5.2.x release.

Bug Fixes:
- Ensure /proposals/:id/datasets and /samples/:id/datasets enforce instance-level access control and group-based visibility, preventing exposure of datasets to unauthorized authenticated users.

Enhancements:
- Update CASL ability configuration so proposal dataset read permissions are correctly scoped to admin and proposal access groups while restricting generic authenticated users.
- Unify dataset access checks in proposal and sample controllers to use dataset-specific abilities and require published datasets when access-group conditions are not met.

Tests:
- Extend proposal tests to cover dataset listing behavior for different roles, including denial for unauthorized users.
- Extend sample tests to validate dataset visibility across multiple owners, user groups, and unauthorized users.
- Adjust v4 dataset count tests to assert forbidden access without filter details for unauthenticated requests.